### PR TITLE
Preserve trailing newline when applying a heading

### DIFF
--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -120,12 +120,17 @@ extension NativeTextViewWrapper.Coordinator {
         let nsText = tv.string as NSString
         let range = tv.selectedRange()
         let lineRange = nsText.lineRange(for: range)
-        let rawLine = nsText.substring(with: lineRange).trimmingCharacters(in: .whitespacesAndNewlines)
+        let originalLine = nsText.substring(with: lineRange)
+        let rawLine = originalLine.trimmingCharacters(in: .whitespacesAndNewlines)
         var content = rawLine
         while content.hasPrefix("#") { content.removeFirst() }
         content = content.trimmingCharacters(in: .whitespaces)
         let prefix = String(repeating: "#", count: level) + " "
-        let newLine = prefix + content
+        // lineRange(for:) includes the trailing line terminator; preserve it so
+        // applying a heading to a non-final line doesn't swallow the newline and
+        // merge the line with the next one (mirrors applyList's suffix handling).
+        let suffix = originalLine.hasSuffix("\n") ? "\n" : ""
+        let newLine = prefix + content + suffix
         if tv.shouldChangeText(in: lineRange, replacementString: newLine) {
             tv.replaceCharacters(in: lineRange, with: newLine)
             tv.didChangeText()


### PR DESCRIPTION
## Problem

`applyHeading(level:)` (the Heading context-menu action, and the `applyHeadingRequest` bus command) replaces the whole `lineRange`. `NSString.lineRange(for:)` includes the trailing line terminator, but the replacement is rebuilt as `"# <content>"` without re-adding it. So applying a heading to any line that isn't the last line of the document deletes the following newline and merges the line into the next one.

Repro:
1. Type two lines - `foo`, then `bar`.
2. Put the caret on `foo` and apply Heading 1.
3. You get `# foobar` instead of `# foo` / `bar`.

## Fix

Mirror what `applyList(prefix:)` already does in the same file: capture whether the original line ended in `\n` and re-append it to the replacement. The selection math is unaffected — the content still starts at `prefix.count`.

No change for the last line of a document, which has no trailing newline to preserve.
