### PR TITLE
Inspector clip mask + caret reveal at document end

### DIFF
--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -288,9 +288,13 @@ extension NativeTextView {
             return
         }
         // Explicit reveal: native scrollRangeToVisible can't position the container's centered subview.
+        // A caret at the document end has no fragment at its location; step back one
+        // char there so the last line's fragment is found (else nothing reveals).
+        let docLength = (self.string as NSString).length
+        let revealOffset = min(range.location, max(0, docLength - 1))
         guard let tlm = textLayoutManager,
               let scrollView = enclosingScrollView,
-              let start = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: range.location) else {
+              let start = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: revealOffset) else {
             super.scrollRangeToVisible(range)
             return
         }

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -123,6 +123,10 @@ final class ScrollingHeaderController {
         if #available(macOS 13.3, *) { host.safeAreaRegions = [] }
 
         let clip = NSView()
+        // Layer-back the clip so `clipsToBounds` reliably masks the layer-backed
+        // NSHostingView; without it the inspector body bleeds below the collapsed
+        // band on async resize (ghost rows + stale heading paints).
+        clip.wantsLayer = true
         clip.translatesAutoresizingMaskIntoConstraints = false
         clip.clipsToBounds = true
         clip.postsFrameChangedNotifications = true


### PR DESCRIPTION
Two editor fixes:

## Inspector clip mask
- Layer-back the scrolling-header clip so `clipsToBounds` reliably masks the layer-backed `NSHostingView`. Fixes the inspector body bleeding below the collapsed band on async resize (ghost rows + stale heading paints).

## Caret reveal at document end
- The reading-column reveal enumerated text fragments from the caret location, which has **no fragment at the very document end** → nothing scrolled and the just-typed line stayed hidden. Step back one char at the end so the last fragment is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)