### PR TITLE
feat(find): match in-document find against the displayed text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to swift-markdown-engine are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `MarkdownEditorBus.findQuery` / `findResults`: query-based in-document find. The host posts a
+  search string (+ current index) and the engine matches against its OWN displayed text,
+  highlighting in display coordinates and posting the match count back. This is correct where the
+  displayed text differs from the source — e.g. node links rendered shorter than `[[Name|UUID]]`,
+  LaTeX, or images — which the legacy `findScrollToRange` (host-computed source-coordinate ranges)
+  highlighted at the wrong offset. Opt-in; `findScrollToRange` is unchanged for existing embedders.
+
 ## [0.7.1] - 2026-06-20
 
 ### Added

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -205,6 +205,16 @@ public struct MarkdownEditorBus: Sendable {
     public var findScrollToRange: Notification.Name?
     /// Posted by the host UI to clear all in-document find highlights.
     public var findClearHighlights: Notification.Name?
+    /// Posted by the host UI to run an in-document find against the engine's OWN displayed
+    /// text. Expected `userInfo["query"] as? String`, optional `userInfo["currentIndex"] as? Int`.
+    /// The engine matches in DISPLAY coordinates, so highlights land correctly even where the
+    /// displayed text differs from the source (e.g. node links rendered shorter than
+    /// `[[Name|UUID]]`, LaTeX, images). Preferred over `findScrollToRange`, which trusts
+    /// host-computed (source-coordinate) ranges.
+    public var findQuery: Notification.Name?
+    /// Posted by the engine in response to `findQuery` with `userInfo["count"] as? Int`
+    /// (number of matches in the displayed text), so the host can show "x of y".
+    public var findResults: Notification.Name?
 
     public init(
         applyBoldRequest: Notification.Name? = nil,
@@ -213,7 +223,9 @@ public struct MarkdownEditorBus: Sendable {
         selectionBoldDidChange: Notification.Name? = nil,
         selectionItalicDidChange: Notification.Name? = nil,
         findScrollToRange: Notification.Name? = nil,
-        findClearHighlights: Notification.Name? = nil
+        findClearHighlights: Notification.Name? = nil,
+        findQuery: Notification.Name? = nil,
+        findResults: Notification.Name? = nil
     ) {
         self.applyBoldRequest = applyBoldRequest
         self.applyItalicRequest = applyItalicRequest
@@ -222,6 +234,8 @@ public struct MarkdownEditorBus: Sendable {
         self.selectionItalicDidChange = selectionItalicDidChange
         self.findScrollToRange = findScrollToRange
         self.findClearHighlights = findClearHighlights
+        self.findQuery = findQuery
+        self.findResults = findResults
     }
 
     public static let `default` = MarkdownEditorBus()

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -14,13 +14,51 @@
 import AppKit
 
 extension NativeTextViewCoordinator {
+    /// Legacy path: the host computes match ranges and posts them. Kept for compatibility, but
+    /// it trusts SOURCE-coordinate ranges, which misalign wherever the displayed text is shorter
+    /// than the source (node links etc.). Prefer `handleFindQuery`.
     @objc func handleFindScrollToRange(_ notification: Notification) {
-        guard let tv = textView,
-              let info = notification.userInfo,
-              let range = info["range"] as? NSRange,
+        guard let info = notification.userInfo,
               let currentIndex = info["currentIndex"] as? Int,
               let allRanges = info["allRanges"] as? [NSRange] else { return }
+        renderFindMatches(allRanges, currentIndex: currentIndex)
+    }
 
+    /// Find against the engine's OWN displayed text (`tv.string`). Matches are computed in
+    /// DISPLAY coordinates, so highlights land correctly even where the displayed text differs
+    /// from the source (node links rendered shorter than `[[Name|UUID]]`, LaTeX, images). Posts
+    /// the match count back via `bus.findResults` so the host can show "x of y".
+    @objc func handleFindQuery(_ notification: Notification) {
+        guard let tv = textView,
+              let info = notification.userInfo,
+              let query = info["query"] as? String else { return }
+        let requestedIndex = info["currentIndex"] as? Int ?? 0
+
+        var allRanges: [NSRange] = []
+        if !query.isEmpty {
+            let haystack = tv.string as NSString
+            let opts: NSString.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+            var searchStart = 0
+            while searchStart < haystack.length {
+                let scope = NSRange(location: searchStart, length: haystack.length - searchStart)
+                let found = haystack.range(of: query, options: opts, range: scope)
+                if found.location == NSNotFound { break }
+                allRanges.append(found)
+                searchStart = found.location + max(found.length, 1)
+            }
+        }
+
+        let currentIndex = allRanges.isEmpty ? 0 : min(max(requestedIndex, 0), allRanges.count - 1)
+        renderFindMatches(allRanges, currentIndex: currentIndex)
+
+        if let resultsName = configuration.services.bus.findResults {
+            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: ["count": allRanges.count])
+        }
+    }
+
+    /// Highlight all matches (current one stronger) and scroll the current match into view.
+    private func renderFindMatches(_ allRanges: [NSRange], currentIndex: Int) {
+        guard let tv = textView else { return }
         let storage = tv.textStorage
         let fullRange = NSRange(location: 0, length: (tv.string as NSString).length)
 
@@ -44,6 +82,8 @@ extension NativeTextViewCoordinator {
         }
 
         // Scroll the current match into view.
+        guard allRanges.indices.contains(currentIndex) else { return }
+        let range = allRanges[currentIndex]
         guard range.location + range.length <= fullRange.length else { return }
         // Default (text view IS documentView): native reveal — unchanged for non-readingWidth embedders.
         guard configuration.readingWidth != nil,

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -236,6 +236,11 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
                 self?.handleFindClearHighlights(notification)
             })
         }
+        if let name = bus.findQuery {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleFindQuery(notification)
+            })
+        }
     }
 
     // Find-in-document highlight handlers live in


### PR DESCRIPTION
## Problem
In-document find (Cmd+F) highlighted the **wrong word** in the host app. The host computed match ranges against the **raw source** text and posted them via `findScrollToRange`, but the engine renders a shorter **display** text into its storage (`textView.string = displayText` / `replaceCharacters`). So source-coordinate ranges land at the wrong offset wherever the display is shorter than the source — most notably **node links** rendered as `Name` instead of `[[Name|UUID]]`, plus LaTeX and images. Every match after such an element was off.

## Fix
The engine now owns the matching, against its **own displayed text**:

- New bus notifications `MarkdownEditorBus.findQuery` (host→engine) and `findResults` (engine→host).
- `handleFindQuery` searches `tv.string` (display) case/diacritic-insensitively, highlights all matches (current one stronger) in **display coordinates**, scrolls the current match into view, and posts the match `count` back so the host can show "x of y".
- The host sends only `{ query, currentIndex }`; navigation re-posts with a new index.
- The legacy `findScrollToRange` path is kept and unchanged for existing embedders (the highlight/scroll body was factored into a shared `renderFindMatches`).

Because matching happens on the displayed text, highlights are correct regardless of how `[[Name|UUID]]` / LaTeX / images render.

## Host adoption
Wire the bus: `MarkdownEditorBus(..., findQuery: .findQuery, findResults: .findResults)`; post `findQuery` with `["query", "currentIndex"]`; observe `findResults` `["count"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)