### PR TITLE
Fix: Misspelling underlines never appear in the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `MarkdownEditorConfiguration.safeAreaInsets`.
 
 ### Fixed
+- Spell-check underlines no longer appear on fenced code blocks or
+  inline `` `code` `` spans. The styler now applies `.spellingState: 0`
+  to those ranges, matching the existing convention used for links,
+  wiki-links, LaTeX, and tables. Prose is unaffected.
 - `NativeTextViewWrapper` keeps links clickable and text selectable
   when `isEditable: false`; `isSelectable` is no longer coupled to
   `isEditable`. (#31)

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -94,6 +94,12 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         // 6. Blockquote bars (left gutter, behind nothing — text is indented)
         drawBlockquoteBars(at: point, in: context)
+
+        // 7. Spell-check underlines. NSTextView's automatic underline pass
+        //    does not fire for our custom NSTextLayoutFragment subclass on
+        //    TextKit 2, so the coordinator drives NSSpellChecker manually
+        //    and stashes ranges for us to paint here.
+        drawSpellMisspellings(at: point, in: context)
     }
 
     // MARK: - Helpers
@@ -586,6 +592,65 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
                 let symbolConfig = sizeConfig.applying(colorConfig)
                 let symbol = baseSymbol.withSymbolConfiguration(symbolConfig) ?? baseSymbol
                 symbol.draw(in: iconRect)
+            }
+        }
+    }
+
+    // MARK: - Spell-check underlines
+
+    /// Paints a dotted red underline beneath every misspelled range that
+    /// intersects this fragment. Walks `coordinator.spellMisspelledRanges`
+    /// (populated by `runSpellCheckPass`) and resolves per-line bounds via
+    /// `textLineFragments`, so wrapped misspellings get separate underlines
+    /// per line.
+    private func drawSpellMisspellings(at point: CGPoint, in context: CGContext) {
+        guard let fragRange = fragmentNSRange, fragRange.length > 0 else { return }
+        guard let textView = textLayoutManager?.textContainer?.textView as? NativeTextView,
+              let coordinator = textView.delegate as? NativeTextViewCoordinator,
+              !coordinator.spellMisspelledRanges.isEmpty else { return }
+
+        let fragStart = fragRange.location
+        let fragEnd = NSMaxRange(fragRange)
+
+        context.saveGState()
+        defer { context.restoreGState() }
+        context.setStrokeColor(NSColor.systemRed.withAlphaComponent(0.7).cgColor)
+        context.setLineWidth(1.5)
+        context.setLineDash(phase: 0, lengths: [1.5, 1.5])
+        context.setLineCap(.round)
+
+        for misspelled in coordinator.spellMisspelledRanges {
+            let mStart = misspelled.location
+            let mEnd = NSMaxRange(misspelled)
+            if mEnd <= fragStart || mStart >= fragEnd { continue }
+
+            let docLo = max(mStart, fragStart)
+            let docHi = min(mEnd, fragEnd)
+            let localLo = docLo - fragStart
+            let localHi = docHi - fragStart
+
+            for lineFragment in textLineFragments {
+                let lr = lineFragment.characterRange
+                let lrLo = lr.location
+                let lrHi = lr.location + lr.length
+                let lo = max(localLo, lrLo)
+                let hi = min(localHi, lrHi)
+                guard lo < hi else { continue }
+
+                let startPos = lineFragment.locationForCharacter(at: lo)
+                let endPos = lineFragment.locationForCharacter(at: hi)
+                let tb = lineFragment.typographicBounds
+                let x1 = point.x + tb.origin.x + startPos.x
+                let x2 = point.x + tb.origin.x + endPos.x
+                guard x2 > x1 else { continue }
+                // Place the underline ~1pt inside the bottom of the line
+                // box, which lines up with where AppKit normally paints
+                // misspelling marks.
+                let y = point.y + tb.origin.y + tb.height - 1.5
+
+                context.move(to: CGPoint(x: x1, y: y))
+                context.addLine(to: CGPoint(x: x2, y: y))
+                context.strokePath()
             }
         }
     }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -367,6 +367,8 @@ enum MarkdownASTStyler {
         attrs.append((parts.codeRange, [
             .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: ctx.codeParagraphStyle,
         ]))
+        // Suppress spell-check underlines on the whole fenced block — code is not prose.
+        attrs.append((parts.codeRange, [.spellingState: 0]))
         let codeContent = ctx.ns.substring(with: parts.content)
         if !codeContent.isEmpty,
            let highlighted = ctx.config.services.syntaxHighlighter.highlight(code: codeContent, language: parts.language) {
@@ -431,6 +433,8 @@ enum MarkdownASTStyler {
 
             case .code(let range, let contentRange):
                 attrs.append((contentRange, [.font: ctx.codeFont, .backgroundColor: ctx.codeBackground]))
+                // Suppress spell-check underlines on inline `code` spans (markers + content).
+                attrs.append((range, [.spellingState: 0]))
                 let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(range)
                     ? [.foregroundColor: ctx.theme.mutedText, .font: ctx.codeFont]
                     : [.foregroundColor: ctx.theme.mutedText.withAlphaComponent(ctx.config.markers.inlineCodeMarkerAlpha),

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+SpellCheck.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+SpellCheck.swift
@@ -1,0 +1,112 @@
+//
+//  NativeTextViewCoordinator+SpellCheck.swift
+//  MarkdownEngine
+//
+//  Drives NSSpellChecker manually and stores misspelled ranges that
+//  `MarkdownTextLayoutFragment.draw(at:in:)` paints as dotted-red
+//  underlines. Required because NSTextView's automatic spell-mark
+//  rendering does not fire for our custom NSTextLayoutFragment subclass
+//  in TextKit 2 — `setSpellingState(_:range:)` and the
+//  `isContinuousSpellCheckingEnabled` flag both end up as no-ops
+//  visually unless we draw the marks ourselves.
+//
+
+import AppKit
+
+extension NativeTextViewCoordinator {
+    /// Debounce window between the last edit and the spell-check pass.
+    /// Long enough to avoid stalling fast typists, short enough that the
+    /// underline appears almost as soon as the word boundary is crossed.
+    private static let spellCheckDebounce: TimeInterval = 0.4
+
+    /// Schedule a (debounced) spell-check pass over the entire document.
+    /// Subsequent calls within the debounce window cancel the previous
+    /// scheduled pass.
+    func scheduleSpellCheck(textView: NSTextView) {
+        spellCheckWorkItem?.cancel()
+        guard userPrefersContinuousSpellChecking else {
+            // Toggle is off — make sure stale marks aren't left around.
+            clearSpellMisspellings(textView: textView)
+            return
+        }
+        let work = DispatchWorkItem { [weak self, weak textView] in
+            guard let self, let textView else { return }
+            self.runSpellCheckPass(textView: textView)
+        }
+        spellCheckWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.spellCheckDebounce,
+            execute: work
+        )
+    }
+
+    /// Run a synchronous full-document scan via `NSSpellChecker.shared`.
+    /// Filters results against the engine's existing zone helpers so code,
+    /// LaTeX, links, and image embeds never end up underlined.
+    func runSpellCheckPass(textView: NSTextView) {
+        guard userPrefersContinuousSpellChecking else {
+            clearSpellMisspellings(textView: textView)
+            return
+        }
+        let string = textView.string
+        let length = (string as NSString).length
+        guard length > 0 else {
+            updateMisspelledRanges([], textView: textView)
+            return
+        }
+        let checker = NSSpellChecker.shared
+        var ranges: [NSRange] = []
+        var location = 0
+        while location < length {
+            var wordCount = 0
+            let range = checker.checkSpelling(
+                of: string,
+                startingAt: location,
+                language: nil,
+                wrap: false,
+                inSpellDocumentWithTag: spellCheckDocumentTag,
+                wordCount: &wordCount
+            )
+            if range.location == NSNotFound { break }
+            if range.length == 0 {
+                location = max(location + 1, NSMaxRange(range))
+                continue
+            }
+            // Honour engine zone suppression — same gates that
+            // `NativeTextView.setSpellingState` uses.
+            if !shouldSuppressSpellMark(range: range, in: string) {
+                ranges.append(range)
+            }
+            location = NSMaxRange(range)
+        }
+        updateMisspelledRanges(ranges, textView: textView)
+    }
+
+    /// Empties the misspelling set and triggers a redraw so any leftover
+    /// underlines disappear immediately.
+    func clearSpellMisspellings(textView: NSTextView) {
+        guard !spellMisspelledRanges.isEmpty else { return }
+        updateMisspelledRanges([], textView: textView)
+    }
+
+    /// Replaces the stored set and asks the text view to redraw. The
+    /// fragment's `draw(at:in:)` reads from `spellMisspelledRanges` on
+    /// each repaint, so a simple `setNeedsDisplay` is enough — no need
+    /// to invalidate layout.
+    private func updateMisspelledRanges(_ ranges: [NSRange], textView: NSTextView) {
+        spellMisspelledRanges = ranges
+        textView.needsDisplay = true
+    }
+
+    /// True when the candidate misspelling falls inside a zone where the
+    /// engine deliberately disables spell marks (code, LaTeX, link, embed).
+    private func shouldSuppressSpellMark(range: NSRange, in text: String) -> Bool {
+        if text.contains("`"), isInsideCode(range: range, in: text) {
+            return true
+        }
+        if text.contains("$"), isInsideLatex(location: range.location, in: text) {
+            return true
+        }
+        return isInsideSpellcheckSuppressedToken(range: range, in: text)
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -156,6 +156,10 @@ extension NativeTextViewCoordinator {
             (scrollView as? ClampedScrollView)?.clampToInsets()
         }
         previousActiveTokenIndices = activeTokenIndices
+        // Re-run the full-document spell scan after the user pauses
+        // typing. The debounce inside `scheduleSpellCheck` keeps this
+        // cheap during continuous edits.
+        scheduleSpellCheck(textView: tv)
     }
 
     public func textViewDidChangeSelection(_ notification: Notification) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -86,6 +86,18 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var userPrefersGrammarChecking: Bool = true
     var userPrefersAutomaticSpellingCorrection: Bool = true
 
+    // MARK: - Spell check rendering state
+    //
+    // TextKit 2's NSTextView does not auto-paint `.spellingState` underlines
+    // for custom NSTextLayoutFragment subclasses (which we use for code-block
+    // backgrounds, LaTeX images, etc.). To restore visible spell marks we
+    // drive NSSpellChecker ourselves on text changes (debounced) and have
+    // `MarkdownTextLayoutFragment.draw(at:in:)` paint dotted-red underlines
+    // for ranges in `spellMisspelledRanges`.
+    var spellMisspelledRanges: [NSRange] = []
+    var spellCheckWorkItem: DispatchWorkItem?
+    lazy var spellCheckDocumentTag: Int = NSSpellChecker.uniqueSpellDocumentTag()
+
     /// Fires after the user toggles a spell/grammar/auto-correction menu item.
     /// Embedders persist the returned policy (e.g. to `UserDefaults`) and feed
     /// it back via ``MarkdownEditorConfiguration/spellChecking`` on next launch.

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -218,6 +218,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             context.coordinator.refreshActiveLinkCaretRect()
             context.coordinator.updateCodeBlockSelection(textView: textView)
         }
+        // Kick off the initial spell scan after the first runloop turn so
+        // styling has settled and the text view is in the window hierarchy.
+        context.coordinator.scheduleSpellCheck(textView: textView)
         return scrollView
     }
 
@@ -353,6 +356,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         context.coordinator.didInitialFormatting = true
+        // Re-scan when the document text/identity has actually changed.
+        // (Font-only changes don't need a fresh spell pass.)
+        context.coordinator.scheduleSpellCheck(textView: textView)
     }
 
     public func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
## Summary
Close #58
- TextKit 2's `NSTextView` does not run its automatic `.spellingState` underline pass on custom `NSTextLayoutFragment` subclasses. Because `MarkdownTextLayoutFragment` overrides `draw(at:in:)` to render code block backgrounds, LaTeX images, list markers, etc., misspellings were never visually marked even with `isContinuousSpellCheckingEnabled` on. This left the spell / grammar / autocorrect plumbing from #36 silently no-op in the editor.
- Drive `NSSpellChecker` on the coordinator: a 400 ms debounced full-document pass runs on text change, on initial mount, and after a node-rebuild update. Hits are filtered through the existing zone helpers (`isInsideCode`, `isInsideLatex`, `isInsideSpellcheckSuppressedToken`) so code, inline code, LaTeX, links, and image embeds stay clean.
- Paint the marks ourselves. `MarkdownTextLayoutFragment.draw(at:in:)` gets a final `drawSpellMisspellings(at:in:)` step that walks the fragment's `textLineFragments`, intersects each cached misspelling range, resolves per-line geometry via `locationForCharacter(at:)`, and strokes a dotted red underline.
- Belt-and-suspenders: `MarkdownASTStyler` now stamps `.spellingState: 0` on fenced code blocks and inline `` `code` `` spans, so the engine's existing suppression contract covers them too (in addition to the coordinator-side filter).

Behavior toggles introduced in #36 (`SpellCheckingPolicy`, the context menu overrides, `userPrefersContinuousSpellChecking`) are unchanged — this PR only adds the missing render pass and routes through the same preference.

## Files

- `TextView/Coordinator/NativeTextViewCoordinator.swift` — adds `spellMisspelledRanges`, `spellCheckWorkItem`, and a lazy `spellCheckDocumentTag` to the coordinator.
- `TextView/Coordinator/NativeTextViewCoordinator+SpellCheck.swift` — new file. `scheduleSpellCheck` (400 ms debounce) + `runSpellCheckPass` (full-document `checkSpelling(of:startingAt:…)` walk, suppress-zone filter, `needsDisplay = true`). `clearSpellMisspellings` resets the cache when the user disables continuous spell checking.
- `TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift` — calls `scheduleSpellCheck` at the end of `textDidChange`.
- `TextView/NativeTextViewWrapper.swift` — kicks off the initial pass at the end of `makeNSView`, and re-schedules from `updateNSView` after a real document rebuild (font-only updates skip it).
- `Renderer/MarkdownTextLayoutFragment.swift` — adds `drawSpellMisspellings(at:in:)` and calls it as the last step of `draw(at:in:)`, so it sits on top of backgrounds, list markers, and LaTeX/image inline symbols.
- `Styling/MarkdownASTStyler.swift` — sets `.spellingState: 0` on fenced code blocks and inline `code` spans alongside the existing font/background attributes.

## Test plan

- Open a doc with a pre-existing misspelling (`paragrahh`). A dotted red underline appears within ~400 ms of mount.
- Type a fresh misspelling. After typing pauses for ~400 ms, the underline appears. Continuous typing does not stutter, double-paint, or churn the layout.
- Toggle "Check Spelling While Typing" off via the context menu — existing underlines clear on the next tick. Toggle back on; they return.
- Misspellings inside fenced ```` ``` ```` blocks, inline `` `code` ``, `$latex$` / `$$block$$`, `[link text](url)`, and `![image](path)` embeds are NOT marked. Misspellings outside those zones are.
- Caret crosses a suppress zone back into prose: the user's context-menu off-state survives (regression check on #36).
- Switch between two notes — the new note's marks appear within ~400 ms; the previous note's cached ranges don't bleed through.
- `swift build` and `swift test` clean.

## Out of scope

- Per-language hints. We pass `language: nil`, so `NSSpellChecker` uses the user's preferred languages. Threading a per-document language hint through `MarkdownEditorConfiguration` is a follow-up.
- Per-paragraph incremental scans. The pass currently re-checks the whole document on each debounced trigger. Cheap for typical notes; can be tightened to a paragraph window if profiling on very large docs shows it.
- Smart Quotes still has the same caret-movement bug pattern called out at the bottom of #36; tracked separately.