### PR TITLE
docs: update ARCHITECTURE.md for the AST pipeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,8 +7,8 @@ Sources/
 ├── MarkdownEngine/                          # core target — zero deps
 │   ├── Configuration/                       # MarkdownEditorConfiguration + MarkdownEditorTheme
 │   ├── Services/                            # 4 protocols, no-op defaults, WikiLinkService
-│   ├── Parser/                              # MarkdownTokenizer.swift + emphasis stack parser
-│   ├── Styling/                             # MarkdownStyler.swift + one extension per token class
+│   ├── Parser/                              # two-phase AST: BlockParser → InlineParser → DocumentAST (+ token projection)
+│   ├── Styling/                             # MarkdownASTStyler (AST walk) + MarkdownStyler facade for NSImage passes
 │   ├── Renderer/                            # LayoutBridge, MarkdownTextLayoutFragment, EmbeddedImageCache
 │   ├── Input/                               # MarkdownInputHandler + MarkdownListHandler
 │   ├── TextView/
@@ -25,94 +25,125 @@ Sources/
 The rest of this file is a per-directory tour, in the order text flows
 through the engine.
 
-## [`Parser/`](Sources/MarkdownEngine/Parser): what is a token?
+## [`Parser/`](Sources/MarkdownEngine/Parser): text → AST → tokens
 
-Regex-driven tokenizer. Emphasis (`*`, `**`, `***`) runs through a
-separate stack parser in `MarkdownTokenizer+Emphasis.swift` to handle
-nesting. Each `MarkdownToken` has a `kind`, a `range`, a `contentRange`,
-and `markerRanges` (for `**bold**`, the two `**`).
+A two-phase AST pipeline following CommonMark's model — block structure first,
+inline content second. There is no regex tokenizer anymore; the structural
+regexes are gone, replaced by hand-written scanners and a real syntax tree.
 
-Token kinds: `italic`, `bold`, `boldItalic`, `link`, `wikiLink`,
-`heading`, `codeBlock`, `inlineCode`, `blockLatex`, `inlineLatex`,
-`imageEmbed`.
+1. **`BlockParser`** splits the document into a flat, gap-free (tiling)
+   sequence of `Block`s: `heading`, `paragraph`, `blockquote`, `list`,
+   `fencedCode`, `blockLatex`, `table`, `thematicBreak`, `blank`. Hand-written
+   line scanners. It memoizes the last parse (UTF-16 buffer cache) so the
+   per-keystroke callers share one line-scan.
+2. **`InlineParser`** turns a single inline-bearing block's text into an inline
+   AST (`[InlineNode]`) with correct CommonMark precedence: code spans →
+   escapes → link family (`![[…]]`, `[[…]]`, `![…](…)`, `[…](…)`, `~~…~~`,
+   `$…$`) → emphasis (`*`/`_` delimiter runs) → `buildTree`. Each pass claims
+   spans only in regions not already claimed, so there are never partial
+   overlaps and the tree is a clean containment tree.
+3. **`MarkdownAST` / `DocumentAST.parse`** combines the two into the semantic
+   document AST — `[BlockNode]`, each inline-bearing block carrying its parsed
+   `[InlineNode]` children in absolute document coordinates. `BlockNode`,
+   `InlineNode`, and `ListItem` are defined here.
 
-**Invariant:** Tokenization is pure, allocation-light, and cheap enough
-to re-run on every keystroke. Tokens are not cached outside
-`NativeTextViewCoordinator`, and never mutated after a styling pass.
+**Tokens are now a projection of the AST, not the source of truth.**
+`MarkdownTokenizer` is just a namespace; its entry point `parseTokensViaAST`
+(implemented in **`BlockScopedTokenizer`** — the live tokenization pipeline)
+walks each `BlockParser` block and emits the legacy flat `[MarkdownToken]`
+shape: block-level tokens (heading, blockquote, fenced code, table, block
+LaTeX) come from **`BlockLevelTokenizer`** (hand scanners), inline tokens from
+the AST via **`InlineASTAdapter`** (`[InlineNode]` → `[MarkdownToken]`). Token
+shapes are reproduced 1:1 from the old regex tokenizer (parity-checked), so the
+consumers that still read tokens — the NSImage render passes, code-block
+handling, `MarkdownInputHandler`, `ContextMenu`, and `MarkdownDetection`
+(caret-aware active-token indices) — keep working unchanged.
+
+**Invariant:** Ranges everywhere are absolute UTF-16 `NSRange`s into the source
+(the editor is TextKit-2 / `NSTextView`-based, so UTF-16 offsets are the native
+currency).
+
+**Invariant:** Parsing is incremental. With `scopedRanges`, `DocumentAST.parse`
+parses inlines only for blocks intersecting the edit, and `BlockScopedTokenizer`
+memoizes per-block tokens (substring → tokens, FIFO-capped) — so a keystroke
+re-parses one block, not the whole document (≈ O(edit)).
 
 ## [`Services/`](Sources/MarkdownEngine/Services): how does the engine talk to your app?
 
-`MarkdownEditorServices.swift` declares the four service protocols.
-Internally each is called synchronously from a specific styling pass:
-`WikiLinkResolver` from `styleWikiLinks`, `EmbeddedImageProvider` from
-`styleImageEmbeds`, `SyntaxHighlighter` from `styleCodeBlocks` /
-`styleInlineCode`, `LatexRenderer` from `styleBlockLatex` /
-`styleInlineLatex`.
+`MarkdownEditorServices.swift` declares the four service protocols. Each is
+called synchronously when its construct is styled or rendered: `WikiLinkResolver`
+while styling wiki-links, `EmbeddedImageProvider` from the image-embed render
+pass, `SyntaxHighlighter` from code styling, `LatexRenderer` from the LaTeX
+render passes.
 
-`WikiLinkService.swift` handles the dual-form storage / display
-transform — storage is `[[Name|<id>]]`, display is `[[Name]]`. The
-coordinator runs it both ways every time `rebuildTextStorageAndStyle()`
-fires.
+`WikiLinkService.swift` handles the dual-form storage / display transform —
+storage is `[[Name|<id>]]`, display is `[[Name]]`. The coordinator runs it both
+ways every time `rebuildTextStorageAndStyle()` fires.
 
 **Invariant:** Service callbacks are synchronous. If an embedder's
-implementation is slow, it caches (both bundled bridges do); the engine
-never async-renders.
+implementation is slow, it caches (both bundled bridges do); the engine never
+async-renders.
 
-**Invariant:** Wiki-link storage and display are different strings.
-Display IDs never leak into the binding.
+**Invariant:** Wiki-link storage and display are different strings. Display IDs
+never leak into the binding.
 
-## [`Styling/`](Sources/MarkdownEngine/Styling): how do tokens become attributes?
+## [`Styling/`](Sources/MarkdownEngine/Styling): how does the AST become attributes?
 
-`MarkdownStyler.styleAttributes()` (`MarkdownStyler.swift:78`) runs an
-ordered pipeline of styling passes — headings, emphasis, auto-links,
-wiki-links, image embeds, markdown links, code blocks, inline code,
-block / inline LaTeX, horizontal rules, incomplete brackets, task
-checkboxes, marker-shrinking — each returning `[(range, attributes)]`.
-Passes are linear and additive; later passes intentionally clobber
-earlier ones (which is why `shrinkInactiveMarkers` runs last).
+`MarkdownASTStyler.styleAttributes()` is the live styler. It walks the document
+AST and emits `[StyledRange]`, **composing** attributes on descent: a heading
+sets a large bold font, descending into bold adds the bold trait (keeping the
+size), into italic adds italic — so nested / combined inline styles stack
+instead of overwriting each other. (Composition is what the old flat pass
+pipeline got wrong, e.g. the shrinking bold in `# **n*o*des**`.)
 
-If the coordinator passes `scopedRanges`, range-based scans only touch
-those paragraphs — the optimization that keeps per-keystroke restyling
-cheap.
+`MarkdownStyler.styleAttributes()` (`MarkdownStyler.swift:43`) is now a thin
+facade: it builds the `StylingContext`, runs the AST styler for all text
+styling, then appends the passes that still render **NSImages** and therefore
+still consume tokens — block / inline LaTeX (`+Latex`), image embeds and image
+links (`+Images`), and rendered tables (`+Tables`). `MarkdownStyler+TaskCheckboxes`
+and `+BulletMarkers` no longer style (the AST styler does); they keep only the
+caret / selection range helpers (`taskSyntaxRange`, `bulletSyntaxRange`,
+`hrLineRange`) the text-view delegate uses.
 
-**Invariant:** Markers shrink, they don't disappear. Inactive markers
-render at `hiddenMarkerFontSize`; they're never removed from text
-storage. Every selection / copy / find / undo bug downstream traces back
-to violating this.
+If the coordinator passes `scopedRanges`, only the intersecting blocks are
+re-styled — the optimization that keeps per-keystroke restyling cheap.
+
+**Invariant:** Markers shrink, they don't disappear. Inactive markers render at
+`hiddenMarkerFontSize`; they're never removed from text storage. Every
+selection / copy / find / undo bug downstream traces back to violating this.
 
 ## [`Renderer/`](Sources/MarkdownEngine/Renderer): TextKit 2 layout
 
-Thin wrappers around `NSTextLayoutManager` (`LayoutBridge.swift`), a
-custom `MarkdownTextLayoutFragment` for precise positioning, and
-`EmbeddedImageCache` keyed by an embedder-supplied fingerprint so images
-and LaTeX results invalidate when the embedder says so.
+Thin wrappers around `NSTextLayoutManager` (`LayoutBridge.swift`), a custom
+`MarkdownTextLayoutFragment` for precise positioning, and `EmbeddedImageCache`
+keyed by an embedder-supplied fingerprint so images and LaTeX results
+invalidate when the embedder says so.
 
 ## [`Input/`](Sources/MarkdownEngine/Input): typing-time helpers
 
-`MarkdownInputHandler.swift` handles auto-wrap for `$…$` / `$$…$$` /
-`![[…]]`. `MarkdownListHandler.swift` handles list continuation,
-indent / outdent, and task-checkbox toggling on Enter / Tab / Backspace.
-Both run synchronously inside the text-view delegate.
+`MarkdownInputHandler.swift` handles auto-wrap for `$…$` / `$$…$$` / `![[…]]`.
+`MarkdownListHandler.swift` handles list continuation, indent / outdent, and
+task-checkbox toggling on Enter / Tab / Backspace. Both run synchronously inside
+the text-view delegate.
 
 ## [`TextView/`](Sources/MarkdownEngine/TextView): NSTextView + SwiftUI bridge
 
-The entry point is `NativeTextViewWrapper.swift` — an
-`NSViewRepresentable` that owns the coordinator and the configured text
-view. Two sub-folders matter:
+The entry point is `NativeTextViewWrapper.swift` — an `NSViewRepresentable` that
+owns the coordinator and the configured text view. Two sub-folders matter:
 
-- `NativeTextView/` — extensions on the AppKit subclass (paste,
-  drag-select boost, spell policy, caret workarounds)
-- `Coordinator/` — `NSTextViewDelegate` glue, split by concern
-  (restyling, writing-tools, find, code-blocks, inline selection,
-  autocorrect)
+- `NativeTextView/` — extensions on the AppKit subclass (paste, drag-select
+  boost, spell policy, caret workarounds)
+- `Coordinator/` — `NSTextViewDelegate` glue, split by concern (restyling,
+  writing-tools, find, code-blocks, inline selection, autocorrect)
 
 Application of `[StyledRange]` to text storage happens in
 `Coordinator/NativeTextViewCoordinator+Restyling.swift` →
-`rebuildTextStorageAndStyle()`.
+`rebuildTextStorageAndStyle()`, which tokenizes via `parseTokensViaAST` and
+calls `MarkdownStyler.styleAttributes()`.
 
 ## [`Configuration/`](Sources/MarkdownEngine/Configuration): the tunables
 
-`MarkdownEditorConfiguration` is a struct of structs — one nested group
-per concern (headings, codeBlock, blockLatex, overscroll, markers,
-lists, …) — passed by reference into every styling pass via the
-`StylingContext`. `MarkdownEditorTheme` is its colour sub-field.
+`MarkdownEditorConfiguration` is a struct of structs — one nested group per
+concern (headings, codeBlock, blockLatex, overscroll, markers, lists, …) —
+passed by reference into the styler via the `StylingContext`.
+`MarkdownEditorTheme` is its colour sub-field.


### PR DESCRIPTION
## What

Updates `ARCHITECTURE.md` to describe the **AST pipeline** that landed in #52 (`implement full AST instead of regex`). The doc still described the old regex tokenizer and the flat 18-pass styler, which no longer exist.

## Corrections

- **`Parser/` section** — rewritten from "Regex-driven tokenizer" to the two-phase AST: `BlockParser` (gap-free block tiling, hand scanners) → `InlineParser` (inline AST with CommonMark precedence) → `DocumentAST` (`BlockNode`/`InlineNode`/`ListItem`). Documents that **tokens are now a projection of the AST** (`parseTokensViaAST` → `BlockScopedTokenizer` + `BlockLevelTokenizer` + `InlineASTAdapter`), kept 1:1 for the consumers that haven't moved to walking the tree (NSImage passes, code blocks, input handlers, detection).
- **`Styling/` section** — `MarkdownASTStyler` is documented as the live styler (AST walk, attribute composition on descent). `MarkdownStyler` is now described as a thin facade that runs the AST styler and then the residual **NSImage-render** passes (LaTeX / image embeds / image links / tables). Noted that `+TaskCheckboxes` / `+BulletMarkers` keep only caret/selection helpers now.
- **Source-layout tree** — updated the `Parser/` and `Styling/` one-liners.
- Added an incremental-parsing invariant (`scopedRanges` + per-block memo → ≈ O(edit) per keystroke).

The still-accurate sections (Services, Renderer, Input, TextView, Configuration) are kept, with minor wording tweaks.

## Follow-up (not in this PR)

Some source-file header comments are still stale from the Phase-2.5 build — e.g. `MarkdownASTStyler.swift` ("built behind the existing styler, not wired… TODO: images, latex, …") and `MarkdownAST.swift` ("the AST-native styler (next increments)"). They no longer match the wired state. Worth a separate cleanup pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
