### PR TITLE
fix(scroll): keep mouse wheel / trackball scrollable past a stale-small clamp

### DIFF
--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -38,10 +38,24 @@ final class ClampedScrollView: NSScrollView {
         // Use the real content height (not the inflated frame) so small
         // documents can't scroll past their actual content. The document view is
         // always a `NativeTextViewContainer` (header band + text column).
-        let realHeight = (doc as? NativeTextViewContainer)?.scrollableContentHeight
-            ?? doc.bounds.height
-        let maxY = max(minY, realHeight - contentView.bounds.height)
+        let container = doc as? NativeTextViewContainer
+        var realHeight = container?.scrollableContentHeight ?? doc.bounds.height
         let b = contentView.bounds
+
+        // `scrollableContentHeight` comes from a cached TextKit-2 measurement that can
+        // under-measure. A continuous trackpad refreshes it mid-gesture, but a discrete
+        // device (mouse wheel, Ploopy trackball) sends one event with no relayout — so a
+        // stale-small height clamps the tick straight back = "scroll doesn't work". When
+        // a clamp-back is imminent, force one fresh full-layout re-measure first. This is
+        // self-limiting (only at the bottom) and still clamps to the real content height.
+        if let textView = container?.textView,
+           b.origin.y > realHeight - b.height {
+            textView.pendingFullLayoutMeasure = true
+            textView.recalcOverscroll(for: self)
+            realHeight = container?.scrollableContentHeight ?? doc.bounds.height
+        }
+
+        let maxY = max(minY, realHeight - contentView.bounds.height)
         let clampedY = min(max(b.origin.y, minY), maxY)
         if clampedY != b.origin.y {
             contentView.scroll(to: NSPoint(x: b.origin.x, y: clampedY))


### PR DESCRIPTION
## Problem
Discrete-delta input devices (classic mouse wheel, Ploopy trackball) intermittently can't scroll the editor; a brief **trackpad** scroll "revives" it.

## Root cause
`ClampedScrollView.scrollWheel` runs `clampToInsets()` after every event, clamping the max scroll against `scrollableContentHeight`, which derives from a cached TextKit-2 measurement (`baseContentHeight`) that can under-measure / settle on a too-small value. A continuous trackpad gesture keeps firing relayout/`recalcOverscroll` mid-gesture and refreshes that cache, so it escapes the clamp. A discrete device delivers a single event with no relayout in between, so a stale-small height clamps each tick straight back to the same spot → "scroll doesn't work".

## Fix
In `clampToInsets()`, when a clamp-back is imminent (`b.origin.y > realHeight - b.height`), force **one** fresh full-layout re-measure and clamp against the corrected height — i.e. make the trackpad's free re-measure deterministic for discrete devices.

- **Self-limiting**: only runs at the bottom edge, never during normal mid-document scrolling (zero steady-state cost).
- Still clamps against the real content height, so short docs can't scroll into the click-below inflation area.

## Invariants preserved
No scroll-into-empty for short docs, bottom overscroll + scroll-away header, reading-column centering, file-switch no-drift, live-resize save/restore — all unchanged (the fix only changes *when* the height is re-validated).

## Tests
`swift build` clean; `swift test` 90/90 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)