### PR TITLE
feat: stamp `.spellingState: 0` on fenced code blocks and inline `code`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SafeAreaInsets` struct exposing `top` / `leading` / `trailing` / `bottom`
   inset knobs for the editor's enclosing scroll view, configurable via
   `MarkdownEditorConfiguration.safeAreaInsets`.
+- `MarkdownASTStyler` now stamps `.spellingState: 0` on fenced code blocks
+  and inline `` `code` `` spans, completing the engine's existing
+  spell-check suppression convention (links, wiki-links, LaTeX, and tables
+  already carry the same attribute). The system spell-checker no longer
+  underlines tokens inside code regions even when continuous spell
+  checking is enabled.
 
 ### Fixed
 - `NativeTextViewWrapper` keeps links clickable and text selectable

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -367,6 +367,8 @@ enum MarkdownASTStyler {
         attrs.append((parts.codeRange, [
             .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: ctx.codeParagraphStyle,
         ]))
+        // Suppress spell-check underlines on the whole fenced block — code is not prose.
+        attrs.append((parts.codeRange, [.spellingState: 0]))
         let codeContent = ctx.ns.substring(with: parts.content)
         if !codeContent.isEmpty,
            let highlighted = ctx.config.services.syntaxHighlighter.highlight(code: codeContent, language: parts.language) {
@@ -431,6 +433,8 @@ enum MarkdownASTStyler {
 
             case .code(let range, let contentRange):
                 attrs.append((contentRange, [.font: ctx.codeFont, .backgroundColor: ctx.codeBackground]))
+                // Suppress spell-check underlines on inline `code` spans (markers + content).
+                attrs.append((range, [.spellingState: 0]))
                 let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(range)
                     ? [.foregroundColor: ctx.theme.mutedText, .font: ctx.codeFont]
                     : [.foregroundColor: ctx.theme.mutedText.withAlphaComponent(ctx.config.markers.inlineCodeMarkerAlpha),

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -75,6 +75,32 @@ struct MarkdownASTStylerTests {
         #expect(a?.fontDescriptor.symbolicTraits.contains(.italic) == false)
         #expect(b?.fontDescriptor.symbolicTraits.contains([.bold, .italic]) == true)
     }
+
+    /// Code is not prose: fenced blocks and inline `code` spans must carry
+    /// `.spellingState: 0` so the system spell-checker leaves them alone,
+    /// matching the existing convention that links / wiki-links / LaTeX / tables
+    /// already follow.
+    @Test("code blocks and inline code receive .spellingState: 0; prose does not")
+    func codeRegionsSuppressSpellCheck() {
+        let text = "prose word\n\n```\nfencedcd notaword\n```\n\nplain `inlnecode` tail"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let ns = text as NSString
+        let fencedContent = ns.range(of: "fencedcd notaword")
+        let inlineSpan = ns.range(of: "`inlnecode`")
+        let prose = ns.range(of: "prose word")
+
+        // Pull every `.spellingState` value from styled ranges that intersect `r`.
+        func spellingStates(intersecting r: NSRange) -> [Int] {
+            attrs.compactMap { entry -> Int? in
+                guard NSIntersectionRange(entry.range, r).length > 0 else { return nil }
+                return entry.attributes[.spellingState] as? Int
+            }
+        }
+
+        #expect(spellingStates(intersecting: fencedContent).contains(0))
+        #expect(spellingStates(intersecting: inlineSpan).contains(0))
+        #expect(spellingStates(intersecting: prose).isEmpty)
+    }
 }
 
 /// Canonical, order-independent string of styled ranges so two style runs can be


### PR DESCRIPTION
Split out from #59 per @Nicolas-Py's review.

## Summary

Code is not prose. Fenced code blocks and inline `` `code` `` spans should be left alone by the system spell-checker, the same way links, wiki-links, LaTeX, and table cells already are. This PR completes the engine's existing spell-check suppression convention with two minimal `MarkdownASTStyler` hunks plus a test.

It is intentionally narrow — no rendering pipeline, no coordinator state, no `NSSpellChecker` driving. The render-pass approach in #59 is being abandoned: the harness output captured in that thread (`red=0` on both arms, byte-identical PNGs) confirms the underline absence on macOS 15.7.7 is a system-wide TextKit 2 issue, not something the custom `NSTextLayoutFragment` subclass causes.

## Files

- `Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift`
  - `styleCodeBlock`: append `.spellingState: 0` on `parts.codeRange` alongside the existing `.font` / `.backgroundColor` / `.paragraphStyle` stamp.
  - inline `.code` case: append `.spellingState: 0` on the full inline `range` (so the backticks are covered too, not just `contentRange`).
- `Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift`
  - New `@Test("code blocks and inline code receive .spellingState: 0; prose does not")` asserting the attribute is present on a fenced-block content range and on an inline `` `code` `` span, and **absent** on a plain prose range.
- `CHANGELOG.md`
  - One bullet under `## [Unreleased] / ### Added`, framed as completing the existing suppression convention.

## Test plan

- `swift build` — clean.
- `swift test` — 70 tests in 7 suites pass, including the new `codeRegionsSuppressSpellCheck`.
- `swift test --filter MarkdownASTStylerTests` — all 4 tests pass (3 pre-existing + 1 new).

## Out of scope

- Misspelling underline rendering on macOS 15.x. The harness in #59 shows the symptom is system-wide on 15.7.7 (vanilla TK2 NSTextView produces `red=0` pixels with `isContinuousSpellCheckingEnabled` on), and would need either an Apple Feedback fix or a version-gated `LayoutBridge`-based fallback in a separate PR.
- Any change to `SpellCheckingPolicy`, the context-menu overrides, or `userPrefersContinuousSpellChecking` introduced in #36.

Closes the styler portion of #58 / #59.