### PR TITLE
fix(undo): drop a document's undo stack when its file is rewritten while switched away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   checking is enabled.
 
 ### Fixed
+- Undo is now kept per `documentId`, so Cmd+Z keeps working after switching
+  files. The single reused `NSTextView` previously wiped its undo manager on
+  every document switch; the editor now vends a per-document `UndoManager`
+  (via the new `undoManager(for:)` delegate method) whose undo/redo stack
+  survives switching away and back. (#77)
+- A document's surviving undo stack is dropped when its text is reloaded
+  *changed* while it was switched away (e.g. renaming a node rewrites the
+  `[[label]]` in every file that links it), so Cmd+Z can no longer replay
+  stale ranges against the rewritten content.
 - `NativeTextViewWrapper` keeps links clickable and text selectable
   when `isEditable: false`; `isSelectable` is no longer coupled to
   `isEditable`. (#31)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -34,6 +34,19 @@ extension NativeTextViewCoordinator {
         return manager
     }
 
+    /// Drops `documentId`'s undo stack when its switch-away snapshot no longer
+    /// matches the text now being loaded (the file was rewritten while switched
+    /// away). AppKit's range-based text undo would otherwise corrupt the reloaded
+    /// content. Returns `true` if a stack was cleared.
+    @discardableResult
+    func invalidateUndoIfContentDiverged(for documentId: String, incomingText: String) -> Bool {
+        guard let snapshot = undoContentSnapshots[documentId], snapshot != incomingText else {
+            return false
+        }
+        undoManagers[documentId]?.removeAllActions()
+        return true
+    }
+
     /// Force base typingAttributes on every change so AppKit's auto-inheritance
     /// can't bleed a heading paragraphStyle into the trailing extra-line
     /// fragment's metrics.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -28,6 +28,10 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     /// its own undo stack that survives switching away and back. Vended through
     /// the `undoManager(for:)` delegate method; pruned alongside `scrollOffsets`.
     var undoManagers: [String: UndoManager] = [:]
+    /// Per-`documentId` content snapshot (storage form) taken on switch-away. On
+    /// switch-back a mismatch means the file was rewritten while backgrounded, so
+    /// the now-stale undo stack is dropped. Pruned alongside `undoManagers`.
+    var undoContentSnapshots: [String: String] = [:]
     @Binding var text: String
     @Binding var isWikiLinkActive: Bool
     var fontName: String

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -64,10 +64,10 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// Base font size in points. Headings, code blocks, and LaTeX are scaled
     /// off this value via ``MarkdownEditorConfiguration``.
     public var fontSize: CGFloat
-    /// Opaque document identifier. Changing this invalidates undo history
-    /// and resets per-document editor state. Set a stable, unique value
-    /// per document when displaying multiple editors so pending
-    /// replacements and undo stay scoped to each editor.
+    /// Opaque document identifier. Each value keeps its own undo stack and
+    /// per-document editor state across switching away and back; the undo stack is
+    /// dropped only if the document's text changes while it is switched away. Set a
+    /// stable, unique value per document so undo/replacements stay scoped.
     public var documentId: String
     /// When `false` the editor renders read-only with no caret.
     public var isEditable: Bool
@@ -367,15 +367,17 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                     $0.key == documentId || retained.contains($0.key)
                 }
             }
-            // Evict undo stacks for documents no longer retained (keep the
-            // current one). removeAllActions() first so a stale registered undo
-            // can't later fire against a swapped-out document.
-            let staleUndoKeys = context.coordinator.undoManagers.keys.filter { key in
-                key != documentId && key != "__default__" && !retained.contains(key)
-            }
+            // Evict undo stacks + content snapshots for documents no longer
+            // retained (keep the current one); clear actions before dropping.
+            let staleUndoKeys = Set(context.coordinator.undoManagers.keys)
+                .union(context.coordinator.undoContentSnapshots.keys)
+                .filter { key in
+                    key != documentId && key != "__default__" && !retained.contains(key)
+                }
             for key in staleUndoKeys {
                 context.coordinator.undoManagers[key]?.removeAllActions()
                 context.coordinator.undoManagers.removeValue(forKey: key)
+                context.coordinator.undoContentSnapshots.removeValue(forKey: key)
             }
         }
 
@@ -489,6 +491,12 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                retainedScrollDocumentIds?.contains(outgoingId) ?? true {
                 context.coordinator.scrollOffsets[outgoingId] = nsView.contentView.bounds.origin.y
             }
+            // Snapshot the outgoing document's content (storage form) so a later
+            // switch-back can detect a file rewritten while it was backgrounded.
+            // `lastSyncedText` still holds the outgoing content here.
+            if let outgoingId = context.coordinator.documentId {
+                context.coordinator.undoContentSnapshots[outgoingId] = context.coordinator.lastSyncedText
+            }
             // Per-document undo: close the OUTGOING document's open coalescing group
             // (while its manager is still active), then switch the active documentId so
             // `undoManager(for:)` starts vending the INCOMING document's own manager. We
@@ -496,6 +504,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             // across a file switch.
             textView.breakUndoCoalescing()
             context.coordinator.documentId = documentId
+            // Drop the incoming document's undo stack if its text changed while
+            // switched away — its recorded ranges are now stale.
+            context.coordinator.invalidateUndoIfContentDiverged(for: documentId, incomingText: text)
             context.coordinator.didInitialFormatting = false
             context.coordinator.didEnsureLayoutForCurrentDocument = false
             context.coordinator.resetImageEmbedState()

--- a/Tests/MarkdownEngineTests/PerDocumentUndoTests.swift
+++ b/Tests/MarkdownEngineTests/PerDocumentUndoTests.swift
@@ -1,0 +1,67 @@
+//
+//  PerDocumentUndoTests.swift
+//  MarkdownEngineTests
+//
+//  Per-`documentId` undo: a stable manager per document (Cmd+Z survives file
+//  switches) and dropping a stale stack when the document's text was rewritten
+//  while it was switched away. Headless.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+struct PerDocumentUndoTests {
+
+    private func makeCoordinator() -> NativeTextViewCoordinator {
+        NativeTextViewCoordinator(
+            text: .constant(""), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
+        )
+    }
+
+    /// UndoManager with one registered action, so `canUndo` is deterministically true.
+    private func populatedManager() -> UndoManager {
+        let target = NSObject()
+        let m = UndoManager()
+        m.groupsByEvent = false
+        m.beginUndoGrouping()
+        m.registerUndo(withTarget: target) { _ in }
+        m.endUndoGrouping()
+        return m
+    }
+
+    @Test("Stable manager per document; distinct across; original returned on switch-back")
+    func vendsStablePerDocumentManager() {
+        let c = makeCoordinator()
+        let tv = NativeTextView(frame: .zero)
+        c.documentId = "A"
+        let a = c.undoManager(for: tv)
+        #expect(c.undoManager(for: tv) === a)
+        c.documentId = "B"
+        #expect(c.undoManager(for: tv) !== a)
+        c.documentId = "A"
+        #expect(c.undoManager(for: tv) === a)
+    }
+
+    @Test("Undo stack dropped only when the reloaded text diverged from the snapshot")
+    func invalidatesOnlyOnDivergedContent() {
+        let c = makeCoordinator()
+        let m = populatedManager()
+        c.undoManagers["A"] = m
+        c.undoContentSnapshots["A"] = "hello"
+        #expect(c.invalidateUndoIfContentDiverged(for: "A", incomingText: "hello") == false)
+        #expect(m.canUndo) // unchanged → kept
+        #expect(c.invalidateUndoIfContentDiverged(for: "A", incomingText: "hello world") == true)
+        #expect(!m.canUndo) // diverged → dropped
+    }
+
+    @Test("No snapshot (first visit) never clears")
+    func noSnapshotNeverClears() {
+        let c = makeCoordinator()
+        c.undoManagers["A"] = populatedManager()
+        #expect(c.invalidateUndoIfContentDiverged(for: "A", incomingText: "x") == false)
+    }
+}


### PR DESCRIPTION
## Problem

Per-document undo (#77) makes a document's undo stack survive switching away and back. But AppKit's text undo records **absolute character ranges**, so if a document's file is rewritten externally while it's switched away, switch-back reloads the changed text and Cmd+Z replays stale ranges against it.

Concrete repro in the embedder (wiki-link notes): edit note A (which links `[[B]]`) → switch to B → rename B (after the debounce the rename rewrites A's file on disk, changing the `[[label]]` length) → switch back to A → **Cmd+Z corrupts A's text** (misplaced edit), or silently no-ops when the stale range is now out of bounds.

Before #77 this couldn't happen — undo was wiped on every switch, so switch-back Cmd+Z was an empty no-op. Surviving undo is the feature; this PR makes it safe.

## Fix

- Snapshot each document's content (storage form) on **switch-away** (`undoContentSnapshots`, from `lastSyncedText`).
- On **switch-back**, `invalidateUndoIfContentDiverged(for:incomingText:)` drops that document's undo stack when the reloaded text differs from the snapshot (timing-independent; the SwiftUI two-phase switch is covered by the existing `lastSyncedText == text` early-return, so the switch branch runs once with the real reloaded text).
- Snapshots are pruned alongside the per-document undo managers.
- Corrects the now-stale `documentId` doc comment ("Changing this invalidates undo history" → undo now survives switches).

Net: +/- across 3 source files + a focused test. No public API change.

## Test

`swift test` — 131 pass (128 existing + 3 new in `PerDocumentUndoTests`): stable manager per document / distinct across / original returned on switch-back; undo dropped only on diverged content; no snapshot never clears. Also verified end-to-end in a Debug build (rename-linked-node repro no longer corrupts; normal Cmd+Z-survives-switch still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)