### PR TITLE
Persist user's spell/grammar toggle across caret movement

### DIFF
--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -44,6 +44,7 @@ public struct MarkdownEditorConfiguration: Sendable {
     public var safeAreaInsets: SafeAreaInsets
     public var scrollers: ScrollersPolicy
     public var textInsets: TextInsets
+    public var spellChecking: SpellCheckingPolicy
 
     public init(
         theme: MarkdownEditorTheme = .default,
@@ -63,7 +64,8 @@ public struct MarkdownEditorConfiguration: Sendable {
         dragSelection: DragSelectionPolicy = .default,
         safeAreaInsets: SafeAreaInsets = .default,
         scrollers: ScrollersPolicy = .default,
-        textInsets: TextInsets = .default
+        textInsets: TextInsets = .default,
+        spellChecking: SpellCheckingPolicy = .default
     ) {
         self.theme = theme
         self.services = services
@@ -83,9 +85,36 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.safeAreaInsets = safeAreaInsets
         self.scrollers = scrollers
         self.textInsets = textInsets
+        self.spellChecking = spellChecking
     }
 
     public static let `default` = MarkdownEditorConfiguration()
+}
+
+// MARK: - Spell checking
+
+/// Initial state for the three "Spelling and Grammar" toggles. Only consulted
+/// at `makeNSView` time; afterwards the user's context-menu choices take
+/// precedence and are surfaced via ``NativeTextViewWrapper/onSpellCheckingPolicyChanged``.
+public struct SpellCheckingPolicy: Sendable {
+    /// Mirrors `NSTextView.isContinuousSpellCheckingEnabled`.
+    public var continuousSpellChecking: Bool
+    /// Mirrors `NSTextView.isGrammarCheckingEnabled`.
+    public var grammarChecking: Bool
+    /// Mirrors `NSTextView.isAutomaticSpellingCorrectionEnabled`.
+    public var automaticSpellingCorrection: Bool
+
+    public init(
+        continuousSpellChecking: Bool = true,
+        grammarChecking: Bool = true,
+        automaticSpellingCorrection: Bool = true
+    ) {
+        self.continuousSpellChecking = continuousSpellChecking
+        self.grammarChecking = grammarChecking
+        self.automaticSpellingCorrection = automaticSpellingCorrection
+    }
+
+    public static let `default` = SpellCheckingPolicy()
 }
 
 // MARK: - Scroll bars

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
@@ -49,9 +49,19 @@ extension NativeTextViewCoordinator {
         }
         cachedSpellingDisabled = shouldDisableSpelling
 
-        textView.isAutomaticSpellingCorrectionEnabled = !shouldDisableSpelling
-        textView.isContinuousSpellCheckingEnabled = !shouldDisableSpelling
-        textView.isGrammarCheckingEnabled = !shouldDisableSpelling
+        // Inside a suppress zone (code/LaTeX/link), force everything off.
+        // Outside, restore to the user's preference — captured via the toggle
+        // overrides in `NativeTextView+SpellingToggles.swift` — so a manual
+        // "off" survives caret movement through suppress zones.
+        textView.isAutomaticSpellingCorrectionEnabled = shouldDisableSpelling
+            ? false
+            : userPrefersAutomaticSpellingCorrection
+        textView.isContinuousSpellCheckingEnabled = shouldDisableSpelling
+            ? false
+            : userPrefersContinuousSpellChecking
+        textView.isGrammarCheckingEnabled = shouldDisableSpelling
+            ? false
+            : userPrefersGrammarChecking
         textView.isAutomaticQuoteSubstitutionEnabled = !shouldDisableSpelling
         textView.isAutomaticDashSubstitutionEnabled = false
     }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -69,6 +69,40 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     // Skip spellcheck property setters when the state wouldn't change.
     var cachedSpellingDisabled: Bool?
 
+    // Mirrors the user's last-known preference for each spell/grammar toggle.
+    // `updateAutocorrectSettings` reads these when restoring outside a
+    // suppress zone, so caret movement no longer clobbers a manual "off".
+    var userPrefersContinuousSpellChecking: Bool = true
+    var userPrefersGrammarChecking: Bool = true
+    var userPrefersAutomaticSpellingCorrection: Bool = true
+
+    /// Fires after the user toggles a spell/grammar/auto-correction menu item.
+    /// Embedders persist the returned policy (e.g. to `UserDefaults`) and feed
+    /// it back via ``MarkdownEditorConfiguration/spellChecking`` on next launch.
+    var onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)?
+
+    var currentSpellCheckingPolicy: SpellCheckingPolicy {
+        SpellCheckingPolicy(
+            continuousSpellChecking: userPrefersContinuousSpellChecking,
+            grammarChecking: userPrefersGrammarChecking,
+            automaticSpellingCorrection: userPrefersAutomaticSpellingCorrection
+        )
+    }
+
+    /// Called from ``NativeTextView`` toggle overrides after `super` flips the
+    /// underlying property. Snapshots the text view's state, refreshes the
+    /// cache so the next caret move doesn't immediately overwrite it, and
+    /// notifies the embedder.
+    func didToggleSpellCheckingPolicy(textView: NSTextView) {
+        userPrefersContinuousSpellChecking = textView.isContinuousSpellCheckingEnabled
+        userPrefersGrammarChecking = textView.isGrammarCheckingEnabled
+        userPrefersAutomaticSpellingCorrection = textView.isAutomaticSpellingCorrectionEnabled
+        // Invalidate the "didn't change" short-circuit so the next selection
+        // update re-applies the preferences cleanly.
+        cachedSpellingDisabled = nil
+        onSpellCheckingPolicyChanged?(currentSpellCheckingPolicy)
+    }
+
     struct ParsedDocument {
         let tokens: [MarkdownToken]
         let codeTokens: [MarkdownToken]

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingToggles.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingToggles.swift
@@ -1,0 +1,31 @@
+//
+//  NativeTextView+SpellingToggles.swift
+//  MarkdownEngine
+//
+//  Created by Nicolas Mallinckrodt on 19.05.26.
+//
+//  AppKit's context menu and Edit > Spelling and Grammar menu route through
+//  these action methods. We forward to `super` so the standard menu state
+//  flips, then snapshot the result into the coordinator so the user's choice
+//  survives the next `updateAutocorrectSettings` pass (which otherwise
+//  restores the "on" state whenever the caret leaves a code/LaTeX/link span).
+//
+
+import AppKit
+
+extension NativeTextView {
+    override func toggleContinuousSpellChecking(_ sender: Any?) {
+        super.toggleContinuousSpellChecking(sender)
+        (delegate as? NativeTextViewCoordinator)?.didToggleSpellCheckingPolicy(textView: self)
+    }
+
+    override func toggleGrammarChecking(_ sender: Any?) {
+        super.toggleGrammarChecking(sender)
+        (delegate as? NativeTextViewCoordinator)?.didToggleSpellCheckingPolicy(textView: self)
+    }
+
+    override func toggleAutomaticSpellingCorrection(_ sender: Any?) {
+        super.toggleAutomaticSpellingCorrection(sender)
+        (delegate as? NativeTextViewCoordinator)?.didToggleSpellCheckingPolicy(textView: self)
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -68,6 +68,10 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// Fires when the set of visible code blocks changes, so embedders can
     /// overlay copy buttons (see ``CodeBlockButton``).
     public var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
+    /// Fires after the user toggles any of the three spell/grammar/auto-correction
+    /// menu items. Embedders persist the policy and pass it back via
+    /// ``MarkdownEditorConfiguration/spellChecking`` on next launch.
+    public var onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)?
 
     public init(
         text: Binding<String>,
@@ -82,7 +86,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
         onInlineSelectionChange: ((InlineSelectionState?) -> Void)? = nil,
-        onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil
+        onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
+        onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil
     ) {
         self._text = text
         self._isWikiLinkActive = isWikiLinkActive
@@ -97,6 +102,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onCaretRectChange = onCaretRectChange
         self.onInlineSelectionChange = onInlineSelectionChange
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
+        self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
     }
 
     public func makeNSView(context: Context) -> NSScrollView {
@@ -154,9 +160,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.font = font
         textView.baseFont = font
         textView.allowsUndo = true
-        textView.isAutomaticSpellingCorrectionEnabled = true
-        textView.isContinuousSpellCheckingEnabled = true
-        textView.isGrammarCheckingEnabled = true
+        textView.isAutomaticSpellingCorrectionEnabled = configuration.spellChecking.automaticSpellingCorrection
+        textView.isContinuousSpellCheckingEnabled = configuration.spellChecking.continuousSpellChecking
+        textView.isGrammarCheckingEnabled = configuration.spellChecking.grammarChecking
         textView.isAutomaticQuoteSubstitutionEnabled = true
         textView.isAutomaticDataDetectionEnabled = true
         textView.isAutomaticDashSubstitutionEnabled = false
@@ -345,6 +351,10 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.documentId = documentId
         coordinator.configuration = configuration
         coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
+        coordinator.userPrefersContinuousSpellChecking = configuration.spellChecking.continuousSpellChecking
+        coordinator.userPrefersGrammarChecking = configuration.spellChecking.grammarChecking
+        coordinator.userPrefersAutomaticSpellingCorrection = configuration.spellChecking.automaticSpellingCorrection
+        coordinator.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
         return coordinator
     }
 }


### PR DESCRIPTION
Closes #34.

## Summary

- `updateAutocorrectSettings` no longer overwrites the user's manual "off" when the caret leaves a code/LaTeX/link suppress zone. The restore branch reads a per-coordinator preference instead of hardcoded `true`.
- New `SpellCheckingPolicy` on `MarkdownEditorConfiguration` lets embedders seed initial state. New `onSpellCheckingPolicyChanged` callback on `NativeTextViewWrapper` lets them persist user toggles (e.g. to `UserDefaults`) and feed the value back on next launch.
- `NativeTextView` overrides `toggleContinuousSpellChecking(_:)`, `toggleGrammarChecking(_:)`, and `toggleAutomaticSpellingCorrection(_:)` to capture context-menu toggles into the coordinator state.

Defaults match prior behavior — `SpellCheckingPolicy.default` is all-on, so existing callers see no change.

## Files

- `Configuration/MarkdownEditorConfiguration.swift` — `SpellCheckingPolicy` struct + `spellChecking` field.
- `TextView/Coordinator/NativeTextViewCoordinator.swift` — `userPrefers*` mirror, `onSpellCheckingPolicyChanged` callback, `didToggleSpellCheckingPolicy(textView:)` handler.
- `TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift` — restore branch honors `userPrefers*`. Suppress-zone path unchanged.
- `TextView/NativeTextView/NativeTextView+SpellingToggles.swift` — new file, AppKit toggle action overrides.
- `TextView/NativeTextViewWrapper.swift` — `makeNSView` reads from `configuration.spellChecking`; new init param threads the callback through `makeCoordinator`.

## Embedder usage

```swift
var config = MarkdownEditorConfiguration.default
config.spellChecking = SpellCheckingPolicy(
    continuousSpellChecking: UserDefaults.standard.object(forKey: "spell") as? Bool ?? true,
    grammarChecking: UserDefaults.standard.object(forKey: "grammar") as? Bool ?? true,
    automaticSpellingCorrection: UserDefaults.standard.object(forKey: "autocorrect") as? Bool ?? true
)

NativeTextViewWrapper(
    text: $text,
    configuration: config,
    onSpellCheckingPolicyChanged: { policy in
        UserDefaults.standard.set(policy.continuousSpellChecking, forKey: "spell")
        UserDefaults.standard.set(policy.grammarChecking, forKey: "grammar")
        UserDefaults.standard.set(policy.automaticSpellingCorrection, forKey: "autocorrect")
    }
)
```

## Test plan

- [ ] Open a doc with a code block. Disable "Check Spelling While Typing" via context menu. Type across the code-block boundary and confirm the underline does not return.
- [ ] Same flow for "Check Grammar With Spelling" and "Correct Spelling Automatically".
- [ ] With an embedder wired to UserDefaults: relaunch the app and confirm the previous off-state survives.
- [ ] Default config (no `spellChecking` override) behaves identically to `main` — all three toggles on at launch.
- [ ] `swift build` and `swift test` clean.

## Out of scope

Smart Quotes (`isAutomaticQuoteSubstitutionEnabled`) has the same caret-movement bug pattern. Tracked separately.