### PR TITLE
Scrolling header API for the markdown editor (+ live-scroll stability)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,9 @@ Sources/
 │   ├── Input/                               # MarkdownInputHandler + MarkdownListHandler
 │   ├── TextView/
 │   │   ├── NativeTextViewWrapper.swift      # SwiftUI entry point (NSViewRepresentable)
+│   │   ├── NativeTextViewContainer.swift    # the scroll view's documentView: header band + text column stacking
+│   │   ├── ScrollingHeaderController.swift  # scroll-away header: hosting, collapse/expand, teardown
+│   │   ├── ClampedScrollView.swift          # scroll range clamped to real content height
 │   │   ├── NativeTextView/                  # AppKit subclass + UX extensions (paste, drag-select, …)
 │   │   └── Coordinator/                     # NSTextViewDelegate split by concern (restyling, find, …)
 │   └── MarkdownEngine.docc/                 # DocC catalog
@@ -129,10 +132,24 @@ the text-view delegate.
 ## [`TextView/`](Sources/MarkdownEngine/TextView): NSTextView + SwiftUI bridge
 
 The entry point is `NativeTextViewWrapper.swift` — an `NSViewRepresentable` that
-owns the coordinator and the configured text view. Two sub-folders matter:
+owns the coordinator and the configured text view.
+
+The scroll view's `documentView` is **always** `NativeTextViewContainer`, never
+the text view itself. The container stacks up to three kinds of siblings in a
+flipped coordinate space: the optional scroll-away header band at the top (a
+clipped `NSHostingView` managed by `ScrollingHeaderController`, reserved height
+mirrored into `container.headerHeight`), the `NativeTextView` at
+`y = headerHeight` (centered at a fixed width when
+`configuration.readingWidth` is set), and — in reading-column mode — the
+full-width wide-table breakout overlays. Anything that converts between
+text-view-local rects and scroll/document space must lift by the text view's
+origin inside the container (`convert(_:to:)` or `frame.origin`); see
+`viewRect(forCharacterRange:)` and the find-in-document paths for the pattern.
+
+Two sub-folders matter:
 
 - `NativeTextView/` — extensions on the AppKit subclass (paste, drag-select
-  boost, spell policy, caret workarounds)
+  boost, spell policy, caret workarounds, frame/overscroll management)
 - `Coordinator/` — `NSTextViewDelegate` glue, split by concern (restyling,
   writing-tools, find, code-blocks, inline selection, autocorrect)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Scroll-away header: `NativeTextViewWrapper` gains `header: AnyView?`,
+  `headerCollapsedHeight: CGFloat`, and `headerExpanded: Bool`. The engine
+  hosts the supplied SwiftUI view above the document body, scrolling with
+  it; collapsing animates the reserved band down to `headerCollapsedHeight`
+  (the top row stays visible, lower rows clip away). The hosted content
+  refreshes on every SwiftUI update and stays fully interactive. Composes
+  with `readingWidth`. See the README's *Scrolling Header* section.
+
 ### Changed
+- The scroll view's `documentView` is now always an engine-internal
+  container view (hosting the text view, the optional scroll-away header,
+  and the reading column's breakout overlays) rather than sometimes the
+  `NSTextView` itself. Embedders that reached into
+  `scrollView.documentView` expecting an `NSTextView` must adapt — the
+  document view's class was never API.
 - **Breaking**: The editor's enclosing scroll view no longer applies a
   hard-coded `top: 55.4` content inset. The default is now `0` on every
   edge, matching the most common embedding case where the editor fills

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -21,9 +21,49 @@ import MarkdownEngineLatex
 
 struct ContentView: View {
     @State private var text: String = sampleMarkdown
+    @State private var showHeader = false
+    @State private var headerExpanded = true
 
     var body: some View {
-        NativeTextViewWrapper(text: $text, configuration: configuration)
+        NativeTextViewWrapper(
+            text: $text,
+            configuration: configuration,
+            header: showHeader ? AnyView(demoHeader) : nil,
+            headerCollapsedHeight: 40,
+            headerExpanded: headerExpanded
+        )
+        .toolbar {
+            ToolbarItemGroup {
+                // Scroll-away header: an embedder-supplied SwiftUI view hosted
+                // above the body that scrolls with it. "Expanded" animates
+                // between the full content height and `headerCollapsedHeight`
+                // (the top row stays visible; the rows below clip away).
+                Toggle("Header", isOn: $showHeader)
+                Toggle("Expanded", isOn: $headerExpanded)
+                    .disabled(!showHeader)
+            }
+        }
+    }
+
+    /// Sample scroll-away header: a fixed top row (kept visible when collapsed)
+    /// plus detail rows that reveal/hide with the `headerExpanded` toggle.
+    private var demoHeader: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("Scroll-away header").font(.headline)
+                Spacer()
+            }
+            .frame(height: 40)   // == headerCollapsedHeight: the always-visible row
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("These rows clip away when the header collapses.")
+                Text("The header scrolls with the document body and stays fully interactive.")
+                    .foregroundStyle(.secondary)
+            }
+            .font(.callout)
+            .padding(.bottom, 12)
+        }
+        .padding(.horizontal, 16)
     }
 
     /// The engine talks to your app through service protocols. Two of them —

--- a/README.md
+++ b/README.md
@@ -224,6 +224,40 @@ NativeTextViewWrapper(
   replacement (e.g. an autocomplete result); the engine consumes it
   and clears the binding.
 
+### Scrolling Header
+
+Host a SwiftUI view above the document body that scrolls away with it —
+document metadata, a property table, a contextual toolbar:
+
+```swift
+NativeTextViewWrapper(
+    text: $text,
+    header: AnyView(MyDocumentHeader(document: document)),
+    headerCollapsedHeight: 40,
+    headerExpanded: isHeaderExpanded
+)
+```
+
+- The engine hosts the view in an `NSHostingView`, reserves its
+  intrinsic height at the top of the scrolled content, and shifts the
+  body below it. The header is a sibling of the text view, so it stays
+  fully interactive (buttons, text fields, menus).
+- `headerExpanded: false` collapses the band to `headerCollapsedHeight`:
+  the top row stays visible while the rows below clip away. Toggling
+  animates the reveal. Size your header so the content above
+  `headerCollapsedHeight` is the part you want to keep visible.
+- The hosted content refreshes on every SwiftUI update — bind your
+  model into the header view as usual. Inject any required environment
+  (`.environmentObject`, `.environment`) into the view *before* wrapping
+  it in `AnyView`; the hosting view does not inherit your hierarchy's
+  environment.
+- Composes with `readingWidth`: the header spans the full viewport
+  width while the body keeps its centered column.
+- Pass `header: nil` (the default) and the editor renders exactly as
+  before — the header path adds nothing to header-less editors.
+
+The demo app's **Header** toolbar toggle shows the full behavior.
+
 ## Demo
 
 A runnable SwiftUI demo lives in [`Demo/`](Demo/MarkdownEngineDemo.xcodeproj).

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ NativeTextViewWrapper(
   (`.environmentObject`, `.environment`) into the view *before* wrapping
   it in `AnyView`; the hosting view does not inherit your hierarchy's
   environment.
+- The reserved band uses the view's **intrinsic** (ideal) height. Text
+  that relies on wrapping at the editor's width can render taller than
+  its ideal height and clip at the band's bottom — give wrapping
+  content an explicit height (`.frame`/`.fixedSize`) or line limit.
 - Composes with `readingWidth`: the header spans the full viewport
   width while the body keeps its centered column.
 - Pass `header: nil` (the default) and the editor renders exactly as

--- a/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
+++ b/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
@@ -182,6 +182,20 @@ extension NativeTextView {
         }
     }
 
+    /// Cheap per-frame overlay shift when the container moves the text view
+    /// vertically (header band growing/collapsing). Breakout overlays are
+    /// SIBLINGS in the container whose frames bake in the text view's offset
+    /// at update time; non-breakout overlays are text-view subviews and move
+    /// with it automatically.
+    func shiftWideTableOverlays(byY deltaY: CGFloat) {
+        guard configuration.readingWidth != nil, !wideTableOverlays.isEmpty else { return }
+        for (_, overlay) in wideTableOverlays {
+            var f = overlay.frame
+            f.origin.y += deltaY
+            overlay.frame = f
+        }
+    }
+
     /// Cheap per-frame overlay reposition on width change (no layout) — keeps tables glued to the text during resize.
     func repositionWideTableOverlaysForWidthChange(insetDelta: CGFloat) {
         guard configuration.readingWidth != nil, !wideTableOverlays.isEmpty else { return }

--- a/Sources/MarkdownEngine/TextView/BottomOverscrollPolicy.swift
+++ b/Sources/MarkdownEngine/TextView/BottomOverscrollPolicy.swift
@@ -40,11 +40,20 @@ struct BottomOverscrollPolicy {
         self.activationRangeFraction = activationRangeFraction
     }
 
-    func activeOverscroll(baseContentHeight: CGFloat, visibleHeight: CGFloat, lineHeight: CGFloat) -> CGFloat {
+    func activeOverscroll(
+        baseContentHeight: CGFloat,
+        headerHeight: CGFloat = 0,
+        visibleHeight: CGFloat,
+        lineHeight: CGFloat
+    ) -> CGFloat {
+        // The header band scrolls with the content, so it counts toward activation
+        // and unlock; the comfortable slack stays viewport-based (the band is gone
+        // once the user reaches the document bottom).
+        let stackedContentHeight = baseContentHeight + headerHeight
         let activationStartHeight = visibleHeight * activationStartFraction
         let activationRange = max(visibleHeight * activationRangeFraction, 1)
         let activationProgress = min(
-            max((baseContentHeight - activationStartHeight) / activationRange, 0),
+            max((stackedContentHeight - activationStartHeight) / activationRange, 0),
             1
         )
         guard activationProgress > 0 else { return 0 }
@@ -54,9 +63,9 @@ struct BottomOverscrollPolicy {
         desiredSlack = max(desiredSlack, minOverscrollPoints)
         desiredSlack = max(0, floor(desiredSlack - lineHeight))
 
-        // Start unlocking downward scroll before the text fully fills the viewport,
-        // then blend into the final comfortable bottom slack.
-        let scrollUnlockDistance = max(visibleHeight - baseContentHeight, 0)
+        // Start unlocking downward scroll before the stacked content fully fills
+        // the viewport, then blend into the final comfortable bottom slack.
+        let scrollUnlockDistance = max(visibleHeight - stackedContentHeight, 0)
         return floor((scrollUnlockDistance + desiredSlack) * activationProgress)
     }
 }

--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -36,8 +36,12 @@ final class ClampedScrollView: NSScrollView {
         guard let doc = documentView else { return }
         let minY = -contentInsets.top
         // Use the real content height (not the inflated frame) so small
-        // documents can't scroll past their actual content.
-        let realHeight = (doc as? NativeTextView)?.scrollableContentHeight ?? doc.bounds.height
+        // documents can't scroll past their actual content. The document view is a
+        // container (header band + text view); fall back to the text view / bounds for
+        // the header-less or legacy cases.
+        let realHeight = (doc as? NativeTextViewContainer)?.scrollableContentHeight
+            ?? (doc as? NativeTextView)?.scrollableContentHeight
+            ?? doc.bounds.height
         let maxY = max(minY, realHeight - contentView.bounds.height)
         let b = contentView.bounds
         let clampedY = min(max(b.origin.y, minY), maxY)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -57,7 +57,10 @@ extension NativeTextViewCoordinator {
         tlm.enumerateTextLayoutFragments(from: matchStart, options: [.ensuresLayout]) { fragment in
             let cv = scrollView.contentView
             let insetsTop = scrollView.contentInsets.top
-            let frame = fragment.layoutFragmentFrame
+            // Fragment frames are text-view-local; the scroll offset is in
+            // document-view space — lift by the text view's offset inside the
+            // container (the header band).
+            let frame = fragment.layoutFragmentFrame.offsetBy(dx: 0, dy: tv.frame.origin.y)
             let visibleTop = cv.bounds.origin.y + insetsTop
             let visibleBottom = cv.bounds.origin.y + cv.bounds.height
             // Only scroll when the match is off-screen; reveal it a little below the top.
@@ -79,9 +82,13 @@ extension NativeTextViewCoordinator {
         let visualTopDocY = preY + insetsTop
         var anchorOffsetFromTop: CGFloat = 0
         var anchorTextRange: NSTextRange? = nil
+        // Fragment frames are text-view-local; visualTopDocY is in document-view
+        // space — lift them by the text view's offset inside the container (the
+        // header band) before comparing.
+        let textViewTop = tv.frame.origin.y
         if let tlm = tv.textLayoutManager {
             tlm.enumerateTextLayoutFragments(from: tlm.documentRange.location, options: [.ensuresLayout]) { fragment in
-                let frame = fragment.layoutFragmentFrame
+                let frame = fragment.layoutFragmentFrame.offsetBy(dx: 0, dy: textViewTop)
                 if frame.maxY < visualTopDocY { return true }
                 anchorTextRange = fragment.rangeInElement
                 anchorOffsetFromTop = visualTopDocY - frame.minY
@@ -97,7 +104,7 @@ extension NativeTextViewCoordinator {
 
         if let tlm = tv.textLayoutManager, let anchor = anchorTextRange {
             tlm.enumerateTextLayoutFragments(from: anchor.location, options: [.ensuresLayout]) { fragment in
-                let newDocY = fragment.layoutFragmentFrame.minY + anchorOffsetFromTop
+                let newDocY = fragment.layoutFragmentFrame.minY + textViewTop + anchorOffsetFromTop
                 let targetScrollY = newDocY - insetsTop
                 if let cv = scrollView?.contentView, abs(cv.bounds.origin.y - targetScrollY) > 0.5 {
                     cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetScrollY))

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -39,6 +39,8 @@ extension NativeTextViewCoordinator {
 
     public func textDidChange(_ notification: Notification) {
         guard let tv = notification.object as? NSTextView else { return }
+        // Before the early returns: the first keystroke must hide the placeholder.
+        (tv as? NativeTextView)?.refreshPlaceholderVisibility()
         let wtActive = isWritingToolsActive
         if wtActive, wtDetectedMode == .unknown {
             let firstEditLen = tv.textStorage?.editedRange.length ?? 0

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -54,7 +54,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var headerConstantConstraint: NSLayoutConstraint?
     /// Drives the collapse/expand animation frame-by-frame.
     var headerAnimTimer: Timer?
-    /// Observes the clip container's height; the SOLE writer of `topContentInset`.
+    /// Observes the header clip's height; the SOLE writer of `container.headerHeight`.
     var headerContentObserver: NSObjectProtocol?
     /// Last documentId for which the SwiftUI header rootView was rebuilt.
     var headerDocumentId: String?
@@ -288,7 +288,17 @@ extension NSTextView {
         let containerOrigin = textContainerOrigin
         boundingRect.origin.x += containerOrigin.x
         boundingRect.origin.y += containerOrigin.y
+        // The text view now sits BELOW a header band inside a container document view,
+        // so its glyph rects (text-view-local) must be lifted into the document view's
+        // space before subtracting the scroll offset (which is in document-view space).
+        // `convert(.zero, to: doc)` yields (0, headerHeight); it self-zeroes if this text
+        // view ever IS the document view (header-less / legacy).
         if let scrollView = enclosingScrollView {
+            if let doc = scrollView.documentView, doc !== self {
+                let originInDoc = convert(CGPoint.zero, to: doc)
+                boundingRect.origin.x += originInDoc.x
+                boundingRect.origin.y += originInDoc.y
+            }
             let contentOffset = scrollView.contentView.bounds.origin
             boundingRect.origin.x -= contentOffset.x
             boundingRect.origin.y -= contentOffset.y

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -43,16 +43,18 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     // MARK: Header
     /// Hosts the embedder's full header content, top-pinned inside `headerClipView`.
     var headerHostingView: NSView?
-    /// Clip container whose height is the reserved top inset. Collapsing animates
-    /// this height between the collapsed (heading) height and the full content
-    /// height, revealing/hiding the lower content while the heading stays put.
+    /// Clip container whose height is the reserved top inset. Reveals/hides the
+    /// lower content while the heading stays put.
     var headerClipView: NSView?
-    /// Animatable height constraint of `headerClipView`.
-    var headerHeightConstraint: NSLayoutConstraint?
+    /// Active when expanded: `clip.height == host.height`, so the reserved region
+    /// always equals the content's (async-resolved) intrinsic height — self-correcting.
+    var headerEqualityConstraint: NSLayoutConstraint?
+    /// Active when collapsed or animating: `clip.height == constant`. The 60fps timer
+    /// drives `.constant`; on expand-settle we hand back to the equality constraint.
+    var headerConstantConstraint: NSLayoutConstraint?
     /// Drives the collapse/expand animation frame-by-frame.
     var headerAnimTimer: Timer?
-    /// Observes the hosted content's height (e.g. tags added) to keep the reserved
-    /// height correct while expanded.
+    /// Observes the clip container's height; the SOLE writer of `topContentInset`.
     var headerContentObserver: NSObjectProtocol?
     /// Last documentId for which the SwiftUI header rootView was rebuilt.
     var headerDocumentId: String?

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -40,6 +40,24 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     private var busObservers: [NSObjectProtocol] = []
     private var registeredAppearanceObserverName: Notification.Name?
     weak var textView: NSTextView?
+    // MARK: Header
+    /// Hosts the embedder's full header content, top-pinned inside `headerClipView`.
+    var headerHostingView: NSView?
+    /// Clip container whose height is the reserved top inset. Collapsing animates
+    /// this height between the collapsed (heading) height and the full content
+    /// height, revealing/hiding the lower content while the heading stays put.
+    var headerClipView: NSView?
+    /// Animatable height constraint of `headerClipView`.
+    var headerHeightConstraint: NSLayoutConstraint?
+    /// Drives the collapse/expand animation frame-by-frame.
+    var headerAnimTimer: Timer?
+    /// Observes the hosted content's height (e.g. tags added) to keep the reserved
+    /// height correct while expanded.
+    var headerContentObserver: NSObjectProtocol?
+    /// Last documentId for which the SwiftUI header rootView was rebuilt.
+    var headerDocumentId: String?
+    /// Last applied expanded state, to detect toggles.
+    var lastHeaderExpanded: Bool?
     var layoutBridge: LayoutBridge?
     var layoutDelegate: MarkdownLayoutManagerDelegate?
     var onLinkClick: ((String) -> Void)?

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -40,26 +40,9 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     private var busObservers: [NSObjectProtocol] = []
     private var registeredAppearanceObserverName: Notification.Name?
     weak var textView: NSTextView?
-    // MARK: Header
-    /// Hosts the embedder's full header content, top-pinned inside `headerClipView`.
-    var headerHostingView: NSView?
-    /// Clip container whose height is the reserved top inset. Reveals/hides the
-    /// lower content while the heading stays put.
-    var headerClipView: NSView?
-    /// Active when expanded: `clip.height == host.height`, so the reserved region
-    /// always equals the content's (async-resolved) intrinsic height — self-correcting.
-    var headerEqualityConstraint: NSLayoutConstraint?
-    /// Active when collapsed or animating: `clip.height == constant`. The 60fps timer
-    /// drives `.constant`; on expand-settle we hand back to the equality constraint.
-    var headerConstantConstraint: NSLayoutConstraint?
-    /// Drives the collapse/expand animation frame-by-frame.
-    var headerAnimTimer: Timer?
-    /// Observes the header clip's height; the SOLE writer of `container.headerHeight`.
-    var headerContentObserver: NSObjectProtocol?
-    /// Last documentId for which the SwiftUI header rootView was rebuilt.
-    var headerDocumentId: String?
-    /// Last applied expanded state, to detect toggles.
-    var lastHeaderExpanded: Bool?
+    /// Owns the scroll-away header (build, content refresh, collapse/expand,
+    /// teardown). Created on first reconcile with a non-nil header.
+    var headerController: ScrollingHeaderController?
     var layoutBridge: LayoutBridge?
     var layoutDelegate: MarkdownLayoutManagerDelegate?
     var onLinkClick: ((String) -> Void)?

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -32,14 +32,7 @@ extension NativeTextView {
             forceFullLayout: pendingFullLayoutMeasure
         )
         let visibleHeight = scrollView.contentView.bounds.height
-        let policy = BottomOverscrollPolicy(
-            overscrollPercent: overscrollPercent,
-            minOverscrollPoints: minOverscrollPoints,
-            maxOverscrollPoints: maxOverscrollPoints,
-            activationStartFraction: configuration.overscroll.activationStartFraction,
-            activationRangeFraction: configuration.overscroll.activationRangeFraction
-        )
-        let resolvedOverscroll = policy.activeOverscroll(
+        let resolvedOverscroll = resolvedOverscroll(
             baseContentHeight: measured,
             visibleHeight: visibleHeight,
             lineHeight: lineHeight
@@ -53,6 +46,43 @@ extension NativeTextView {
         baseContentHeight = measured
         activeBottomOverscroll = resolvedOverscroll
         applyManagedFrameSize(width: targetWidth ?? frame.size.width)
+    }
+
+    /// Re-run the policy with the CURRENT base content height — no TextKit
+    /// re-measure. For header-band changes (runs per animation frame).
+    func reapplyOverscrollPolicy(for scrollView: NSScrollView) {
+        let lineHeight = layoutBridgeDefaultLineHeight(for: self.baseFont, using: layoutBridge)
+        let resolved = resolvedOverscroll(
+            baseContentHeight: baseContentHeight,
+            visibleHeight: scrollView.contentView.bounds.height,
+            lineHeight: lineHeight
+        )
+        guard abs(resolved - activeBottomOverscroll) > 0.5 else { return }
+        activeBottomOverscroll = resolved
+        applyManagedFrameSize(width: frame.size.width)
+    }
+
+    /// Shared policy evaluation, including the header band stacked above the text —
+    /// without it, a short text under an expanded band gets no slack.
+    private func resolvedOverscroll(
+        baseContentHeight: CGFloat,
+        visibleHeight: CGFloat,
+        lineHeight: CGFloat
+    ) -> CGFloat {
+        let headerHeight = (superview as? NativeTextViewContainer)?.headerHeight ?? 0
+        let policy = BottomOverscrollPolicy(
+            overscrollPercent: overscrollPercent,
+            minOverscrollPoints: minOverscrollPoints,
+            maxOverscrollPoints: maxOverscrollPoints,
+            activationStartFraction: configuration.overscroll.activationStartFraction,
+            activationRangeFraction: configuration.overscroll.activationRangeFraction
+        )
+        return policy.activeOverscroll(
+            baseContentHeight: baseContentHeight,
+            headerHeight: headerHeight,
+            visibleHeight: visibleHeight,
+            lineHeight: lineHeight
+        )
     }
 
     func measuredBaseContentHeight(minimumHeight: CGFloat, forceFullLayout: Bool = false) -> CGFloat {
@@ -69,11 +99,19 @@ extension NativeTextView {
         // Lay out the last fragment; gives a max-Y fallback if enumerateTextSegments misses it.
         var fragmentMaxY: CGFloat = 0
         var visited = 0
+        // Geometry of the fragment containing the document end — the extra line
+        // fragment normalization below needs its frame and line boxes.
+        var lastFragmentFrame: NSRect = .zero
+        var lastFragmentLineBoxes: [CGRect] = []
         textLayoutManager.enumerateTextLayoutFragments(
             from: documentEnd,
             options: [.reverse, .ensuresLayout, .ensuresExtraLineFragment]
         ) { fragment in
             let frame = fragment.layoutFragmentFrame
+            if visited == 0 {
+                lastFragmentFrame = frame
+                lastFragmentLineBoxes = fragment.textLineFragments.map { $0.typographicBounds }
+            }
             fragmentMaxY = max(fragmentMaxY, frame.maxY)
             // Trailing block image draws below TextKit's height; count its surface extent so it scrolls.
             let surfaceMaxY = frame.origin.y + fragment.renderingSurfaceBounds.maxY
@@ -86,16 +124,57 @@ extension NativeTextView {
         let segmentRange = NSTextRange(location: documentEnd)
         textLayoutManager.ensureLayout(for: segmentRange)
         var segmentMaxY: CGFloat = 0
+        var segmentMinY: CGFloat = 0
         textLayoutManager.enumerateTextSegments(
             in: segmentRange,
             type: .standard,
             options: .middleFragmentsExcluded
         ) { _, rect, _, _ in
-            segmentMaxY = max(segmentMaxY, rect.maxY)
+            if rect.maxY >= segmentMaxY {
+                segmentMaxY = rect.maxY
+                segmentMinY = rect.minY
+            }
             return true
         }
 
-        let rawHeight = max(segmentMaxY, fragmentMaxY)
+        var rawHeight = max(segmentMaxY, fragmentMaxY)
+
+        // With a trailing "\n", the last line is TextKit's extra line fragment.
+        // Its metrics follow the final newline's attributes — not the body style a
+        // typed line would get — so the measured height would jump on the first
+        // typed character. Normalize the empty last line to body metrics.
+        if segmentMaxY > 0, let storage = textStorage, storage.mutableString.hasSuffix("\n") {
+            let bodyLineHeight = ceil(layoutBridgeDefaultLineHeight(for: baseFont, using: layoutBridge))
+                + configuration.paragraph.lineHeightExtraSpacing
+
+            // TextKit omits the final paragraph's paragraphSpacing above the extra
+            // line fragment but inserts it once a real character follows — add the
+            // missing gap so typing stays height-neutral.
+            let ns = storage.mutableString
+            let lastParaRange = ns.paragraphRange(for: NSRange(location: ns.length - 1, length: 0))
+            let lastParaStyle = storage.attribute(
+                .paragraphStyle, at: lastParaRange.location, effectiveRange: nil
+            ) as? NSParagraphStyle
+            let paragraphSpacing = lastParaStyle?.paragraphSpacing ?? 0
+            let prevLineBottom: CGFloat
+            if lastFragmentLineBoxes.count >= 2 {
+                let secondToLast = lastFragmentLineBoxes[lastFragmentLineBoxes.count - 2]
+                prevLineBottom = lastFragmentFrame.minY + secondToLast.maxY
+            } else {
+                prevLineBottom = lastFragmentFrame.minY
+            }
+            let appliedGap = max(segmentMinY - prevLineBottom, 0)
+            let missingSpacing = max(paragraphSpacing - appliedGap, 0)
+            let normalizedEnd = segmentMinY + missingSpacing + bodyLineHeight
+            if abs(rawHeight - segmentMaxY) < 0.5 {
+                // The extra line itself is the bottom-most content — replace it.
+                rawHeight = normalizedEnd
+            } else {
+                // Something else (e.g. a trailing image surface) reaches lower — keep it.
+                rawHeight = max(rawHeight, normalizedEnd)
+            }
+        }
+
         return max(ceil(rawHeight + (textContainerInset.height * 2)), minimumContentHeight)
     }
 

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -96,16 +96,16 @@ extension NativeTextView {
         }
 
         let rawHeight = max(segmentMaxY, fragmentMaxY)
-        // Cache the text-only height, then add the reserved top header space so the
-        // content (and scroll range) includes the header region the text sits below.
-        let textHeight = max(ceil(rawHeight + (textContainerInset.height * 2)), minimumContentHeight)
-        textOnlyContentHeight = textHeight
-        return textHeight + topContentInset
+        return max(ceil(rawHeight + (textContainerInset.height * 2)), minimumContentHeight)
     }
 
     func applyManagedFrameSize(width: CGFloat) {
         let contentHeight = max(ceil(baseContentHeight + activeBottomOverscroll), 0)
-        let scrollViewHeight = enclosingScrollView?.contentView.bounds.height ?? 0
+        // The container stacks a header band ABOVE this text view, so the text view only
+        // needs to fill the viewport MINUS that band for the whole document view to fill
+        // the viewport on short docs (header + textView ≥ viewport).
+        let headerH = (superview as? NativeTextViewContainer)?.headerHeight ?? 0
+        let scrollViewHeight = max((enclosingScrollView?.contentView.bounds.height ?? 0) - headerH, 0)
         let targetSize = NSSize(
             width: max(width, 0),
             height: max(contentHeight, scrollViewHeight)
@@ -116,6 +116,9 @@ extension NativeTextView {
         isApplyingManagedFrameSize = true
         super.setFrameSize(targetSize)
         isApplyingManagedFrameSize = false
+        // Tell the container our height changed so it can re-stack (move us below the
+        // header) and size itself. Re-entrancy is guarded inside the container.
+        (superview as? NativeTextViewContainer)?.textViewDidResize()
     }
 
     override func setFrameSize(_ newSize: NSSize) {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -96,10 +96,11 @@ extension NativeTextView {
         }
 
         let rawHeight = max(segmentMaxY, fragmentMaxY)
-        // Add the reserved top header space so the content (and scroll range)
-        // includes the header region that the text was shifted below.
-        let measuredHeight = ceil(rawHeight + (textContainerInset.height * 2) + topContentInset)
-        return max(measuredHeight, minimumContentHeight + topContentInset)
+        // Cache the text-only height, then add the reserved top header space so the
+        // content (and scroll range) includes the header region the text sits below.
+        let textHeight = max(ceil(rawHeight + (textContainerInset.height * 2)), minimumContentHeight)
+        textOnlyContentHeight = textHeight
+        return textHeight + topContentInset
     }
 
     func applyManagedFrameSize(width: CGFloat) {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -96,8 +96,10 @@ extension NativeTextView {
         }
 
         let rawHeight = max(segmentMaxY, fragmentMaxY)
-        let measuredHeight = ceil(rawHeight + (textContainerInset.height * 2))
-        return max(measuredHeight, minimumContentHeight)
+        // Add the reserved top header space so the content (and scroll range)
+        // includes the header region that the text was shifted below.
+        let measuredHeight = ceil(rawHeight + (textContainerInset.height * 2) + topContentInset)
+        return max(measuredHeight, minimumContentHeight + topContentInset)
     }
 
     func applyManagedFrameSize(width: CGFloat) {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Placeholder.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Placeholder.swift
@@ -1,0 +1,93 @@
+//
+//  NativeTextView+Placeholder.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 11.06.26.
+//
+//  Embedder-supplied ghost text shown while the document is empty. Lives inside
+//  the text view, so it sits below the scroll-away header band, tracks its
+//  animation, and scrolls with the content.
+//
+
+import AppKit
+
+/// Transparent, click-through label drawing the placeholder at the text
+/// container origin. A plain NSView — overriding `draw(_:)` here is safe
+/// (unlike on the TextKit-2 backed `NativeTextView` itself).
+final class PlaceholderLabelView: NSView {
+    var attributedText: NSAttributedString? {
+        didSet { needsDisplay = true }
+    }
+
+    /// Top-left origin to match the flipped text view's first-line position.
+    override var isFlipped: Bool { true }
+
+    /// Clicks fall through to the text view (focus + caret placement).
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+
+    override func draw(_ dirtyRect: NSRect) {
+        attributedText?.draw(
+            with: bounds,
+            options: [.usesLineFragmentOrigin, .usesFontLeading]
+        )
+    }
+}
+
+extension NativeTextView {
+    /// Install, refresh, or remove the placeholder. Cheap when nothing changed —
+    /// called from every `updateNSView`.
+    func setPlaceholder(_ attributed: NSAttributedString?) {
+        if let attributed {
+            let view: PlaceholderLabelView
+            if let existing = placeholderView {
+                view = existing
+                if existing.attributedText?.isEqual(to: attributed) != true {
+                    existing.attributedText = attributed
+                }
+            } else {
+                view = PlaceholderLabelView()
+                view.attributedText = attributed
+                view.autoresizingMask = [.width, .height]
+                addSubview(view)
+                placeholderView = view
+            }
+            let target = placeholderFrame()
+            if !view.frame.isApproximatelyEqual(to: target) {
+                view.frame = target
+            }
+        } else if let placeholderView {
+            placeholderView.removeFromSuperview()
+            self.placeholderView = nil
+        }
+        refreshPlaceholderVisibility()
+    }
+
+    /// Visible only while the document is truly empty: the first typed character
+    /// hides it, deleting everything brings it back.
+    func refreshPlaceholderVisibility() {
+        guard let placeholderView else { return }
+        let shouldHide = (textStorage?.length ?? 0) > 0
+        if placeholderView.isHidden != shouldHide {
+            placeholderView.isHidden = shouldHide
+        }
+    }
+
+    /// The text container's content area: where TextKit places the first line.
+    private func placeholderFrame() -> NSRect {
+        NSRect(
+            x: textContainerInset.width,
+            y: textContainerInset.height,
+            width: max(bounds.width - textContainerInset.width * 2, 0),
+            height: max(bounds.height - textContainerInset.height, 0)
+        )
+    }
+}
+
+private extension NSRect {
+    func isApproximatelyEqual(to other: NSRect) -> Bool {
+        abs(origin.x - other.origin.x) < 0.5
+            && abs(origin.y - other.origin.y) < 0.5
+            && abs(size.width - other.size.width) < 0.5
+            && abs(size.height - other.size.height) < 0.5
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -52,6 +52,11 @@ final class NativeTextView: NSTextView {
     // MARK: Drag-select state
     var dragStartMouseScreenLoc: NSPoint?
 
+    // MARK: Placeholder state
+    /// Click-through ghost-text label shown while the document is empty;
+    /// managed by `NativeTextView+Placeholder.swift`.
+    weak var placeholderView: PlaceholderLabelView?
+
     // MARK: Wide-table overlay state
     /// Live NSScrollView per wide table; keyed by source-ID hash.
     var wideTableOverlays: [Int: WideTableOverlay] = [:]

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -38,6 +38,12 @@ final class NativeTextView: NSTextView {
     var minOverscrollPoints: CGFloat = MarkdownEditorConfiguration.default.overscroll.minPoints
 
     // MARK: Top header reservation
+    /// The measured text content height *excluding* the header reservation. Cached
+    /// by `measuredBaseContentHeight` so that changing `topContentInset` is a cheap,
+    /// consistent recompute (`baseContentHeight = textOnlyContentHeight + inset`)
+    /// rather than a second, divergent accounting of the content height.
+    var textOnlyContentHeight: CGFloat = 0
+
     /// Empty space reserved at the very top of the content for an embedder-supplied
     /// header view (see ``NativeTextViewWrapper`` `header:`). The text is shifted
     /// down by this amount via `textContainerOrigin` and the measured content height
@@ -46,25 +52,18 @@ final class NativeTextView: NSTextView {
     /// body. Driven internally by the wrapper from the header's intrinsic height.
     var topContentInset: CGFloat = 0 {
         didSet {
-            let delta = topContentInset - oldValue
-            guard abs(delta) > 0.01 else { return }
-            // The reserved region grows/shrinks by exactly `delta`; the text below
-            // is unchanged, so adjust the content height directly instead of doing a
-            // full TextKit re-measure. This keeps header expand/collapse smooth at
-            // 60fps (the wrapper drives this from the header's animating height).
-            baseContentHeight = max(0, baseContentHeight + delta)
-            // Pin the scroll origin across the frame resize. The header is anchored
-            // to the top of the content, so growth must happen *below* it; without
-            // this, NSScrollView's resize bias shifts the whole content (the header
-            // appears to jump) instead of only moving the header's lower edge.
-            let clip = enclosingScrollView?.contentView
-            let savedOrigin = clip?.bounds.origin
+            guard abs(topContentInset - oldValue) > 0.01 else { return }
+            // Single source of truth, identical to `measuredBaseContentHeight`:
+            // total content height = text height + reserved header. Cheap — no
+            // TextKit re-measure — and never double-counts or fights the scroller.
+            baseContentHeight = textOnlyContentHeight + topContentInset
             applyManagedFrameSize(width: frame.size.width)
-            if let clip, let savedOrigin, clip.bounds.origin != savedOrigin {
-                clip.setBoundsOrigin(savedOrigin)
-                enclosingScrollView?.reflectScrolledClipView(clip)
+            // Clamp only when the header isn't animating: clamping on every tick
+            // re-anchors the scroller and can yank the body. The animation clamps
+            // once at settle.
+            if (delegate as? NativeTextViewCoordinator)?.headerAnimTimer == nil {
+                (enclosingScrollView as? ClampedScrollView)?.clampToInsets()
             }
-            (enclosingScrollView as? ClampedScrollView)?.clampToInsets()
             needsDisplay = true
         }
     }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -37,46 +37,6 @@ final class NativeTextView: NSTextView {
     var maxOverscrollPoints: CGFloat = MarkdownEditorConfiguration.default.overscroll.maxPoints
     var minOverscrollPoints: CGFloat = MarkdownEditorConfiguration.default.overscroll.minPoints
 
-    // MARK: Top header reservation
-    /// The measured text content height *excluding* the header reservation. Cached
-    /// by `measuredBaseContentHeight` so that changing `topContentInset` is a cheap,
-    /// consistent recompute (`baseContentHeight = textOnlyContentHeight + inset`)
-    /// rather than a second, divergent accounting of the content height.
-    var textOnlyContentHeight: CGFloat = 0
-
-    /// Empty space reserved at the very top of the content for an embedder-supplied
-    /// header view (see ``NativeTextViewWrapper`` `header:`). The text is shifted
-    /// down by this amount via `textContainerOrigin` and the measured content height
-    /// grows to match, so a header subview placed in `[0, topContentInset]` lives
-    /// inside the text view's bounds — hit-tested normally — and scrolls with the
-    /// body. Driven internally by the wrapper from the header's intrinsic height.
-    var topContentInset: CGFloat = 0 {
-        didSet {
-            guard abs(topContentInset - oldValue) > 0.01 else { return }
-            // Single source of truth, identical to `measuredBaseContentHeight`:
-            // total content height = text height + reserved header. Cheap — no
-            // TextKit re-measure — and never double-counts or fights the scroller.
-            baseContentHeight = textOnlyContentHeight + topContentInset
-            applyManagedFrameSize(width: frame.size.width)
-            // Clamp only when the header isn't animating: clamping on every tick
-            // re-anchors the scroller and can yank the body. The animation clamps
-            // once at settle.
-            if (delegate as? NativeTextViewCoordinator)?.headerAnimTimer == nil {
-                (enclosingScrollView as? ClampedScrollView)?.clampToInsets()
-            }
-            needsDisplay = true
-        }
-    }
-
-    /// Shift all text down by `topContentInset` so the reserved header region at the
-    /// top stays empty. The engine already routes every click / cursor-rect
-    /// conversion through `textContainerOrigin`, so this offset is honored
-    /// consistently across drawing, hit-mapping, and caret math.
-    override var textContainerOrigin: NSPoint {
-        let base = super.textContainerOrigin
-        return NSPoint(x: base.x, y: base.y + topContentInset)
-    }
-
     // MARK: Editor wiring
     var onPasteImage: ((NSPasteboard) -> String?)?
     weak var layoutBridge: LayoutBridge?

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -37,6 +37,47 @@ final class NativeTextView: NSTextView {
     var maxOverscrollPoints: CGFloat = MarkdownEditorConfiguration.default.overscroll.maxPoints
     var minOverscrollPoints: CGFloat = MarkdownEditorConfiguration.default.overscroll.minPoints
 
+    // MARK: Top header reservation
+    /// Empty space reserved at the very top of the content for an embedder-supplied
+    /// header view (see ``NativeTextViewWrapper`` `header:`). The text is shifted
+    /// down by this amount via `textContainerOrigin` and the measured content height
+    /// grows to match, so a header subview placed in `[0, topContentInset]` lives
+    /// inside the text view's bounds — hit-tested normally — and scrolls with the
+    /// body. Driven internally by the wrapper from the header's intrinsic height.
+    var topContentInset: CGFloat = 0 {
+        didSet {
+            let delta = topContentInset - oldValue
+            guard abs(delta) > 0.01 else { return }
+            // The reserved region grows/shrinks by exactly `delta`; the text below
+            // is unchanged, so adjust the content height directly instead of doing a
+            // full TextKit re-measure. This keeps header expand/collapse smooth at
+            // 60fps (the wrapper drives this from the header's animating height).
+            baseContentHeight = max(0, baseContentHeight + delta)
+            // Pin the scroll origin across the frame resize. The header is anchored
+            // to the top of the content, so growth must happen *below* it; without
+            // this, NSScrollView's resize bias shifts the whole content (the header
+            // appears to jump) instead of only moving the header's lower edge.
+            let clip = enclosingScrollView?.contentView
+            let savedOrigin = clip?.bounds.origin
+            applyManagedFrameSize(width: frame.size.width)
+            if let clip, let savedOrigin, clip.bounds.origin != savedOrigin {
+                clip.setBoundsOrigin(savedOrigin)
+                enclosingScrollView?.reflectScrolledClipView(clip)
+            }
+            (enclosingScrollView as? ClampedScrollView)?.clampToInsets()
+            needsDisplay = true
+        }
+    }
+
+    /// Shift all text down by `topContentInset` so the reserved header region at the
+    /// top stays empty. The engine already routes every click / cursor-rect
+    /// conversion through `textContainerOrigin`, so this offset is honored
+    /// consistently across drawing, hit-mapping, and caret math.
+    override var textContainerOrigin: NSPoint {
+        let base = super.textContainerOrigin
+        return NSPoint(x: base.x, y: base.y + topContentInset)
+    }
+
     // MARK: Editor wiring
     var onPasteImage: ((NSPasteboard) -> String?)?
     weak var layoutBridge: LayoutBridge?

--- a/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
@@ -28,11 +28,17 @@ final class NativeTextViewContainer: NSView {
     var headerHeight: CGFloat = 0 {
         didSet {
             guard abs(headerHeight - oldValue) > 0.01 else { return }
-            // The text view's viewport-fill inflation depends on the band height
-            // (header + text view ≥ viewport, not viewport + band). Re-apply it FIRST
-            // so the restack below sizes the container against the corrected height —
-            // a short doc never grows a phantom scroll range when the band changes.
-            if let textView { textView.applyManagedFrameSize(width: textView.frame.width) }
+            if let textView {
+                // Band height feeds the overscroll activation — re-run the policy
+                // first (no re-measure; skipped when detached, e.g. teardown).
+                if let scrollView = enclosingScrollView {
+                    textView.reapplyOverscrollPolicy(for: scrollView)
+                }
+                // The viewport-fill inflation depends on the band height
+                // (header + text view ≥ viewport); re-apply before the restack so a
+                // short doc never grows a phantom scroll range.
+                textView.applyManagedFrameSize(width: textView.frame.width)
+            }
             restack(propagateWidth: false)
         }
     }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
@@ -1,0 +1,82 @@
+//
+//  NativeTextViewContainer.swift
+//  MarkdownEngine
+//
+//  Document view of the editor's scroll view. Stacks the scroll-away header and the
+//  `NativeTextView` as SIBLINGS with disjoint frames, so body text can never composite
+//  over the header. The previous design hosted the header as a SUBVIEW of the text view
+//  (reserving space via a `textContainerOrigin` shift); during a responsive-scroll blit
+//  the cached body bitmap and the header's own `NSHostingView` layer advanced against
+//  slightly different origins, so the body drifted up over the collapsed tags row. No
+//  compositing fix could unify them (NSHostingView always forces its own layer), so the
+//  header is now a sibling: the body and header occupy disjoint rectangles in this
+//  container and overlap is geometrically impossible.
+//
+
+import AppKit
+
+final class NativeTextViewContainer: NSView {
+    /// The body. Sizes its OWN height (content + overscroll); the container only moves
+    /// it below the header band and sizes itself to the sum.
+    weak var textView: NativeTextView?
+
+    /// Reserved header band height (mirrors the clip's resolved height). Sole driver of
+    /// the vertical stack: the text view sits at `y = headerHeight`.
+    var headerHeight: CGFloat = 0 {
+        didSet {
+            guard abs(headerHeight - oldValue) > 0.01 else { return }
+            restack(propagateWidth: false)
+        }
+    }
+
+    private var isRestacking = false
+
+    /// Flipped (top-left origin) to match `NSTextView`, so `y = headerHeight` means
+    /// "below the header" and the text view's local space is a pure translation of the
+    /// container's. A non-flipped container would invert the stack and break every
+    /// `convert(_:to:)`-based coordinate path.
+    override var isFlipped: Bool { true }
+
+    /// Real scrollable height = header band + the text view's real content (no
+    /// min-viewport inflation), so the scroll view can't scroll past actual content.
+    var scrollableContentHeight: CGFloat {
+        headerHeight + (textView?.scrollableContentHeight ?? 0)
+    }
+
+    /// Single layout method. Moves the text view below the header (ORIGIN only — never
+    /// `setFrameSize`, so the text view's self-measure isn't re-triggered) and sizes the
+    /// container to `headerHeight + textViewHeight` (min the viewport). The header clip
+    /// is positioned by its own Auto Layout against this container, so it isn't touched.
+    func restack(propagateWidth: Bool) {
+        guard !isRestacking, let textView else { return }
+        isRestacking = true
+        defer { isRestacking = false }
+
+        let w = bounds.width
+        // Width propagation happens ONLY from the scroll-view-driven path; a height-only
+        // restack must never resize the text view (that would re-measure → loop).
+        if propagateWidth, abs(textView.frame.width - w) > 0.5 {
+            textView.setFrameSize(NSSize(width: w, height: textView.frame.height))
+        }
+        if abs(textView.frame.origin.y - headerHeight) > 0.01 || abs(textView.frame.origin.x) > 0.01 {
+            textView.setFrameOrigin(NSPoint(x: 0, y: headerHeight))
+        }
+        let viewportH = enclosingScrollView?.contentView.bounds.height ?? 0
+        let totalH = max(headerHeight + textView.frame.height, viewportH)
+        if abs(frame.height - totalH) > 0.5 {
+            setFrameSize(NSSize(width: w, height: totalH))
+        }
+    }
+
+    /// The text view calls this after it self-resizes its height.
+    func textViewDidResize() {
+        guard !isRestacking else { return }
+        restack(propagateWidth: false)
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        // Width came from the scroll view's clip view (autoresizing); propagate it.
+        restack(propagateWidth: true)
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
@@ -29,6 +29,10 @@ final class NativeTextViewContainer: NSView {
         didSet {
             guard abs(headerHeight - oldValue) > 0.01 else { return }
             restack(propagateWidth: false)
+            // The text view's viewport-fill inflation depends on the band height
+            // (header + text view ≥ viewport, not viewport + band). Re-apply it so a
+            // short doc never grows a phantom scroll range when the band changes.
+            if let textView { textView.applyManagedFrameSize(width: textView.frame.width) }
         }
     }
 

--- a/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
@@ -28,11 +28,12 @@ final class NativeTextViewContainer: NSView {
     var headerHeight: CGFloat = 0 {
         didSet {
             guard abs(headerHeight - oldValue) > 0.01 else { return }
-            restack(propagateWidth: false)
             // The text view's viewport-fill inflation depends on the band height
-            // (header + text view ≥ viewport, not viewport + band). Re-apply it so a
-            // short doc never grows a phantom scroll range when the band changes.
+            // (header + text view ≥ viewport, not viewport + band). Re-apply it FIRST
+            // so the restack below sizes the container against the corrected height —
+            // a short doc never grows a phantom scroll range when the band changes.
             if let textView { textView.applyManagedFrameSize(width: textView.frame.width) }
+            restack(propagateWidth: false)
         }
     }
 
@@ -75,7 +76,11 @@ final class NativeTextViewContainer: NSView {
         // (0 in full-width mode) — preserve it here.
         let x = textView.configuration.readingWidth != nil ? textView.frame.origin.x : 0
         if abs(textView.frame.origin.y - headerHeight) > 0.01 || abs(textView.frame.origin.x - x) > 0.01 {
+            let deltaY = headerHeight - textView.frame.origin.y
             textView.setFrameOrigin(NSPoint(x: x, y: headerHeight))
+            // Breakout wide-table overlays are siblings whose frames bake in the
+            // text view's offset — keep them glued to their anchor paragraphs.
+            textView.shiftWideTableOverlays(byY: deltaY)
         }
         let viewportH = enclosingScrollView?.contentView.bounds.height ?? 0
         let totalH = max(headerHeight + textView.frame.height, viewportH)

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -452,82 +452,114 @@ private extension NativeTextViewWrapper {
         host.translatesAutoresizingMaskIntoConstraints = false
         clip.addSubview(host)
 
-        let collapsed = max(0, headerCollapsedHeight)
-        let heightC = clip.heightAnchor.constraint(equalToConstant: collapsed)
+        // Two height options for the clip; exactly one is active at a time.
+        //  • equality: clip.height == host.height  → expanded, tracks content live.
+        //  • constant: clip.height == <value>      → collapsed, or animating.
+        let equalityC = clip.heightAnchor.constraint(equalTo: host.heightAnchor)
+        let constantC = clip.heightAnchor.constraint(equalToConstant: max(0, headerCollapsedHeight))
         NSLayoutConstraint.activate([
             clip.topAnchor.constraint(equalTo: textView.topAnchor),
             clip.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
             clip.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
-            heightC,
             // Host is full-height (top-pinned); overflow below the clip is hidden.
             host.topAnchor.constraint(equalTo: clip.topAnchor),
             host.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
             host.trailingAnchor.constraint(equalTo: clip.trailingAnchor)
         ])
+        if headerExpanded { equalityC.isActive = true } else { constantC.isActive = true }
 
         coord.headerHostingView = host
         coord.headerClipView = clip
-        coord.headerHeightConstraint = heightC
+        coord.headerEqualityConstraint = equalityC
+        coord.headerConstantConstraint = constantC
         coord.headerDocumentId = documentId
+        coord.lastHeaderExpanded = headerExpanded
 
+        // SOLE writer of topContentInset: the clip's height drives the reserved
+        // region. Synchronous (queue nil) so the body tracks the header with no lag.
         coord.headerContentObserver = NotificationCenter.default.addObserver(
-            forName: NSView.frameDidChangeNotification, object: clip, queue: .main
+            forName: NSView.frameDidChangeNotification, object: clip, queue: nil
         ) { [weak clip, weak native] _ in
             guard let clip, let native else { return }
-            native.topContentInset = clip.frame.height
+            let h = clip.frame.height
+            guard abs(native.topContentInset - h) > 0.5 else { return }
+            native.topContentInset = h
         }
 
-        // Set the correct initial height (no animation on first appearance).
         textView.layoutSubtreeIfNeeded()
-        let full = max(collapsed, host.frame.height)
-        heightC.constant = headerExpanded ? full : collapsed
-        textView.layoutSubtreeIfNeeded()
-        native.topContentInset = heightC.constant
-        coord.lastHeaderExpanded = headerExpanded
+        native.topContentInset = clip.frame.height
     }
 
     func applyExpansion(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
-        guard let heightC = coord.headerHeightConstraint, let host = coord.headerHostingView else { return }
+        guard let equalityC = coord.headerEqualityConstraint,
+              let constantC = coord.headerConstantConstraint,
+              let clip = coord.headerClipView,
+              let host = coord.headerHostingView else { return }
         let collapsed = max(0, headerCollapsedHeight)
-        let full = max(collapsed, host.frame.height)
-        let target = headerExpanded ? full : collapsed
 
         if coord.lastHeaderExpanded != headerExpanded {
             coord.lastHeaderExpanded = headerExpanded
-            animateHeader(to: target, textView: textView, native: native, coord: coord)
-        } else if coord.headerAnimTimer == nil, abs(heightC.constant - target) > 0.5 {
-            // Target drifted while not animating (heading/content height changed).
-            heightC.constant = target
+            // Hand the clip height to the animatable constant constraint.
+            let start = clip.frame.height
+            equalityC.isActive = false
+            constantC.constant = start
+            constantC.isActive = true
+            let target: CGFloat
+            if headerExpanded {
+                host.invalidateIntrinsicContentSize()
+                host.layoutSubtreeIfNeeded()
+                target = max(collapsed, host.fittingSize.height)
+            } else {
+                target = collapsed
+            }
+            animateHeader(to: target, expandedAfter: headerExpanded,
+                          textView: textView, native: native, coord: coord)
+        } else if !headerExpanded, coord.headerAnimTimer == nil, constantC.isActive,
+                  abs(constantC.constant - collapsed) > 0.5 {
+            // Collapsed steady: keep the constant in sync with the heading height.
+            constantC.constant = collapsed
             textView.layoutSubtreeIfNeeded()
-            native.topContentInset = target
         }
+        // Expanded steady: the equality constraint already tracks the content.
     }
 
-    func animateHeader(to target: CGFloat, textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
-        guard let heightC = coord.headerHeightConstraint else { return }
+    func animateHeader(to target: CGFloat, expandedAfter: Bool,
+                       textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+        guard let constantC = coord.headerConstantConstraint else { return }
         coord.headerAnimTimer?.invalidate()
-        let start = heightC.constant
+        let start = constantC.constant
+
+        func settle() {
+            coord.headerAnimTimer = nil
+            if expandedAfter, let equalityC = coord.headerEqualityConstraint {
+                // Hand back to the live-tracking equality constraint.
+                constantC.isActive = false
+                equalityC.isActive = true
+                textView.layoutSubtreeIfNeeded()
+            }
+            // One clamp once the height has settled (skipped during the animation).
+            (textView.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
+        }
+
         guard abs(target - start) > 0.5 else {
-            heightC.constant = target
+            constantC.constant = target
             textView.layoutSubtreeIfNeeded()
-            native.topContentInset = target
+            settle()
             return
         }
         let duration: CGFloat = 0.32
         var progress: CGFloat = 0
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak textView, weak native, weak coord] t in
-            guard let textView, let native, let coord, let heightC = coord.headerHeightConstraint else {
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak textView, weak coord] t in
+            guard let textView, let coord, let constantC = coord.headerConstantConstraint else {
                 t.invalidate(); return
             }
             progress = min(1, progress + (1.0 / 60.0) / duration)
             let eased = progress < 0.5 ? 2 * progress * progress : 1 - pow(-2 * progress + 2, 2) / 2
-            let h = start + (target - start) * eased
-            heightC.constant = h
-            textView.layoutSubtreeIfNeeded()
-            native.topContentInset = h
+            constantC.constant = start + (target - start) * eased
+            textView.layoutSubtreeIfNeeded()   // → clip frame change → clip observer → topContentInset
             if progress >= 1 {
                 t.invalidate()
-                coord.headerAnimTimer = nil
+                settle()
             }
         }
         RunLoop.main.add(timer, forMode: .common)
@@ -542,7 +574,8 @@ private extension NativeTextViewWrapper {
         coord.headerClipView?.removeFromSuperview()
         coord.headerClipView = nil
         coord.headerHostingView = nil
-        coord.headerHeightConstraint = nil
+        coord.headerEqualityConstraint = nil
+        coord.headerConstantConstraint = nil
         coord.headerDocumentId = nil
         coord.lastHeaderExpanded = nil
         native.topContentInset = 0

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -75,8 +75,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
     /// SwiftUI header hosted above the body and scrolling with it. The engine owns
     /// an `NSHostingView`, reserves its (intrinsic) height at the top of the text
-    /// content, and refreshes its `rootView` when `documentId` changes. Because the
-    /// header lives inside the text view's bounds, it is fully interactive. Inject
+    /// content, and refreshes its `rootView` when `documentId` changes. The header is
+    /// a sibling of the text view in the scrolled container, so it is fully interactive. Inject
     /// any required SwiftUI environment into this content before passing it in.
     public var header: AnyView?
     /// Core (AppKit) alternative to ``header``: a raw NSView hosted in the same
@@ -182,25 +182,17 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.postsFrameChangedNotifications = true
         textView.autoresizingMask = [.width]
         textView.backgroundColor = .clear
-        // Layer-back the scrolled document view so an embedder-supplied header
-        // (hosted in a layer-backed clip subview, see `buildHeader`) and the body
-        // text composite within ONE Core Animation tree and advance on the same
-        // commit. Without this the header is a CA-sublayer island inside a
-        // non-layer-backed, transparent text view: during a live scroll the header
-        // layer is repositioned by Core Animation while the body strip just below
-        // the reserved band is repainted synchronously by TextKit on a different
-        // cadence, so for a frame the freshly-drawn body shows through where the
-        // header's lower rows belong (the inline inspector's summary row dropping
-        // out mid-scroll). `.onSetNeedsDisplay` keeps TextKit caret/selection
-        // redraw on-demand rather than re-rasterizing on every bounds change.
+        // Layer-back the text view for smooth scrolling. The scroll-away header is now
+        // a SIBLING of the text view inside the container (`NativeTextViewContainer`),
+        // not a subview, so no cross-layer unification with the header is needed — they
+        // occupy disjoint frames and cannot composite over each other.
         textView.wantsLayer = true
         textView.layerContentsRedrawPolicy = .onSetNeedsDisplay
-        // TEMP (remove before merge): one-shot startup marker so a tester can
-        // confirm in the console that a FRESH engine build is running — Xcode
-        // aggressively serves stale local-package builds; if this line is absent,
-        // delete ~/Library/Developer/Xcode/DerivedData/Nodes-* and rebuild.
-        NSLog("⟦NODES-ENGINE⟧ editor created — wantsLayer=%@ — build=header-compositing-fix-1",
-              textView.wantsLayer ? "true" : "false")
+        // Clip the body to the text view's bounds so responsive-scroll OVERDRAW can't
+        // render text ABOVE the text view's frame top (into the header band that sits
+        // above it). NSView does NOT clip to bounds by default; without this the body
+        // bleeds up over the collapsed header even though the FRAMES are disjoint.
+        textView.clipsToBounds = true
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
         textView.font = font
         textView.baseFont = font
@@ -220,7 +212,20 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.layoutBridge = bridge
         textView.layoutBridge = bridge
 
-        scrollView.documentView = textView
+        // The document view is a container that stacks the (optional) scroll-away header
+        // ABOVE the text view as siblings (see `NativeTextViewContainer`). The text view
+        // keeps managing its own height; the container offsets it below the header band
+        // and sizes itself to the sum. This makes body/header overlap geometrically
+        // impossible (disjoint frames), replacing the old in-text-view header hosting.
+        let vpSize = scrollView.contentView.bounds.size
+        let container = NativeTextViewContainer(frame: NSRect(origin: .zero, size: vpSize))
+        container.autoresizingMask = [.width]
+        container.clipsToBounds = true
+        container.textView = textView
+        textView.autoresizingMask = []   // width + origin are driven by the container
+        textView.frame = NSRect(x: 0, y: 0, width: vpSize.width, height: textView.frame.height)
+        container.addSubview(textView)
+        scrollView.documentView = container
         // Force full-document layout at init so paragraph heights are known
         // upfront; otherwise TextKit 2 viewport layout causes scroll drift.
         textLayoutManager.ensureLayout(for: textLayoutManager.documentRange)
@@ -247,15 +252,17 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                 context.coordinator.updateCodeBlockSelection(textView: textView)
             }
             // Only react with overscroll recalc when the viewport itself resizes
-            // (window resize). Without this guard, TextKit-induced textView frame
-            // changes echo back here and re-trigger recalcOverscroll, causing a
-            // 149pt height oscillation after clicks.
-            guard abs(textView.frame.height - scrollView.contentView.bounds.height) > 1 else { return }
+            // (window resize). Without this guard, TextKit-induced frame changes echo
+            // back here and re-trigger recalcOverscroll, causing a 149pt height
+            // oscillation after clicks. Compare the CONTAINER (the document view) height
+            // to the viewport — it tracks the viewport for short docs.
+            guard let container = scrollView.documentView as? NativeTextViewContainer,
+                  abs(container.frame.height - scrollView.contentView.bounds.height) > 1 else { return }
             textView.recalcOverscroll(for: scrollView)
             scrollView.clampToInsets()
         }
         NotificationCenter.default.addObserver(forName: NSView.boundsDidChangeNotification, object: scrollView.contentView, queue: nil) { _ in
-            (textView as? NativeTextView)?.ensureVisibleLayout()
+            textView.ensureVisibleLayout()
             if context.coordinator.isWritingToolsActive {
                 context.coordinator.fixWritingToolsChildWindowIfNeeded(textView: textView)
             }
@@ -268,7 +275,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     }
 
     public func updateNSView(_ nsView: NSScrollView, context: Context) {
-        guard let textView = nsView.documentView as? NSTextView else { return }
+        guard let container = nsView.documentView as? NativeTextViewContainer,
+              let textView = container.textView else { return }
         reconcileHeader(textView: textView, context: context)
 
         let isNodeSwitch = context.coordinator.documentId != documentId
@@ -288,9 +296,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             return
         }
 
-        if let bottomTextView = nsView.documentView as? NativeTextView {
-            bottomTextView.onPasteImage = onPasteImage
-        }
+        textView.onPasteImage = onPasteImage
         if nsView.hasVerticalScroller != configuration.scrollers.hasVerticalScroller {
             nsView.hasVerticalScroller = configuration.scrollers.hasVerticalScroller
         }
@@ -319,7 +325,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             context.coordinator.lastImageFingerprint = newImageFingerprint
             context.coordinator.lastWikiFingerprint = newWikiFingerprint
             context.coordinator.configuration.services = configuration.services
-            (nsView.documentView as? NativeTextView)?.configuration.services = configuration.services
+            textView.configuration.services = configuration.services
             // Only an image change needs a layout re-measure; a wiki-link rename is style-only.
             if imageChanged, let tlm = textView.textLayoutManager {
                 tlm.invalidateLayout(for: tlm.documentRange)
@@ -361,7 +367,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             context.coordinator.didEnsureLayoutForCurrentDocument = false
             context.coordinator.resetImageEmbedState()
             // Drop old document's wide-table overlays synchronously.
-            (textView as? NativeTextView)?.removeAllWideTableOverlays()
+            textView.removeAllWideTableOverlays()
             // Reset scroll to top of content so the previous file's scrollY
             // doesn't leak into a (potentially shorter) new file.
             nsView.contentView.scroll(to: NSPoint(x: 0, y: -nsView.contentInsets.top))
@@ -371,11 +377,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
         textView.font = font
-        if let tv = nsView.documentView as? NativeTextView {
-            tv.baseFont = font
-            tv.recalcOverscroll(for: nsView)
-            (nsView as? ClampedScrollView)?.clampToInsets()
-        }
+        textView.baseFont = font
+        textView.recalcOverscroll(for: nsView)
+        (nsView as? ClampedScrollView)?.clampToInsets()
 
         // Sync coordinator's font fields BEFORE the rebuild so the helper
         // reads the current values from the View struct.
@@ -386,14 +390,10 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             from: text,
             invalidateLayout: isNodeSwitch
         )
-        if let tv = nsView.documentView as? NativeTextView {
-            tv.recalcOverscroll(for: nsView)
-            (nsView as? ClampedScrollView)?.clampToInsets()
-        }
+        textView.recalcOverscroll(for: nsView)
+        (nsView as? ClampedScrollView)?.clampToInsets()
         DispatchQueue.main.async {
-            if let tv = nsView.documentView as? NativeTextView {
-                context.coordinator.updateCodeBlockSelection(textView: tv)
-            }
+            context.coordinator.updateCodeBlockSelection(textView: textView)
         }
 
         context.coordinator.onCaretRectChange = onCaretRectChange
@@ -441,7 +441,7 @@ private extension NativeTextViewWrapper {
         }
 
         if coord.headerClipView == nil {
-            buildHeader(textView: textView, native: native, coord: coord)
+            buildHeader(native: native, coord: coord)
         } else if coord.headerDocumentId != documentId,
                   let h = header,
                   let hv = coord.headerHostingView as? NSHostingView<AnyView> {
@@ -449,14 +449,21 @@ private extension NativeTextViewWrapper {
             coord.headerDocumentId = documentId
         }
 
-        applyExpansion(textView: textView, native: native, coord: coord)
+        applyExpansion(textView: textView, coord: coord)
     }
 
-    func buildHeader(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+    func buildHeader(native: NativeTextView, coord: NativeTextViewCoordinator) {
+        guard let container = native.superview as? NativeTextViewContainer else { return }
         let host: NSView
         if let header {
             let h = NSHostingView(rootView: header)
             if #available(macOS 13.0, *) { h.sizingOptions = [.intrinsicContentSize] }
+            // Ignore the window safe area (the toolbar/navbar region). Otherwise, as the
+            // host scrolls relative to that safe area, SwiftUI adds/removes a TOP inset to
+            // "flow under the navbar" — which shifts the content down inside the host and
+            // pushes the collapsed summary/tags row below the clip mask (the "sliding
+            // window"), and makes the measured intrinsic height oscillate with scrollY.
+            if #available(macOS 13.3, *) { h.safeAreaRegions = [] }
             host = h
         } else if let headerView {
             host = headerView
@@ -466,7 +473,11 @@ private extension NativeTextViewWrapper {
         clip.translatesAutoresizingMaskIntoConstraints = false
         clip.clipsToBounds = true
         clip.postsFrameChangedNotifications = true
-        textView.addSubview(clip)
+        // The clip is a SIBLING of the text view inside the container (top band), not a
+        // subview of the text view. Auto-Layout-pinned to the container's top/leading/
+        // trailing; its height is owned by the equality/constant constraints below and
+        // read back into `container.headerHeight`.
+        container.addSubview(clip)
 
         host.translatesAutoresizingMaskIntoConstraints = false
         clip.addSubview(host)
@@ -477,9 +488,9 @@ private extension NativeTextViewWrapper {
         let equalityC = clip.heightAnchor.constraint(equalTo: host.heightAnchor)
         let constantC = clip.heightAnchor.constraint(equalToConstant: max(0, headerCollapsedHeight))
         NSLayoutConstraint.activate([
-            clip.topAnchor.constraint(equalTo: textView.topAnchor),
-            clip.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
-            clip.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
+            clip.topAnchor.constraint(equalTo: container.topAnchor),
+            clip.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            clip.trailingAnchor.constraint(equalTo: container.trailingAnchor),
             // Host is full-height (top-pinned); overflow below the clip is hidden.
             host.topAnchor.constraint(equalTo: clip.topAnchor),
             host.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
@@ -494,30 +505,27 @@ private extension NativeTextViewWrapper {
         coord.headerDocumentId = documentId
         coord.lastHeaderExpanded = headerExpanded
 
-        // SOLE writer of topContentInset: the clip's height drives the reserved
-        // region. Synchronous (queue nil) so the body tracks the header with no lag.
+        // SOLE writer of `container.headerHeight`: the clip's height drives the header
+        // band, which the container reads to offset the text view. Synchronous (queue
+        // nil) so the body tracks the header with no lag.
         //
-        // While the *constant* constraint governs (collapsed, or mid-animation) the
-        // reserved height is its `.constant` — the intended, stable value — NOT the
-        // live `clip.frame.height`. The text view is autoresizing-mask driven while
-        // the clip is Auto-Layout-pinned to it, so a scroll-time layout pass can
-        // momentarily expose a smaller in-flight clip frame before the required
-        // constant re-settles. Trusting that transient would shrink topContentInset
-        // and slide the body up under the heading (clipping the summary row +
-        // chevron). Reading the constant instead keeps the collapsed reservation
-        // rock-stable through scrolling. When expanded, the equality constraint is
-        // active and `clip.frame.height` (== host height) is the live source.
+        // While the *constant* constraint governs (collapsed, or mid-animation) the band
+        // height is its `.constant` — the intended, stable value — NOT the live
+        // `clip.frame.height`, which a scroll-time layout pass can momentarily expose
+        // smaller before the constant re-settles. Reading the constant keeps the
+        // collapsed band rock-stable. When expanded, the equality constraint is active
+        // and `clip.frame.height` (== host height) is the live source.
         coord.headerContentObserver = NotificationCenter.default.addObserver(
             forName: NSView.frameDidChangeNotification, object: clip, queue: nil
-        ) { [weak clip, weak native, weak coord] _ in
-            guard let clip, let native else { return }
+        ) { [weak clip, weak container, weak coord] _ in
+            guard let clip, let container else { return }
             let h = Self.reservedHeaderHeight(clip: clip, coord: coord)
-            guard abs(native.topContentInset - h) > 0.5 else { return }
-            native.topContentInset = h
+            guard abs(container.headerHeight - h) > 0.5 else { return }
+            container.headerHeight = h
         }
 
-        textView.layoutSubtreeIfNeeded()
-        native.topContentInset = Self.reservedHeaderHeight(clip: clip, coord: coord)
+        container.layoutSubtreeIfNeeded()
+        container.headerHeight = Self.reservedHeaderHeight(clip: clip, coord: coord)
     }
 
     /// The reserved top inset the body should sit below. When the constant
@@ -530,7 +538,7 @@ private extension NativeTextViewWrapper {
         return clip.frame.height
     }
 
-    func applyExpansion(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+    func applyExpansion(textView: NSTextView, coord: NativeTextViewCoordinator) {
         guard let equalityC = coord.headerEqualityConstraint,
               let constantC = coord.headerConstantConstraint,
               let clip = coord.headerClipView,
@@ -553,18 +561,18 @@ private extension NativeTextViewWrapper {
                 target = collapsed
             }
             animateHeader(to: target, expandedAfter: headerExpanded,
-                          textView: textView, native: native, coord: coord)
+                          textView: textView, coord: coord)
         } else if !headerExpanded, coord.headerAnimTimer == nil, constantC.isActive,
                   abs(constantC.constant - collapsed) > 0.5 {
             // Collapsed steady: keep the constant in sync with the heading height.
             constantC.constant = collapsed
-            textView.layoutSubtreeIfNeeded()
+            clip.superview?.layoutSubtreeIfNeeded()
         }
         // Expanded steady: the equality constraint already tracks the content.
     }
 
     func animateHeader(to target: CGFloat, expandedAfter: Bool,
-                       textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+                       textView: NSTextView, coord: NativeTextViewCoordinator) {
         guard let constantC = coord.headerConstantConstraint else { return }
         coord.headerAnimTimer?.invalidate()
         let start = constantC.constant
@@ -575,7 +583,7 @@ private extension NativeTextViewWrapper {
                 // Hand back to the live-tracking equality constraint.
                 constantC.isActive = false
                 equalityC.isActive = true
-                textView.layoutSubtreeIfNeeded()
+                coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
             }
             // One clamp once the height has settled (skipped during the animation).
             (textView.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
@@ -583,7 +591,7 @@ private extension NativeTextViewWrapper {
 
         guard abs(target - start) > 0.5 else {
             constantC.constant = target
-            textView.layoutSubtreeIfNeeded()
+            coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
             settle()
             return
         }
@@ -596,7 +604,8 @@ private extension NativeTextViewWrapper {
             progress = min(1, progress + (1.0 / 60.0) / duration)
             let eased = progress < 0.5 ? 2 * progress * progress : 1 - pow(-2 * progress + 2, 2) / 2
             constantC.constant = start + (target - start) * eased
-            textView.layoutSubtreeIfNeeded()   // → clip frame change → clip observer → topContentInset
+            // → clip height change → clip frameDidChange → observer → container.headerHeight → restack.
+            coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
             if progress >= 1 {
                 t.invalidate()
                 settle()
@@ -618,6 +627,8 @@ private extension NativeTextViewWrapper {
         coord.headerConstantConstraint = nil
         coord.headerDocumentId = nil
         coord.lastHeaderExpanded = nil
-        native.topContentInset = 0
+        if let container = native.superview as? NativeTextViewContainer {
+            container.headerHeight = 0   // → restack: text view back to y=0, container shrinks
+        }
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -73,6 +73,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// ``MarkdownEditorConfiguration/spellChecking`` on next launch.
     public var onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)?
 
+    /// Ghost text shown at the first-line position while the document is empty;
+    /// the first typed character hides it. Lives inside the scrolled content, so
+    /// it sits below the header band and tracks its expand/collapse animation.
+    public var placeholder: NSAttributedString?
+
     /// SwiftUI header hosted above the body and scrolling with it. The engine owns
     /// an `NSHostingView`, reserves its (intrinsic) height at the top of the text
     /// content, and refreshes the hosted content on every SwiftUI update. The header
@@ -103,6 +108,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onInlineSelectionChange: ((InlineSelectionState?) -> Void)? = nil,
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
         onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
+        placeholder: NSAttributedString? = nil,
         header: AnyView? = nil,
         headerCollapsedHeight: CGFloat = 0,
         headerExpanded: Bool = true
@@ -121,6 +127,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onInlineSelectionChange = onInlineSelectionChange
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
+        self.placeholder = placeholder
         self.header = header
         self.headerCollapsedHeight = headerCollapsedHeight
         self.headerExpanded = headerExpanded
@@ -237,6 +244,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
 
         textView.recalcOverscroll(for: scrollView)
+        textView.setPlaceholder(placeholder)
         // Initial reading-column centering; the resize observer below handles later changes.
         if configuration.readingWidth != nil {
             textView.centerReadingColumn(forClipWidth: scrollView.contentView.bounds.width)
@@ -300,6 +308,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
 
         textView.onPasteImage = onPasteImage
+        textView.setPlaceholder(placeholder)
         if nsView.hasVerticalScroller != configuration.scrollers.hasVerticalScroller {
             nsView.hasVerticalScroller = configuration.scrollers.hasVerticalScroller
         }
@@ -397,6 +406,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         )
         textView.recalcOverscroll(for: nsView)
         (nsView as? ClampedScrollView)?.clampToInsets()
+        // Document rebuilds bypass textDidChange — re-derive emptiness here.
+        textView.refreshPlaceholderVisibility()
         DispatchQueue.main.async {
             context.coordinator.updateCodeBlockSelection(textView: textView)
         }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -182,6 +182,25 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.postsFrameChangedNotifications = true
         textView.autoresizingMask = [.width]
         textView.backgroundColor = .clear
+        // Layer-back the scrolled document view so an embedder-supplied header
+        // (hosted in a layer-backed clip subview, see `buildHeader`) and the body
+        // text composite within ONE Core Animation tree and advance on the same
+        // commit. Without this the header is a CA-sublayer island inside a
+        // non-layer-backed, transparent text view: during a live scroll the header
+        // layer is repositioned by Core Animation while the body strip just below
+        // the reserved band is repainted synchronously by TextKit on a different
+        // cadence, so for a frame the freshly-drawn body shows through where the
+        // header's lower rows belong (the inline inspector's summary row dropping
+        // out mid-scroll). `.onSetNeedsDisplay` keeps TextKit caret/selection
+        // redraw on-demand rather than re-rasterizing on every bounds change.
+        textView.wantsLayer = true
+        textView.layerContentsRedrawPolicy = .onSetNeedsDisplay
+        // TEMP (remove before merge): one-shot startup marker so a tester can
+        // confirm in the console that a FRESH engine build is running — Xcode
+        // aggressively serves stale local-package builds; if this line is absent,
+        // delete ~/Library/Developer/Xcode/DerivedData/Nodes-* and rebuild.
+        NSLog("⟦NODES-ENGINE⟧ editor created — wantsLayer=%@ — build=header-compositing-fix-1",
+              textView.wantsLayer ? "true" : "false")
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
         textView.font = font
         textView.baseFont = font
@@ -477,17 +496,38 @@ private extension NativeTextViewWrapper {
 
         // SOLE writer of topContentInset: the clip's height drives the reserved
         // region. Synchronous (queue nil) so the body tracks the header with no lag.
+        //
+        // While the *constant* constraint governs (collapsed, or mid-animation) the
+        // reserved height is its `.constant` — the intended, stable value — NOT the
+        // live `clip.frame.height`. The text view is autoresizing-mask driven while
+        // the clip is Auto-Layout-pinned to it, so a scroll-time layout pass can
+        // momentarily expose a smaller in-flight clip frame before the required
+        // constant re-settles. Trusting that transient would shrink topContentInset
+        // and slide the body up under the heading (clipping the summary row +
+        // chevron). Reading the constant instead keeps the collapsed reservation
+        // rock-stable through scrolling. When expanded, the equality constraint is
+        // active and `clip.frame.height` (== host height) is the live source.
         coord.headerContentObserver = NotificationCenter.default.addObserver(
             forName: NSView.frameDidChangeNotification, object: clip, queue: nil
-        ) { [weak clip, weak native] _ in
+        ) { [weak clip, weak native, weak coord] _ in
             guard let clip, let native else { return }
-            let h = clip.frame.height
+            let h = Self.reservedHeaderHeight(clip: clip, coord: coord)
             guard abs(native.topContentInset - h) > 0.5 else { return }
             native.topContentInset = h
         }
 
         textView.layoutSubtreeIfNeeded()
-        native.topContentInset = clip.frame.height
+        native.topContentInset = Self.reservedHeaderHeight(clip: clip, coord: coord)
+    }
+
+    /// The reserved top inset the body should sit below. When the constant
+    /// constraint governs (collapsed / animating) this is its `.constant` — stable
+    /// against transient mid-layout clip frames; otherwise the live clip height.
+    static func reservedHeaderHeight(clip: NSView, coord: NativeTextViewCoordinator?) -> CGFloat {
+        if let constantC = coord?.headerConstantConstraint, constantC.isActive {
+            return constantC.constant
+        }
+        return clip.frame.height
     }
 
     func applyExpansion(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -73,6 +73,24 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// ``MarkdownEditorConfiguration/spellChecking`` on next launch.
     public var onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)?
 
+    /// SwiftUI header hosted above the body and scrolling with it. The engine owns
+    /// an `NSHostingView`, reserves its (intrinsic) height at the top of the text
+    /// content, and refreshes its `rootView` when `documentId` changes. Because the
+    /// header lives inside the text view's bounds, it is fully interactive. Inject
+    /// any required SwiftUI environment into this content before passing it in.
+    public var header: AnyView?
+    /// Core (AppKit) alternative to ``header``: a raw NSView hosted in the same
+    /// reserved region for non-SwiftUI embedders. The engine sizes/places it but
+    /// does not manage its content. Ignored when ``header`` is non-nil.
+    public var headerView: NSView?
+    /// Visible header height when collapsed — typically just the heading. Content
+    /// below this is clipped. The embedder measures and supplies it so the heading
+    /// stays fully visible while the lower content reveals/hides.
+    public var headerCollapsedHeight: CGFloat
+    /// Whether the header is expanded to its full content height or collapsed to
+    /// ``headerCollapsedHeight``. Toggling animates the reveal.
+    public var headerExpanded: Bool
+
     public init(
         text: Binding<String>,
         isWikiLinkActive: Binding<Bool> = .constant(false),
@@ -87,7 +105,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onCaretRectChange: ((CGRect) -> Void)? = nil,
         onInlineSelectionChange: ((InlineSelectionState?) -> Void)? = nil,
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
-        onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil
+        onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
+        header: AnyView? = nil,
+        headerView: NSView? = nil,
+        headerCollapsedHeight: CGFloat = 0,
+        headerExpanded: Bool = true
     ) {
         self._text = text
         self._isWikiLinkActive = isWikiLinkActive
@@ -103,6 +125,10 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onInlineSelectionChange = onInlineSelectionChange
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
+        self.header = header
+        self.headerView = headerView
+        self.headerCollapsedHeight = headerCollapsedHeight
+        self.headerExpanded = headerExpanded
     }
 
     public func makeNSView(context: Context) -> NSScrollView {
@@ -218,11 +244,13 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             context.coordinator.refreshActiveLinkCaretRect()
             context.coordinator.updateCodeBlockSelection(textView: textView)
         }
+        reconcileHeader(textView: textView, context: context)
         return scrollView
     }
 
     public func updateNSView(_ nsView: NSScrollView, context: Context) {
         guard let textView = nsView.documentView as? NSTextView else { return }
+        reconcileHeader(textView: textView, context: context)
 
         let isNodeSwitch = context.coordinator.documentId != documentId
         let wtActive: Bool = {
@@ -374,5 +402,149 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.userPrefersAutomaticSpellingCorrection = configuration.spellChecking.automaticSpellingCorrection
         coordinator.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
         return coordinator
+    }
+}
+
+// MARK: - Scrolling header view
+
+private extension NativeTextViewWrapper {
+    /// Host the header inside a clip container at the top of the content. The clip
+    /// height is the reserved top inset; collapsing animates it between
+    /// `headerCollapsedHeight` and the full content height, so the heading stays
+    /// fixed while the lower content reveals/hides.
+    func reconcileHeader(textView: NSTextView, context: Context) {
+        let coord = context.coordinator
+        guard let native = textView as? NativeTextView else { return }
+
+        guard header != nil || headerView != nil else {
+            if coord.headerClipView != nil { removeHeader(coord: coord, native: native) }
+            return
+        }
+
+        if coord.headerClipView == nil {
+            buildHeader(textView: textView, native: native, coord: coord)
+        } else if coord.headerDocumentId != documentId,
+                  let h = header,
+                  let hv = coord.headerHostingView as? NSHostingView<AnyView> {
+            hv.rootView = h
+            coord.headerDocumentId = documentId
+        }
+
+        applyExpansion(textView: textView, native: native, coord: coord)
+    }
+
+    func buildHeader(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+        let host: NSView
+        if let header {
+            let h = NSHostingView(rootView: header)
+            if #available(macOS 13.0, *) { h.sizingOptions = [.intrinsicContentSize] }
+            host = h
+        } else if let headerView {
+            host = headerView
+        } else { return }
+
+        let clip = NSView()
+        clip.translatesAutoresizingMaskIntoConstraints = false
+        clip.clipsToBounds = true
+        clip.postsFrameChangedNotifications = true
+        textView.addSubview(clip)
+
+        host.translatesAutoresizingMaskIntoConstraints = false
+        clip.addSubview(host)
+
+        let collapsed = max(0, headerCollapsedHeight)
+        let heightC = clip.heightAnchor.constraint(equalToConstant: collapsed)
+        NSLayoutConstraint.activate([
+            clip.topAnchor.constraint(equalTo: textView.topAnchor),
+            clip.leadingAnchor.constraint(equalTo: textView.leadingAnchor),
+            clip.trailingAnchor.constraint(equalTo: textView.trailingAnchor),
+            heightC,
+            // Host is full-height (top-pinned); overflow below the clip is hidden.
+            host.topAnchor.constraint(equalTo: clip.topAnchor),
+            host.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: clip.trailingAnchor)
+        ])
+
+        coord.headerHostingView = host
+        coord.headerClipView = clip
+        coord.headerHeightConstraint = heightC
+        coord.headerDocumentId = documentId
+
+        coord.headerContentObserver = NotificationCenter.default.addObserver(
+            forName: NSView.frameDidChangeNotification, object: clip, queue: .main
+        ) { [weak clip, weak native] _ in
+            guard let clip, let native else { return }
+            native.topContentInset = clip.frame.height
+        }
+
+        // Set the correct initial height (no animation on first appearance).
+        textView.layoutSubtreeIfNeeded()
+        let full = max(collapsed, host.frame.height)
+        heightC.constant = headerExpanded ? full : collapsed
+        textView.layoutSubtreeIfNeeded()
+        native.topContentInset = heightC.constant
+        coord.lastHeaderExpanded = headerExpanded
+    }
+
+    func applyExpansion(textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+        guard let heightC = coord.headerHeightConstraint, let host = coord.headerHostingView else { return }
+        let collapsed = max(0, headerCollapsedHeight)
+        let full = max(collapsed, host.frame.height)
+        let target = headerExpanded ? full : collapsed
+
+        if coord.lastHeaderExpanded != headerExpanded {
+            coord.lastHeaderExpanded = headerExpanded
+            animateHeader(to: target, textView: textView, native: native, coord: coord)
+        } else if coord.headerAnimTimer == nil, abs(heightC.constant - target) > 0.5 {
+            // Target drifted while not animating (heading/content height changed).
+            heightC.constant = target
+            textView.layoutSubtreeIfNeeded()
+            native.topContentInset = target
+        }
+    }
+
+    func animateHeader(to target: CGFloat, textView: NSTextView, native: NativeTextView, coord: NativeTextViewCoordinator) {
+        guard let heightC = coord.headerHeightConstraint else { return }
+        coord.headerAnimTimer?.invalidate()
+        let start = heightC.constant
+        guard abs(target - start) > 0.5 else {
+            heightC.constant = target
+            textView.layoutSubtreeIfNeeded()
+            native.topContentInset = target
+            return
+        }
+        let duration: CGFloat = 0.32
+        var progress: CGFloat = 0
+        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak textView, weak native, weak coord] t in
+            guard let textView, let native, let coord, let heightC = coord.headerHeightConstraint else {
+                t.invalidate(); return
+            }
+            progress = min(1, progress + (1.0 / 60.0) / duration)
+            let eased = progress < 0.5 ? 2 * progress * progress : 1 - pow(-2 * progress + 2, 2) / 2
+            let h = start + (target - start) * eased
+            heightC.constant = h
+            textView.layoutSubtreeIfNeeded()
+            native.topContentInset = h
+            if progress >= 1 {
+                t.invalidate()
+                coord.headerAnimTimer = nil
+            }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        coord.headerAnimTimer = timer
+    }
+
+    func removeHeader(coord: NativeTextViewCoordinator, native: NativeTextView) {
+        coord.headerAnimTimer?.invalidate(); coord.headerAnimTimer = nil
+        if let o = coord.headerContentObserver {
+            NotificationCenter.default.removeObserver(o); coord.headerContentObserver = nil
+        }
+        coord.headerClipView?.removeFromSuperview()
+        coord.headerClipView = nil
+        coord.headerHostingView = nil
+        coord.headerHeightConstraint = nil
+        coord.headerDocumentId = nil
+        coord.lastHeaderExpanded = nil
+        native.topContentInset = 0
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -75,16 +75,13 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
     /// SwiftUI header hosted above the body and scrolling with it. The engine owns
     /// an `NSHostingView`, reserves its (intrinsic) height at the top of the text
-    /// content, and refreshes its `rootView` when `documentId` changes. The header is
-    /// a sibling of the text view in the scrolled container, so it is fully interactive. Inject
-    /// any required SwiftUI environment into this content before passing it in.
+    /// content, and refreshes the hosted content on every SwiftUI update. The header
+    /// is a sibling of the text view in the scrolled container, so it is fully
+    /// interactive. Inject any required SwiftUI environment into this content
+    /// before passing it in.
     public var header: AnyView?
-    /// Core (AppKit) alternative to ``header``: a raw NSView hosted in the same
-    /// reserved region for non-SwiftUI embedders. The engine sizes/places it but
-    /// does not manage its content. Ignored when ``header`` is non-nil.
-    public var headerView: NSView?
-    /// Visible header height when collapsed — typically just the heading. Content
-    /// below this is clipped. The embedder measures and supplies it so the heading
+    /// Visible header height when collapsed — typically just the top row. Content
+    /// below this is clipped. The embedder measures and supplies it so the top row
     /// stays fully visible while the lower content reveals/hides.
     public var headerCollapsedHeight: CGFloat
     /// Whether the header is expanded to its full content height or collapsed to
@@ -107,7 +104,6 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
         onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
         header: AnyView? = nil,
-        headerView: NSView? = nil,
         headerCollapsedHeight: CGFloat = 0,
         headerExpanded: Bool = true
     ) {
@@ -126,7 +122,6 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
         self.header = header
-        self.headerView = headerView
         self.headerCollapsedHeight = headerCollapsedHeight
         self.headerExpanded = headerExpanded
     }
@@ -441,212 +436,30 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         return coordinator
     }
 }
-
 // MARK: - Scrolling header view
 
 private extension NativeTextViewWrapper {
-    /// Host the header inside a clip container at the top of the content. The clip
-    /// height is the reserved top inset; collapsing animates it between
-    /// `headerCollapsedHeight` and the full content height, so the heading stays
-    /// fixed while the lower content reveals/hides.
+    /// Host the embedder's header above the body, inside the container document
+    /// view. The hosted content refreshes on every SwiftUI update; build,
+    /// collapse/expand, and teardown live in `ScrollingHeaderController`.
     func reconcileHeader(textView: NSTextView, context: Context) {
         let coord = context.coordinator
-        guard let native = textView as? NativeTextView else { return }
+        guard let container = (textView as? NativeTextView)?.superview as? NativeTextViewContainer else { return }
 
-        guard header != nil || headerView != nil else {
-            if coord.headerClipView != nil { removeHeader(coord: coord, native: native) }
+        guard let header else {
+            if let controller = coord.headerController {
+                controller.remove(from: container)
+                coord.headerController = nil
+            }
             return
         }
-
-        if coord.headerClipView == nil {
-            buildHeader(native: native, coord: coord)
-        } else if coord.headerDocumentId != documentId,
-                  let h = header,
-                  let hv = coord.headerHostingView as? NSHostingView<AnyView> {
-            hv.rootView = h
-            coord.headerDocumentId = documentId
-        }
-
-        applyExpansion(textView: textView, coord: coord)
-    }
-
-    func buildHeader(native: NativeTextView, coord: NativeTextViewCoordinator) {
-        guard let container = native.superview as? NativeTextViewContainer else { return }
-        let host: NSView
-        if let header {
-            let h = NSHostingView(rootView: header)
-            if #available(macOS 13.0, *) { h.sizingOptions = [.intrinsicContentSize] }
-            // Ignore the window safe area (the toolbar/navbar region). Otherwise, as the
-            // host scrolls relative to that safe area, SwiftUI adds/removes a TOP inset to
-            // "flow under the navbar" — which shifts the content down inside the host and
-            // pushes the collapsed summary/tags row below the clip mask (the "sliding
-            // window"), and makes the measured intrinsic height oscillate with scrollY.
-            if #available(macOS 13.3, *) { h.safeAreaRegions = [] }
-            host = h
-        } else if let headerView {
-            host = headerView
-        } else { return }
-
-        let clip = NSView()
-        clip.translatesAutoresizingMaskIntoConstraints = false
-        clip.clipsToBounds = true
-        clip.postsFrameChangedNotifications = true
-        // The clip is a SIBLING of the text view inside the container (top band), not a
-        // subview of the text view. Auto-Layout-pinned to the container's top/leading/
-        // trailing; its height is owned by the equality/constant constraints below and
-        // read back into `container.headerHeight`.
-        container.addSubview(clip)
-
-        host.translatesAutoresizingMaskIntoConstraints = false
-        clip.addSubview(host)
-
-        // Two height options for the clip; exactly one is active at a time.
-        //  • equality: clip.height == host.height  → expanded, tracks content live.
-        //  • constant: clip.height == <value>      → collapsed, or animating.
-        let equalityC = clip.heightAnchor.constraint(equalTo: host.heightAnchor)
-        let constantC = clip.heightAnchor.constraint(equalToConstant: max(0, headerCollapsedHeight))
-        NSLayoutConstraint.activate([
-            clip.topAnchor.constraint(equalTo: container.topAnchor),
-            clip.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            clip.trailingAnchor.constraint(equalTo: container.trailingAnchor),
-            // Host is full-height (top-pinned); overflow below the clip is hidden.
-            host.topAnchor.constraint(equalTo: clip.topAnchor),
-            host.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
-            host.trailingAnchor.constraint(equalTo: clip.trailingAnchor)
-        ])
-        if headerExpanded { equalityC.isActive = true } else { constantC.isActive = true }
-
-        coord.headerHostingView = host
-        coord.headerClipView = clip
-        coord.headerEqualityConstraint = equalityC
-        coord.headerConstantConstraint = constantC
-        coord.headerDocumentId = documentId
-        coord.lastHeaderExpanded = headerExpanded
-
-        // SOLE writer of `container.headerHeight`: the clip's height drives the header
-        // band, which the container reads to offset the text view. Synchronous (queue
-        // nil) so the body tracks the header with no lag.
-        //
-        // While the *constant* constraint governs (collapsed, or mid-animation) the band
-        // height is its `.constant` — the intended, stable value — NOT the live
-        // `clip.frame.height`, which a scroll-time layout pass can momentarily expose
-        // smaller before the constant re-settles. Reading the constant keeps the
-        // collapsed band rock-stable. When expanded, the equality constraint is active
-        // and `clip.frame.height` (== host height) is the live source.
-        coord.headerContentObserver = NotificationCenter.default.addObserver(
-            forName: NSView.frameDidChangeNotification, object: clip, queue: nil
-        ) { [weak clip, weak container, weak coord] _ in
-            guard let clip, let container else { return }
-            let h = Self.reservedHeaderHeight(clip: clip, coord: coord)
-            guard abs(container.headerHeight - h) > 0.5 else { return }
-            container.headerHeight = h
-        }
-
-        container.layoutSubtreeIfNeeded()
-        container.headerHeight = Self.reservedHeaderHeight(clip: clip, coord: coord)
-    }
-
-    /// The reserved top inset the body should sit below. When the constant
-    /// constraint governs (collapsed / animating) this is its `.constant` — stable
-    /// against transient mid-layout clip frames; otherwise the live clip height.
-    static func reservedHeaderHeight(clip: NSView, coord: NativeTextViewCoordinator?) -> CGFloat {
-        if let constantC = coord?.headerConstantConstraint, constantC.isActive {
-            return constantC.constant
-        }
-        return clip.frame.height
-    }
-
-    func applyExpansion(textView: NSTextView, coord: NativeTextViewCoordinator) {
-        guard let equalityC = coord.headerEqualityConstraint,
-              let constantC = coord.headerConstantConstraint,
-              let clip = coord.headerClipView,
-              let host = coord.headerHostingView else { return }
-        let collapsed = max(0, headerCollapsedHeight)
-
-        if coord.lastHeaderExpanded != headerExpanded {
-            coord.lastHeaderExpanded = headerExpanded
-            // Hand the clip height to the animatable constant constraint.
-            let start = clip.frame.height
-            equalityC.isActive = false
-            constantC.constant = start
-            constantC.isActive = true
-            let target: CGFloat
-            if headerExpanded {
-                host.invalidateIntrinsicContentSize()
-                host.layoutSubtreeIfNeeded()
-                target = max(collapsed, host.fittingSize.height)
-            } else {
-                target = collapsed
-            }
-            animateHeader(to: target, expandedAfter: headerExpanded,
-                          textView: textView, coord: coord)
-        } else if !headerExpanded, coord.headerAnimTimer == nil, constantC.isActive,
-                  abs(constantC.constant - collapsed) > 0.5 {
-            // Collapsed steady: keep the constant in sync with the heading height.
-            constantC.constant = collapsed
-            clip.superview?.layoutSubtreeIfNeeded()
-        }
-        // Expanded steady: the equality constraint already tracks the content.
-    }
-
-    func animateHeader(to target: CGFloat, expandedAfter: Bool,
-                       textView: NSTextView, coord: NativeTextViewCoordinator) {
-        guard let constantC = coord.headerConstantConstraint else { return }
-        coord.headerAnimTimer?.invalidate()
-        let start = constantC.constant
-
-        func settle() {
-            coord.headerAnimTimer = nil
-            if expandedAfter, let equalityC = coord.headerEqualityConstraint {
-                // Hand back to the live-tracking equality constraint.
-                constantC.isActive = false
-                equalityC.isActive = true
-                coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
-            }
-            // One clamp once the height has settled (skipped during the animation).
-            (textView.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
-        }
-
-        guard abs(target - start) > 0.5 else {
-            constantC.constant = target
-            coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
-            settle()
-            return
-        }
-        let duration: CGFloat = 0.32
-        var progress: CGFloat = 0
-        let timer = Timer(timeInterval: 1.0 / 60.0, repeats: true) { [weak textView, weak coord] t in
-            guard let textView, let coord, let constantC = coord.headerConstantConstraint else {
-                t.invalidate(); return
-            }
-            progress = min(1, progress + (1.0 / 60.0) / duration)
-            let eased = progress < 0.5 ? 2 * progress * progress : 1 - pow(-2 * progress + 2, 2) / 2
-            constantC.constant = start + (target - start) * eased
-            // → clip height change → clip frameDidChange → observer → container.headerHeight → restack.
-            coord.headerClipView?.superview?.layoutSubtreeIfNeeded()
-            if progress >= 1 {
-                t.invalidate()
-                settle()
-            }
-        }
-        RunLoop.main.add(timer, forMode: .common)
-        coord.headerAnimTimer = timer
-    }
-
-    func removeHeader(coord: NativeTextViewCoordinator, native: NativeTextView) {
-        coord.headerAnimTimer?.invalidate(); coord.headerAnimTimer = nil
-        if let o = coord.headerContentObserver {
-            NotificationCenter.default.removeObserver(o); coord.headerContentObserver = nil
-        }
-        coord.headerClipView?.removeFromSuperview()
-        coord.headerClipView = nil
-        coord.headerHostingView = nil
-        coord.headerEqualityConstraint = nil
-        coord.headerConstantConstraint = nil
-        coord.headerDocumentId = nil
-        coord.lastHeaderExpanded = nil
-        if let container = native.superview as? NativeTextViewContainer {
-            container.headerHeight = 0   // → restack: text view back to y=0, container shrinks
-        }
+        let controller = coord.headerController ?? ScrollingHeaderController()
+        coord.headerController = controller
+        controller.reconcile(
+            header: header,
+            collapsedHeight: headerCollapsedHeight,
+            expanded: headerExpanded,
+            container: container
+        )
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -184,17 +184,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         // Width and origin are driven by the container document view (see below).
         textView.autoresizingMask = []
         textView.backgroundColor = .clear
-        // Layer-back the text view for smooth scrolling. The scroll-away header is now
-        // a SIBLING of the text view inside the container (`NativeTextViewContainer`),
-        // not a subview, so no cross-layer unification with the header is needed — they
-        // occupy disjoint frames and cannot composite over each other.
-        textView.wantsLayer = true
-        textView.layerContentsRedrawPolicy = .onSetNeedsDisplay
-        // Clip the body to the text view's bounds so responsive-scroll OVERDRAW can't
-        // render text ABOVE the text view's frame top (into the header band that sits
-        // above it). NSView does NOT clip to bounds by default; without this the body
-        // bleeds up over the collapsed header even though the FRAMES are disjoint.
-        textView.clipsToBounds = true
+        // Body compositing for the scroll-away header (clipsToBounds + redraw policy)
+        // is applied by ScrollingHeaderController when a header is first supplied, so
+        // header-less embedders keep AppKit's default rendering.
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
         textView.font = font
         textView.baseFont = font

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -1,0 +1,236 @@
+//
+//  ScrollingHeaderController.swift
+//  MarkdownEngine
+//
+//  Owns the scroll-away header hosted above the editor body: an embedder-supplied
+//  SwiftUI view in an `NSHostingView`, inside a clipping band at the top of the
+//  container document view. The clip's height is the reserved band the body sits
+//  below; collapsing animates it between the embedder's collapsed height and the
+//  content's intrinsic height, so the top of the header stays put while the lower
+//  content reveals/hides.
+//
+
+import AppKit
+import SwiftUI
+
+@MainActor
+final class ScrollingHeaderController {
+    /// Clip container whose height is the reserved top band. Reveals/hides the
+    /// lower content while the top stays put.
+    private(set) var clipView: NSView?
+    /// Hosts the embedder's full header content, top-pinned inside the clip.
+    private(set) var hostingView: NSHostingView<AnyView>?
+
+    /// Active when expanded: `clip.height == host.height`, so the reserved band
+    /// always equals the content's (async-resolved) intrinsic height — self-correcting.
+    private var equalityConstraint: NSLayoutConstraint?
+    /// Active when collapsed or animating: `clip.height == constant`.
+    private var constantConstraint: NSLayoutConstraint?
+    /// Observes the clip's height; the SOLE writer of `container.headerHeight`.
+    private var clipFrameObserver: NSObjectProtocol?
+    /// Last applied expanded state, to detect toggles.
+    private var lastExpanded: Bool?
+    /// Invalidates stale animation completions when a new toggle interrupts one.
+    private var animationToken = 0
+
+    /// Collapse/expand animation duration. Internal so tests can shrink it.
+    var animationDuration: TimeInterval = 0.32
+
+    /// The reserved top band the body should sit below. When the constant
+    /// constraint governs (collapsed / animating) this is its `constant` — stable
+    /// against transient mid-layout clip frames; otherwise the live clip height.
+    var reservedHeight: CGFloat {
+        if let constantConstraint, constantConstraint.isActive {
+            return constantConstraint.constant
+        }
+        return clipView?.frame.height ?? 0
+    }
+
+    deinit {
+        if let clipFrameObserver {
+            NotificationCenter.default.removeObserver(clipFrameObserver)
+        }
+    }
+
+    /// Build the header on first call; afterwards refresh the hosted content
+    /// (every call — the embedder's view may capture changing values) and apply
+    /// the collapse/expand state.
+    func reconcile(
+        header: AnyView,
+        collapsedHeight: CGFloat,
+        expanded: Bool,
+        container: NativeTextViewContainer
+    ) {
+        if clipView == nil {
+            build(header: header, collapsedHeight: collapsedHeight, expanded: expanded, container: container)
+        } else if let hostingView {
+            hostingView.rootView = header
+        }
+        applyExpansion(collapsedHeight: collapsedHeight, expanded: expanded, container: container)
+    }
+
+    func remove(from container: NativeTextViewContainer?) {
+        animationToken += 1
+        if let clipFrameObserver {
+            NotificationCenter.default.removeObserver(clipFrameObserver)
+            self.clipFrameObserver = nil
+        }
+        clipView?.removeFromSuperview()
+        clipView = nil
+        hostingView = nil
+        equalityConstraint = nil
+        constantConstraint = nil
+        lastExpanded = nil
+        container?.headerHeight = 0   // → restack: text view back to y=0, container shrinks
+    }
+
+    // MARK: - Internals
+
+    private func build(
+        header: AnyView,
+        collapsedHeight: CGFloat,
+        expanded: Bool,
+        container: NativeTextViewContainer
+    ) {
+        let host = NSHostingView(rootView: header)
+        if #available(macOS 13.0, *) { host.sizingOptions = [.intrinsicContentSize] }
+        // Ignore the window safe area (the toolbar/navbar region). Otherwise, as the
+        // host scrolls relative to that safe area, SwiftUI adds/removes a TOP inset to
+        // "flow under the navbar" — which shifts the content down inside the host,
+        // pushes the collapsed band's content below the clip mask, and makes the
+        // measured intrinsic height oscillate with the scroll position.
+        if #available(macOS 13.3, *) { host.safeAreaRegions = [] }
+
+        let clip = NSView()
+        clip.translatesAutoresizingMaskIntoConstraints = false
+        clip.clipsToBounds = true
+        clip.postsFrameChangedNotifications = true
+        // The clip is a SIBLING of the text view inside the container (top band).
+        // Auto-Layout-pinned to the container's top/leading/trailing; its height is
+        // owned by the equality/constant constraint pair below and read back into
+        // `container.headerHeight`.
+        container.addSubview(clip)
+
+        host.translatesAutoresizingMaskIntoConstraints = false
+        clip.addSubview(host)
+
+        // Two height options for the clip; exactly one is active at a time.
+        //  • equality: clip.height == host.height  → expanded, tracks content live.
+        //  • constant: clip.height == <value>      → collapsed, or animating.
+        let equalityC = clip.heightAnchor.constraint(equalTo: host.heightAnchor)
+        let constantC = clip.heightAnchor.constraint(equalToConstant: max(0, collapsedHeight))
+        NSLayoutConstraint.activate([
+            clip.topAnchor.constraint(equalTo: container.topAnchor),
+            clip.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            clip.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            // Host is full-height (top-pinned); overflow below the clip is hidden.
+            host.topAnchor.constraint(equalTo: clip.topAnchor),
+            host.leadingAnchor.constraint(equalTo: clip.leadingAnchor),
+            host.trailingAnchor.constraint(equalTo: clip.trailingAnchor)
+        ])
+        if expanded { equalityC.isActive = true } else { constantC.isActive = true }
+
+        hostingView = host
+        clipView = clip
+        equalityConstraint = equalityC
+        constantConstraint = constantC
+        lastExpanded = expanded
+
+        // SOLE writer of `container.headerHeight`: the clip's height drives the header
+        // band, which the container reads to offset the text view. Synchronous (queue
+        // nil) so the body tracks the header with no lag. `reservedHeight` reads the
+        // constant's intended value while it governs — a scroll-time layout pass can
+        // momentarily expose a smaller in-flight clip frame.
+        clipFrameObserver = NotificationCenter.default.addObserver(
+            forName: NSView.frameDidChangeNotification, object: clip, queue: nil
+        ) { [weak self, weak container] _ in
+            MainActor.assumeIsolated {
+                guard let self, let container else { return }
+                let h = self.reservedHeight
+                guard abs(container.headerHeight - h) > 0.5 else { return }
+                container.headerHeight = h
+            }
+        }
+
+        container.layoutSubtreeIfNeeded()
+        container.headerHeight = reservedHeight
+    }
+
+    private func applyExpansion(
+        collapsedHeight: CGFloat,
+        expanded: Bool,
+        container: NativeTextViewContainer
+    ) {
+        guard let equalityC = equalityConstraint,
+              let constantC = constantConstraint,
+              let clip = clipView,
+              let host = hostingView else { return }
+        let collapsed = max(0, collapsedHeight)
+
+        if lastExpanded != expanded {
+            lastExpanded = expanded
+            // Hand the clip height to the animatable constant constraint.
+            let start = clip.frame.height
+            equalityC.isActive = false
+            constantC.constant = start
+            constantC.isActive = true
+            let target: CGFloat
+            if expanded {
+                host.invalidateIntrinsicContentSize()
+                host.layoutSubtreeIfNeeded()
+                target = max(collapsed, host.fittingSize.height)
+            } else {
+                target = collapsed
+            }
+            animate(to: target, expandedAfter: expanded, container: container)
+        } else if !expanded, constantC.isActive, animationToken == settledToken,
+                  abs(constantC.constant - collapsed) > 0.5 {
+            // Collapsed steady: keep the constant in sync with the collapsed height.
+            constantC.constant = collapsed
+            container.layoutSubtreeIfNeeded()
+        }
+        // Expanded steady: the equality constraint already tracks the content.
+    }
+
+    /// Tracks whether an animation is in flight: `animationToken` advances on every
+    /// animation start and interruption; `settledToken` catches up on settle.
+    private var settledToken = 0
+
+    private func animate(to target: CGFloat, expandedAfter: Bool, container: NativeTextViewContainer) {
+        guard let constantC = constantConstraint else { return }
+        animationToken += 1
+        let token = animationToken
+
+        func settle() {
+            guard token == animationToken else { return }   // interrupted by a newer toggle
+            settledToken = token
+            if expandedAfter, let equalityC = equalityConstraint, let constantC = constantConstraint {
+                // Hand back to the live-tracking equality constraint.
+                constantC.isActive = false
+                equalityC.isActive = true
+                clipView?.superview?.layoutSubtreeIfNeeded()
+            }
+            // One clamp once the height has settled (skipped during the animation).
+            (container.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
+        }
+
+        let start = constantC.constant
+        guard abs(target - start) > 0.5 else {
+            constantC.constant = target
+            container.layoutSubtreeIfNeeded()
+            settle()
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = animationDuration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            // Animating the constraint's constant marks the container needing layout
+            // each frame; the window's display cycle runs the layout pass, the clip's
+            // frame change fires the observer, and the body tracks the band.
+            constantC.animator().constant = target
+        }, completionHandler: {
+            MainActor.assumeIsolated { settle() }
+        })
+    }
+}

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -64,6 +64,11 @@ final class ScrollingHeaderController {
         if clipView == nil {
             build(header: header, collapsedHeight: collapsedHeight, expanded: expanded, container: container)
         } else if let hostingView {
+            // Refresh on every reconcile (every updateNSView, including keystrokes):
+            // the embedder's view may capture changing values, and SwiftUI's diff of
+            // an unchanged hierarchy is cheap — the same cost the header would pay
+            // rendered anywhere else in the embedder's tree. @State inside the
+            // header survives (same root structure diffs in place).
             hostingView.rootView = header
         }
         applyExpansion(collapsedHeight: collapsedHeight, expanded: expanded, container: container)
@@ -71,6 +76,8 @@ final class ScrollingHeaderController {
 
     func remove(from container: NativeTextViewContainer?) {
         animationToken += 1
+        settledToken = animationToken   // no animation in flight after teardown
+        animationTargetHeight = nil
         if let clipFrameObserver {
             NotificationCenter.default.removeObserver(clipFrameObserver)
             self.clipFrameObserver = nil
@@ -161,7 +168,7 @@ final class ScrollingHeaderController {
             MainActor.assumeIsolated {
                 guard let self, let container else { return }
                 let h = self.reservedHeight
-                guard abs(container.headerHeight - h) > 0.5 else { return }
+                guard abs(container.headerHeight - h) > 0.1 else { return }
                 container.headerHeight = h
             }
         }
@@ -197,11 +204,19 @@ final class ScrollingHeaderController {
                 target = collapsed
             }
             animate(to: target, expandedAfter: expanded, container: container)
-        } else if !expanded, constantC.isActive, animationToken == settledToken,
-                  abs(constantC.constant - collapsed) > 0.5 {
-            // Collapsed steady: keep the constant in sync with the collapsed height.
-            constantC.constant = collapsed
-            container.layoutSubtreeIfNeeded()
+        } else if !expanded, constantC.isActive {
+            if animationToken != settledToken {
+                // A collapse animation is in flight. If the collapsed height changed
+                // mid-flight (e.g. the pinned row re-measured), retarget — the new
+                // value arrives only on this reconcile and would otherwise be lost.
+                if let target = animationTargetHeight, abs(target - collapsed) > 0.5 {
+                    animate(to: collapsed, expandedAfter: false, container: container)
+                }
+            } else if abs(constantC.constant - collapsed) > 0.5 {
+                // Collapsed steady: keep the constant in sync with the collapsed height.
+                constantC.constant = collapsed
+                container.layoutSubtreeIfNeeded()
+            }
         }
         // Expanded steady: the equality constraint already tracks the content.
     }
@@ -209,15 +224,19 @@ final class ScrollingHeaderController {
     /// Tracks whether an animation is in flight: `animationToken` advances on every
     /// animation start and interruption; `settledToken` catches up on settle.
     private var settledToken = 0
+    /// Target of the in-flight animation, for mid-flight retargeting.
+    private var animationTargetHeight: CGFloat?
 
     private func animate(to target: CGFloat, expandedAfter: Bool, container: NativeTextViewContainer) {
         guard let constantC = constantConstraint else { return }
         animationToken += 1
         let token = animationToken
+        animationTargetHeight = target
 
         func settle() {
             guard token == animationToken else { return }   // interrupted by a newer toggle
             settledToken = token
+            animationTargetHeight = nil
             if expandedAfter, let equalityC = equalityConstraint, let constantC = constantConstraint {
                 // Hand back to the live-tracking equality constraint.
                 constantC.isActive = false
@@ -228,16 +247,13 @@ final class ScrollingHeaderController {
             (container.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
         }
 
+        // ALWAYS go through the animator, even for a no-distance move: a direct
+        // property set would not cancel an animation already in flight on the
+        // constant, which would keep ticking toward its stale target underneath us.
         let start = constantC.constant
-        guard abs(target - start) > 0.5 else {
-            constantC.constant = target
-            container.layoutSubtreeIfNeeded()
-            settle()
-            return
-        }
-
+        let instant = abs(target - start) <= 0.5
         NSAnimationContext.runAnimationGroup({ context in
-            context.duration = animationDuration
+            context.duration = instant ? 0 : animationDuration
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
             // Animating the constraint's constant marks the container needing layout
             // each frame; the window's display cycle runs the layout pass, the clip's
@@ -246,5 +262,6 @@ final class ScrollingHeaderController {
         }, completionHandler: {
             MainActor.assumeIsolated { settle() }
         })
+        if instant { container.layoutSubtreeIfNeeded() }
     }
 }

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -92,6 +92,20 @@ final class ScrollingHeaderController {
         expanded: Bool,
         container: NativeTextViewContainer
     ) {
+        // Body compositing, gated on header presence so header-less editors keep
+        // AppKit's default rendering: the body is layer-backed (TextKit 2's default,
+        // asserted here for the seam fix), redrawn only on explicit invalidation, and
+        // clipped to its bounds so responsive-scroll OVERDRAW can't render text above
+        // the frame top into the header band. NSView does NOT clip by default; without
+        // this the body bleeds up over the collapsed header even though the frames
+        // are disjoint. Left in place if the header is later removed — un-clipping a
+        // live text view buys nothing and risks a repaint glitch.
+        if let textView = container.textView {
+            textView.wantsLayer = true
+            textView.layerContentsRedrawPolicy = .onSetNeedsDisplay
+            textView.clipsToBounds = true
+        }
+
         let host = NSHostingView(rootView: header)
         if #available(macOS 13.0, *) { host.sizingOptions = [.intrinsicContentSize] }
         // Ignore the window safe area (the toolbar/navbar region). Otherwise, as the

--- a/Tests/MarkdownEngineTests/BottomOverscrollPolicyTests.swift
+++ b/Tests/MarkdownEngineTests/BottomOverscrollPolicyTests.swift
@@ -1,0 +1,74 @@
+//
+//  BottomOverscrollPolicyTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 11.06.26.
+//
+//  Bottom-overscroll math, in particular how the scroll-away header band
+//  participates in activation/unlock while the slack stays viewport-based.
+//
+
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("BottomOverscrollPolicy")
+struct BottomOverscrollPolicyTests {
+
+    /// Engine defaults: percent 0.5, max 450, min 40, activation 0.15 + 0.85.
+    private let policy = BottomOverscrollPolicy(configuration: .default)
+    private let visible: CGFloat = 800
+    private let lineHeight: CGFloat = 26
+
+    @Test func shortTextWithoutBandGetsNoSlack() {
+        // Below the activation start (0.15 × 800 = 120): nothing to scroll.
+        let slack = policy.activeOverscroll(
+            baseContentHeight: 100, visibleHeight: visible, lineHeight: lineHeight
+        )
+        #expect(slack == 0)
+    }
+
+    @Test func emptyDocumentWithoutBandGetsNoSlack() {
+        let slack = policy.activeOverscroll(
+            baseContentHeight: 30, visibleHeight: visible, lineHeight: lineHeight
+        )
+        #expect(slack == 0)
+    }
+
+    @Test func expandedBandActivatesSlackForShortText() {
+        // Text alone is below the activation start (100 < 120), but the 550pt
+        // band pushes its end near the viewport bottom — slack must unlock.
+        let slack = policy.activeOverscroll(
+            baseContentHeight: 100, headerHeight: 550,
+            visibleHeight: visible, lineHeight: lineHeight
+        )
+        #expect(slack > 0)
+        // The document must actually overflow so the band can be scrolled away.
+        let scrollRange = 550 + 100 + slack - visible
+        #expect(scrollRange > 100)
+    }
+
+    @Test func fullyActivatedSlackIsBandIndependent() {
+        // At full activation the band has scrolled away — slack must not change.
+        // Defaults: floor(min(800 × 0.5, 450) − 26) = 374.
+        let without = policy.activeOverscroll(
+            baseContentHeight: 800, visibleHeight: visible, lineHeight: lineHeight
+        )
+        let with = policy.activeOverscroll(
+            baseContentHeight: 800, headerHeight: 550,
+            visibleHeight: visible, lineHeight: lineHeight
+        )
+        #expect(without == 374)
+        #expect(with == 374)
+    }
+
+    @Test func headerlessRampMatchesPreBandBehavior() {
+        // Locks the pre-header formula for plain editors (headerHeight = 0):
+        // progress = (500 − 120) / 680, unlock = 300, slack = 374
+        // → floor((300 + 374) × 0.55882…) = 376.
+        let slack = policy.activeOverscroll(
+            baseContentHeight: 500, visibleHeight: visible, lineHeight: lineHeight
+        )
+        #expect(slack == 376)
+    }
+}

--- a/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
+++ b/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
@@ -52,7 +52,10 @@ struct NativeTextViewContainerTests {
         stack.container.headerHeight = 40
 
         #expect(stack.textView.frame.origin.y == 40)
-        #expect(stack.container.frame.height == 940)
+        // Band changes re-run the overscroll policy — assert slack-agnostic
+        // stacking so policy tuning can't break this test.
+        #expect(stack.textView.frame.height == 900 + stack.textView.activeBottomOverscroll)
+        #expect(stack.container.frame.height == 40 + stack.textView.frame.height)
     }
 
     @Test func containerNeverShrinksBelowViewport() {
@@ -82,7 +85,11 @@ struct NativeTextViewContainerTests {
 
         stack.container.headerHeight = 40
 
-        #expect(stack.container.scrollableContentHeight == 600)
+        // The band change re-runs the policy (slack > primed 60), while the primed
+        // base content height must survive un-clobbered (no re-measure).
+        #expect(stack.textView.activeBottomOverscroll > 60)
+        #expect(stack.container.scrollableContentHeight
+            == 40 + 500 + stack.textView.activeBottomOverscroll)
     }
 
     @Test func readingColumnKeepsCenteredXThroughRestacks() {

--- a/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
+++ b/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
@@ -102,6 +102,30 @@ struct NativeTextViewContainerTests {
         #expect(stack.textView.frame.width == stack.textView.readingColumnWidth)
     }
 
+    @Test func headerGrowthOnShortDocAddsNoPhantomScrollRange() {
+        let stack = makeStack()
+        stack.textView.baseContentHeight = 100
+        stack.textView.applyManagedFrameSize(width: 600)
+        #expect(stack.container.frame.height == 800)
+
+        // Reserving a header band must re-apply the viewport-fill inflation:
+        // header + text view == viewport, otherwise a short doc grows a
+        // phantom scroll range (spurious scroller, clamp-fighting jitter).
+        stack.container.headerHeight = 40
+        #expect(stack.textView.frame.height == 760)
+        #expect(stack.container.frame.height == 800)
+
+        // Expanding the header (animation drives headerHeight per frame).
+        stack.container.headerHeight = 300
+        #expect(stack.textView.frame.height == 500)
+        #expect(stack.container.frame.height == 800)
+
+        // Collapsing back restores the band split.
+        stack.container.headerHeight = 40
+        #expect(stack.textView.frame.height == 760)
+        #expect(stack.container.frame.height == 800)
+    }
+
     @Test func fullWidthModePropagatesViewportWidth() {
         let stack = makeStack()
         stack.textView.baseContentHeight = 900

--- a/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
+++ b/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
@@ -62,6 +62,17 @@ struct NativeTextViewContainerTests {
 
         #expect(stack.textView.frame.height == 800)   // viewport-fill inflation
         #expect(stack.container.frame.height == 800)
+
+        // Exercise the container's OWN viewport floor: force the text view to an
+        // under-filling height (bypassing the managed inflation) — the container
+        // must still span the viewport so there's no dead band below the body.
+        stack.textView.isApplyingManagedFrameSize = true
+        stack.textView.setFrameSize(NSSize(width: 600, height: 100))
+        stack.textView.isApplyingManagedFrameSize = false
+        stack.container.textViewDidResize()
+
+        #expect(stack.textView.frame.height == 100)
+        #expect(stack.container.frame.height == 800)
     }
 
     @Test func scrollableContentHeightComposesHeaderAndContent() {

--- a/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
@@ -1,0 +1,180 @@
+//
+//  ScrollingHeaderControllerTests.swift
+//  MarkdownEngineTests
+//
+//  The scroll-away header: build, content refresh, collapse/expand reserved
+//  height, and removal — headless (no window).
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("ScrollingHeaderController")
+struct ScrollingHeaderControllerTests {
+
+    struct Stack {
+        let scrollView: ClampedScrollView
+        let container: NativeTextViewContainer
+        let textView: NativeTextView
+        let controller: ScrollingHeaderController
+    }
+
+    private func makeStack(viewport: NSSize = NSSize(width: 600, height: 800)) -> Stack {
+        let scrollView = ClampedScrollView(frame: NSRect(origin: .zero, size: viewport))
+        let textView = NativeTextView(frame: .zero)
+        textView.configuration = .default
+        textView.autoresizingMask = []
+        let container = NativeTextViewContainer(frame: NSRect(origin: .zero, size: viewport))
+        container.autoresizingMask = [.width]
+        container.textView = textView
+        textView.frame = NSRect(x: 0, y: 0, width: viewport.width, height: 0)
+        container.addSubview(textView)
+        scrollView.documentView = container
+        return Stack(
+            scrollView: scrollView, container: container, textView: textView,
+            controller: ScrollingHeaderController()
+        )
+    }
+
+    private func fixedHeightHeader(_ height: CGFloat) -> AnyView {
+        AnyView(Color.clear.frame(width: 200, height: height))
+    }
+
+    /// Spin the main run loop until `condition` holds (or ~2s passes), laying
+    /// out the container each turn — headless stand-in for the window's
+    /// per-frame layout during an animation.
+    private func spinUntil(_ container: NativeTextViewContainer, _ condition: () -> Bool) {
+        let deadline = Date(timeIntervalSinceNow: 2.0)
+        while !condition() && Date() < deadline {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.02))
+            container.layoutSubtreeIfNeeded()
+        }
+    }
+
+    @Test func buildReservesCollapsedHeightWhenCollapsed() {
+        let stack = makeStack()
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+
+        #expect(stack.controller.clipView != nil)
+        #expect(stack.controller.reservedHeight == 30)
+        #expect(stack.container.headerHeight == 30)
+        #expect(stack.textView.frame.origin.y == 30)
+    }
+
+    @Test func buildTracksContentHeightWhenExpanded() {
+        let stack = makeStack()
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: true,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+
+        #expect(stack.controller.reservedHeight == 120)
+        #expect(stack.container.headerHeight == 120)
+    }
+
+    @Test func reconcileRefreshesHeaderContentWithinSameDocument() {
+        let stack = makeStack()
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: true,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+        #expect(stack.container.headerHeight == 120)
+
+        // Same document, new content (e.g. the user renamed the title): the
+        // hosted rootView must refresh — the reserved band tracks the new
+        // intrinsic height without any document switch.
+        stack.controller.reconcile(
+            header: fixedHeightHeader(90), collapsedHeight: 30, expanded: true,
+            container: stack.container
+        )
+        spinUntil(stack.container) { stack.container.headerHeight == 90 }
+
+        #expect(stack.container.headerHeight == 90)
+    }
+
+    @Test func collapsedSteadyTracksCollapsedHeightChanges() {
+        let stack = makeStack()
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 44, expanded: false,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+
+        #expect(stack.controller.reservedHeight == 44)
+        #expect(stack.container.headerHeight == 44)
+    }
+
+    @Test func expandAnimatesToContentHeightAndSettles() {
+        let stack = makeStack()
+        stack.controller.animationDuration = 0.05
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+        #expect(stack.container.headerHeight == 30)
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: true,
+            container: stack.container
+        )
+        spinUntil(stack.container) { stack.container.headerHeight == 120 }
+
+        #expect(stack.container.headerHeight == 120)
+        // After settling, the live-tracking equality constraint governs again.
+        #expect(stack.controller.reservedHeight == 120)
+    }
+
+    @Test func collapseAnimatesBackToCollapsedHeight() {
+        let stack = makeStack()
+        stack.controller.animationDuration = 0.05
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: true,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+        spinUntil(stack.container) { stack.container.headerHeight == 30 }
+
+        #expect(stack.container.headerHeight == 30)
+        #expect(stack.controller.reservedHeight == 30)
+    }
+
+    @Test func removeRestoresHeaderlessStacking() {
+        let stack = makeStack()
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+        stack.container.layoutSubtreeIfNeeded()
+        #expect(stack.container.headerHeight == 30)
+
+        stack.controller.remove(from: stack.container)
+
+        #expect(stack.controller.clipView == nil)
+        #expect(stack.container.headerHeight == 0)
+        #expect(stack.textView.frame.origin.y == 0)
+        #expect(stack.container.subviews.count == 1)   // text view only
+    }
+}

--- a/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
@@ -161,6 +161,26 @@ struct ScrollingHeaderControllerTests {
         #expect(stack.controller.reservedHeight == 30)
     }
 
+    @Test func bodyClippingIsGatedOnHeaderPresence() {
+        let stack = makeStack()
+        // Header-less editors keep AppKit's defaults — no clipping or redraw-policy
+        // change for embedders that never pass a header. (TextKit 2 text views are
+        // layer-backed by default; that part was never a change.)
+        #expect(stack.textView.clipsToBounds == false)
+
+        stack.controller.reconcile(
+            header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
+            container: stack.container
+        )
+
+        // With a header, the body must be layer-backed, clipped, and redrawn on
+        // explicit invalidation so responsive-scroll overdraw can't bleed into the
+        // band above it.
+        #expect(stack.textView.wantsLayer == true)
+        #expect(stack.textView.clipsToBounds == true)
+        #expect(stack.textView.layerContentsRedrawPolicy == .onSetNeedsDisplay)
+    }
+
     @Test func removeRestoresHeaderlessStacking() {
         let stack = makeStack()
         stack.controller.reconcile(

--- a/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
@@ -54,6 +54,12 @@ struct ScrollingHeaderControllerTests {
         }
     }
 
+    /// Animated settles go through the clip-frame observer, which carries a
+    /// small deadband — compare with a matching tolerance, not exact equality.
+    private func nearly(_ value: CGFloat, _ target: CGFloat) -> Bool {
+        abs(value - target) <= 0.25
+    }
+
     @Test func buildReservesCollapsedHeightWhenCollapsed() {
         let stack = makeStack()
 
@@ -98,9 +104,9 @@ struct ScrollingHeaderControllerTests {
             header: fixedHeightHeader(90), collapsedHeight: 30, expanded: true,
             container: stack.container
         )
-        spinUntil(stack.container) { stack.container.headerHeight == 90 }
+        spinUntil(stack.container) { nearly(stack.container.headerHeight, 90) }
 
-        #expect(stack.container.headerHeight == 90)
+        #expect(nearly(stack.container.headerHeight, 90))
     }
 
     @Test func collapsedSteadyTracksCollapsedHeightChanges() {
@@ -135,9 +141,9 @@ struct ScrollingHeaderControllerTests {
             header: fixedHeightHeader(120), collapsedHeight: 30, expanded: true,
             container: stack.container
         )
-        spinUntil(stack.container) { stack.container.headerHeight == 120 }
+        spinUntil(stack.container) { nearly(stack.container.headerHeight, 120) }
 
-        #expect(stack.container.headerHeight == 120)
+        #expect(nearly(stack.container.headerHeight, 120))
         // After settling, the live-tracking equality constraint governs again.
         #expect(stack.controller.reservedHeight == 120)
     }
@@ -155,9 +161,9 @@ struct ScrollingHeaderControllerTests {
             header: fixedHeightHeader(120), collapsedHeight: 30, expanded: false,
             container: stack.container
         )
-        spinUntil(stack.container) { stack.container.headerHeight == 30 }
+        spinUntil(stack.container) { nearly(stack.container.headerHeight, 30) }
 
-        #expect(stack.container.headerHeight == 30)
+        #expect(nearly(stack.container.headerHeight, 30))
         #expect(stack.controller.reservedHeight == 30)
     }
 


### PR DESCRIPTION
## What

Adds an embedder-supplied **scroll-away header** to the markdown editor: a SwiftUI view hosted above the document body that scrolls with it, with an animated collapse to a pinned top row. Used by Nodes to host the inline Node Inspector, but designed and named as a general engine feature.

```swift
NativeTextViewWrapper(
    text: $text,
    header: AnyView(MyDocumentHeader(document: document)),
    headerCollapsedHeight: 40,
    headerExpanded: isExpanded
)
```

## How it works

The scroll view's `documentView` is now **always** a `NativeTextViewContainer` — a flipped container that stacks the optional header band and the `NativeTextView` as **siblings with disjoint frames**, so body text can never composite over the header (an earlier in-text-view design hit an unfixable layer-cadence seam during responsive scroll; the container file documents the why).

- `ScrollingHeaderController` (owned by the coordinator) hosts the header in a clipped `NSHostingView`. An equality/constant constraint pair drives expanded (live content tracking) vs. collapsed; collapse/expand animates via `NSAnimationContext`, with token-guarded settles and mid-flight retargeting.
- The clip's resolved height mirrors into `container.headerHeight`; the container restacks the body below the band and re-applies the text view's viewport-fill sizing, so short documents never grow a phantom scroll range.
- The hosted content refreshes on **every** SwiftUI update (no document-id coupling) and stays fully interactive.
- The body-compositing changes (`clipsToBounds`, redraw policy) are **gated on header presence** — header-less embedders keep AppKit's default rendering, and `header: nil` is a true zero-cost path.

## Merged with main's reading column

This branch unifies `NativeTextViewContainer` with main's `ReadingColumnContainerView` (now deleted): one container owns the header band (y) while `centerReadingColumn` keeps owning the column's centered x. Header + `readingWidth` compose; wide-table breakout overlays and every text-view-local → document-space conversion (caret rects, find-in-document reveal/restore, custom scroll-to-reveal) are lifted by the text view's offset inside the container. `ARCHITECTURE.md` documents the container and the coordinate-space rule.

## Testing

- 84 tests pass, including new headless suites for the container stacking (header band, viewport floor, reading-column centering, phantom-scroll regression) and the header controller (build, per-update content refresh, collapse/expand animation + settle, layer-backing gate, removal).
- Demo app gains **Header / Expanded** toolbar toggles for manual smoke-testing (`Demo/`).
- Two multi-agent adversarial review passes ran over the branch; all confirmed findings are fixed in the last commit.
- Suggested manual smoke items (header present): caret blink/placement at end-of-doc, IME/marked text, selection, find-in-document with `readingWidth` + header, wide tables in reading mode while collapsing the header.

## API notes

- `header: AnyView?` (default `nil`), `headerCollapsedHeight: CGFloat` (default 0), `headerExpanded: Bool` (default `true`). README has a *Scrolling Header* section; CHANGELOG has Added/Changed entries.
- The band reserves the header's **intrinsic** height — wrapping text should carry an explicit height or line limit (documented).
- A raw-`NSView` header variant was considered and dropped for v1: without an intrinsic height contract its layout is under-determined. Can return later behind an explicit height API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
