### PR TITLE
feat(bus): extend formatting bus with strikethrough / inline code / blockquote / list / link actions, and word-boundary auto-detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `true`, `mouseMoved:` skips calling `super.mouseMoved` to avoid NSTextView's
   built-in I-beam cursor, setting the arrow cursor instead. Exposed through
   `NativeTextViewWrapper.isCursorExcluded`.
+- `MarkdownEditorBus` extended with nine new notification types for
+  formatting toolbar integration: `applyStrikethroughRequest`,
+  `applyInlineCodeRequest`, `applyBlockquoteRequest`,
+  `applyUnorderedListRequest`, `applyOrderedListRequest`,
+  `applyLinkRequest`, `applyCodeBlockRequest`,
+  `applyHorizontalRuleRequest`, `applyImageRequest`. Embedders wire
+  these into `NotificationCenter` to trigger formatting from
+  external UI (toolbars, menus) without reaching into the editor's
+  view hierarchy.
+- New formatting actions on the coordinator (callable directly or
+  via the bus above): `didMarkdownStrikethrough`, `didMarkdownInlineCode`,
+  `didMarkdownBlockquote`, `didMarkdownLink`, `didMarkdownCodeBlock`,
+  `didMarkdownHorizontalRule`, `didMarkdownImage`.
+- Word-boundary detection in inline formatting: when the cursor is
+  placed inside an English word with no active text selection, bold,
+  italic, strikethrough, and inline-code actions now auto-select the
+  containing word before wrapping. If no word character is adjacent
+  to the cursor, empty markers are inserted as before. The cursor's
+  relative offset within the word is preserved after wrapping
+  (e.g. `wo|rd` → `**wo|rd**`).
+- Headless test suite for formatting actions (`FormattingActionTests`
+  — 21 tests covering bold, strikethrough, inline code, blockquote,
+  link, code block, horizontal rule, and image insertion).
+
+### Fixed
+- Blockquote removal no longer doubles trailing newlines when the
+  original line already carries one.
 
 ## [0.7.1] - 2026-06-20
 
@@ -89,7 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A document's surviving undo stack is dropped when its text is reloaded
   *changed* while it was switched away (e.g. renaming a node rewrites the
   `[[label]]` in every file that links it), so Cmd+Z can no longer replay
-  stale ranges against the rewritten content.
+  stale ranges against the rewritten content. (#78)
 - `NativeTextViewWrapper` keeps links clickable and text selectable
   when `isEditable: false`; `isSelectable` is no longer coupled to
   `isEditable`. (#31)

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -195,6 +195,26 @@ public struct MarkdownEditorBus: Sendable {
     /// Posted by the host UI to request the engine apply a heading level.
     /// Expected `userInfo["level"] as? Int`.
     public var applyHeadingRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply strikethrough styling.
+    public var applyStrikethroughRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply inline code styling.
+    public var applyInlineCodeRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply blockquote styling.
+    public var applyBlockquoteRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply unordered list styling.
+    public var applyUnorderedListRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply ordered list styling.
+    public var applyOrderedListRequest: Notification.Name?
+    /// Posted by the host UI to insert a Markdown link.
+    /// Expected `userInfo["url"] as? String`.
+    public var applyLinkRequest: Notification.Name?
+    /// Posted by the host UI to insert a fenced code block at the cursor.
+    public var applyCodeBlockRequest: Notification.Name?
+    /// Posted by the host UI to insert a horizontal rule (`---`) at the cursor.
+    public var applyHorizontalRuleRequest: Notification.Name?
+    /// Posted by the host UI to insert an image embed.
+    /// Expected `userInfo["url"] as? String`.
+    public var applyImageRequest: Notification.Name?
     /// Posted by the engine after every selection change with `userInfo["isBold"] as? Bool`.
     public var selectionBoldDidChange: Notification.Name?
     /// Posted by the engine after every selection change with `userInfo["isItalic"] as? Bool`.
@@ -220,6 +240,15 @@ public struct MarkdownEditorBus: Sendable {
         applyBoldRequest: Notification.Name? = nil,
         applyItalicRequest: Notification.Name? = nil,
         applyHeadingRequest: Notification.Name? = nil,
+        applyStrikethroughRequest: Notification.Name? = nil,
+        applyInlineCodeRequest: Notification.Name? = nil,
+        applyBlockquoteRequest: Notification.Name? = nil,
+        applyUnorderedListRequest: Notification.Name? = nil,
+        applyOrderedListRequest: Notification.Name? = nil,
+        applyLinkRequest: Notification.Name? = nil,
+        applyCodeBlockRequest: Notification.Name? = nil,
+        applyHorizontalRuleRequest: Notification.Name? = nil,
+        applyImageRequest: Notification.Name? = nil,
         selectionBoldDidChange: Notification.Name? = nil,
         selectionItalicDidChange: Notification.Name? = nil,
         findScrollToRange: Notification.Name? = nil,
@@ -230,6 +259,15 @@ public struct MarkdownEditorBus: Sendable {
         self.applyBoldRequest = applyBoldRequest
         self.applyItalicRequest = applyItalicRequest
         self.applyHeadingRequest = applyHeadingRequest
+        self.applyStrikethroughRequest = applyStrikethroughRequest
+        self.applyInlineCodeRequest = applyInlineCodeRequest
+        self.applyBlockquoteRequest = applyBlockquoteRequest
+        self.applyUnorderedListRequest = applyUnorderedListRequest
+        self.applyOrderedListRequest = applyOrderedListRequest
+        self.applyLinkRequest = applyLinkRequest
+        self.applyCodeBlockRequest = applyCodeBlockRequest
+        self.applyHorizontalRuleRequest = applyHorizontalRuleRequest
+        self.applyImageRequest = applyImageRequest
         self.selectionBoldDidChange = selectionBoldDidChange
         self.selectionItalicDidChange = selectionItalicDidChange
         self.findScrollToRange = findScrollToRange

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -11,50 +11,15 @@ import Cocoa
 import SwiftUI
 
 extension NativeTextViewWrapper.Coordinator {
+    // The engine ships no built-in menu (API-only). It hands the default NSMenu + the
+    // current selection to the embedder's onBuildContextMenu hook, which returns the menu
+    // to show. The didMarkdown* actions below stay so embedders can drive them via the bus.
     public func textView(_ textView: NSTextView,
-                  menu: NSMenu,
-                  for event: NSEvent,
-                  at charIndex: Int) -> NSMenu? {
-        let customMenu = menu.copy() as? NSMenu ?? NSMenu()
-
-        if let fontIndex = customMenu.items.firstIndex(where: { $0.title == "Font" }) {
-            customMenu.removeItem(at: fontIndex)
-            let formatItem = NSMenuItem(title: "Format", action: nil, keyEquivalent: "")
-            let formatSubmenu = NSMenu(title: "Format")
-            let boldItem = NSMenuItem(title: "Bold", action: #selector(didMarkdownBold(_:)), keyEquivalent: "")
-            boldItem.target = self
-            formatSubmenu.addItem(boldItem)
-            let italicItem = NSMenuItem(title: "Italic", action: #selector(didMarkdownItalic(_:)), keyEquivalent: "")
-            italicItem.target = self
-            formatSubmenu.addItem(italicItem)
-            formatItem.submenu = formatSubmenu
-            customMenu.insertItem(formatItem, at: fontIndex)
-
-            let headingItem = NSMenuItem(title: "Heading", action: nil, keyEquivalent: "")
-            let headingSubmenu = NSMenu(title: "Heading")
-            for level in 1...3 {
-                let item = NSMenuItem(title: "H\(level)", action: #selector(didMarkdownHeading(_:)), keyEquivalent: "")
-                item.target = self
-                item.tag = level
-                headingSubmenu.addItem(item)
-            }
-            headingItem.submenu = headingSubmenu
-            customMenu.insertItem(headingItem, at: fontIndex + 1)
-
-            let listItem = NSMenuItem(title: "Lists", action: nil, keyEquivalent: "")
-            let listSubmenu = NSMenu(title: "Lists")
-            let unorderedItem = NSMenuItem(title: "Bullet", action: #selector(didMarkdownUnorderedList(_:)), keyEquivalent: "")
-            unorderedItem.target = self
-            listSubmenu.addItem(unorderedItem)
-            let orderedItem = NSMenuItem(title: "Numbered", action: #selector(didMarkdownOrderedList(_:)), keyEquivalent: "")
-            orderedItem.target = self
-            listSubmenu.addItem(orderedItem)
-            listItem.submenu = listSubmenu
-            customMenu.insertItem(listItem, at: fontIndex + 2)
-            customMenu.insertItem(NSMenuItem.separator(), at: fontIndex + 3)
-        }
-
-        return customMenu
+                         menu: NSMenu,
+                         for event: NSEvent,
+                         at charIndex: Int) -> NSMenu? {
+        guard let build = onBuildContextMenu else { return menu }
+        return build(menu, textView.selectedRange())
     }
 
     /// Returns the smallest bold or boldItalic token that fully contains the selection, or nil when the selection isn't enclosed by emphasis with a bold trait.
@@ -464,34 +429,6 @@ extension NativeTextViewWrapper.Coordinator {
     }
 }
 
-// MARK: - Menu Item Validation
-extension NativeTextViewWrapper.Coordinator: NSMenuItemValidation {
-    public func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-        guard let tv = textView else { return true }
-        let nsText = tv.string as NSString
-        let range = tv.selectedRange()
-        switch menuItem.action {
-        case #selector(didMarkdownBold(_:)):
-            menuItem.state = enclosingBoldToken(for: range, in: tv.string) != nil ? .on : .off
-            return true
-        case #selector(didMarkdownItalic(_:)):
-            menuItem.state = enclosingItalicToken(for: range, in: tv.string) != nil ? .on : .off
-            return true
-        case #selector(didMarkdownStrikethrough(_:)):
-            menuItem.state = isSelectionStrikethrough(in: nsText, range: range) ? .on : .off
-            return true
-        case #selector(didMarkdownInlineCode(_:)):
-            menuItem.state = isSelectionInlineCode(in: nsText, range: range) ? .on : .off
-            return true
-        case #selector(didMarkdownBlockquote(_:)):
-            return !isSelectionBlockquote(in: nsText, range: range)
-        case #selector(didMarkdownHeading(_:)):
-            return !isSelectionHeading(level: menuItem.tag, in: nsText, range: range)
-        case #selector(didMarkdownUnorderedList(_:)),
-             #selector(didMarkdownOrderedList(_:)):
-            return !isSelectionList(in: nsText, range: range)
-        default:
-            return true
-        }
-    }
-}
+// Menu Item Validation (checkmark state) removed together with the built-in menu —
+// engine ships no UI. Expose the isSelection* checks as a query API if embedders
+// need menu state.

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -81,6 +81,42 @@ extension NativeTextViewWrapper.Coordinator {
         return enclosingItalicToken(for: range, in: nsText as String) != nil
     }
 
+    func isSelectionStrikethrough(in nsText: NSString, range: NSRange) -> Bool {
+        return enclosingToken(of: .strikethrough, for: range, in: nsText as String) != nil
+    }
+
+    func isSelectionInlineCode(in nsText: NSString, range: NSRange) -> Bool {
+        return enclosingToken(of: .inlineCode, for: range, in: nsText as String) != nil
+    }
+
+    /// Returns the smallest token of `kind` that fully contains the selection, or nil.
+    private func enclosingToken(of kind: MarkdownTokenKind, for selection: NSRange, in text: String) -> MarkdownToken? {
+        let tokens = parsedDocument(for: text).tokens
+        return tokens.first { $0.kind == kind && tokenEncloses($0, selection: selection) }
+    }
+
+    /// Expands the given text location outward to the nearest alphanumeric
+    /// + underscore word boundaries. Returns nil when no word characters
+    /// are adjacent to the location.
+    private func wordRange(at location: Int, in nsText: NSString) -> NSRange? {
+        guard location >= 0, location <= nsText.length else { return nil }
+        let charSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "_"))
+        var start = location
+        while start > 0 {
+            let ch = nsText.character(at: start - 1)
+            guard let scalar = Unicode.Scalar(ch), charSet.contains(scalar) else { break }
+            start -= 1
+        }
+        var end = location
+        while end < nsText.length {
+            let ch = nsText.character(at: end)
+            guard let scalar = Unicode.Scalar(ch), charSet.contains(scalar) else { break }
+            end += 1
+        }
+        let length = end - start
+        return length > 0 ? NSRange(location: start, length: length) : nil
+    }
+
     private func tokenEncloses(_ token: MarkdownToken, selection: NSRange) -> Bool {
         return selection.location >= token.range.location
             && NSMaxRange(selection) <= NSMaxRange(token.range)
@@ -113,6 +149,12 @@ extension NativeTextViewWrapper.Coordinator {
         let line = nsText.substring(with: lineRange)
         return line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ")
             || line.hasPrefix("\t• ") || line.hasPrefix("1. ")
+    }
+
+    func isSelectionBlockquote(in nsText: NSString, range: NSRange) -> Bool {
+        let lineRange = nsText.lineRange(for: range)
+        let line = nsText.substring(with: lineRange)
+        return line.hasPrefix("> ")
     }
 
     private func applyHeading(level: Int) {
@@ -186,6 +228,12 @@ extension NativeTextViewWrapper.Coordinator {
             return
         }
 
+        if range.length == 0, let wr = wordRange(at: range.location, in: tv.string as NSString), wr.length > 0 {
+            let cursorOffset = range.location - wr.location
+            wrapWordRange(wr, with: "**", cursorOffset: cursorOffset)
+            return
+        }
+
         if range.length == 0 {
             insertEmptyMarkers("**")
             return
@@ -205,12 +253,180 @@ extension NativeTextViewWrapper.Coordinator {
             return
         }
 
+        if range.length == 0, let wr = wordRange(at: range.location, in: tv.string as NSString), wr.length > 0 {
+            let cursorOffset = range.location - wr.location
+            wrapWordRange(wr, with: "*", cursorOffset: cursorOffset)
+            return
+        }
+
         if range.length == 0 {
             insertEmptyMarkers("*")
             return
         }
 
         wrapSelection(with: "*")
+    }
+
+    @objc func didMarkdownStrikethrough(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+
+        if let token = enclosingToken(of: .strikethrough, for: range, in: tv.string) {
+            unwrapToken(token, leftReplacement: "", rightReplacement: "")
+            return
+        }
+
+        if range.length == 0, let wr = wordRange(at: range.location, in: tv.string as NSString), wr.length > 0 {
+            let cursorOffset = range.location - wr.location
+            wrapWordRange(wr, with: "~~", cursorOffset: cursorOffset)
+            return
+        }
+
+        if range.length == 0 {
+            insertEmptyMarkers("~~")
+            return
+        }
+
+        wrapSelection(with: "~~")
+    }
+
+    @objc func didMarkdownInlineCode(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+
+        if let token = enclosingToken(of: .inlineCode, for: range, in: tv.string) {
+            unwrapToken(token, leftReplacement: "", rightReplacement: "")
+            return
+        }
+
+        if range.length == 0, let wr = wordRange(at: range.location, in: tv.string as NSString), wr.length > 0 {
+            let cursorOffset = range.location - wr.location
+            wrapWordRange(wr, with: "`", cursorOffset: cursorOffset)
+            return
+        }
+
+        if range.length == 0 {
+            insertEmptyMarkers("`")
+            return
+        }
+
+        wrapSelection(with: "`")
+    }
+
+    @objc func didMarkdownBlockquote(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let nsText = tv.string as NSString
+        let range = tv.selectedRange()
+        let lineRange = nsText.lineRange(for: range)
+        let originalLine = nsText.substring(with: lineRange)
+
+        if originalLine.hasPrefix("> ") {
+            let stripped = String(originalLine.dropFirst(2))
+            let needsNewline = originalLine.hasSuffix("\n") && !stripped.hasSuffix("\n")
+            let replacement = stripped + (needsNewline ? "\n" : "")
+            if tv.shouldChangeText(in: lineRange, replacementString: replacement) {
+                tv.replaceCharacters(in: lineRange, with: replacement)
+                tv.didChangeText()
+                let newLoc = max(lineRange.location, range.location - 2)
+                tv.setSelectedRange(NSRange(location: newLoc, length: 0))
+                DispatchQueue.main.async { self.text = tv.string }
+            }
+        } else {
+            let newLine = "> " + originalLine
+            if tv.shouldChangeText(in: lineRange, replacementString: newLine) {
+                tv.replaceCharacters(in: lineRange, with: newLine)
+                tv.didChangeText()
+                tv.setSelectedRange(NSRange(location: lineRange.location + 2, length: range.length))
+                DispatchQueue.main.async { self.text = tv.string }
+            }
+        }
+    }
+
+    @objc func didMarkdownLink(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+        let url = (sender as? NSNotification)?.userInfo?["url"] as? String ?? ""
+
+        if range.length > 0 {
+            let nsText = tv.string as NSString
+            let selected = nsText.substring(with: range)
+            let newText = "[\(selected)](\(url))"
+            if tv.shouldChangeText(in: range, replacementString: newText) {
+                tv.replaceCharacters(in: range, with: newText)
+                tv.didChangeText()
+                tv.setSelectedRange(NSRange(location: range.location + newText.count, length: 0))
+                DispatchQueue.main.async { self.text = tv.string }
+            }
+        } else {
+            let insertion = "[](\(url))"
+            if tv.shouldChangeText(in: range, replacementString: insertion) {
+                tv.replaceCharacters(in: range, with: insertion)
+                tv.didChangeText()
+                tv.setSelectedRange(NSRange(location: range.location + 1, length: 0))
+                DispatchQueue.main.async { self.text = tv.string }
+            }
+        }
+    }
+
+    @objc func didMarkdownCodeBlock(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+        let nsText = tv.string as NSString
+        let lineRange = nsText.lineRange(for: range)
+        let prefix = range.location > lineRange.location ? "\n" : ""
+        let insertion = "\(prefix)```\n\n```\n"
+        if tv.shouldChangeText(in: range, replacementString: insertion) {
+            tv.replaceCharacters(in: range, with: insertion)
+            tv.didChangeText()
+            let cursorLoc = range.location + prefix.count + 4
+            tv.setSelectedRange(NSRange(location: cursorLoc, length: 0))
+            DispatchQueue.main.async { self.text = tv.string }
+        }
+    }
+
+    @objc func didMarkdownHorizontalRule(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+        let nsText = tv.string as NSString
+        let lineRange = nsText.lineRange(for: range)
+        let prefix = range.location > lineRange.location ? "\n" : ""
+        let insertion = "\(prefix)---\n"
+        if tv.shouldChangeText(in: range, replacementString: insertion) {
+            tv.replaceCharacters(in: range, with: insertion)
+            tv.didChangeText()
+            let cursorLoc = range.location + insertion.count
+            tv.setSelectedRange(NSRange(location: cursorLoc, length: 0))
+            DispatchQueue.main.async { self.text = tv.string }
+        }
+    }
+
+    @objc func didMarkdownImage(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+        let url = (sender as? NSNotification)?.userInfo?["url"] as? String ?? ""
+        let insertion = "![](\(url))"
+        if tv.shouldChangeText(in: range, replacementString: insertion) {
+            tv.replaceCharacters(in: range, with: insertion)
+            tv.didChangeText()
+            tv.setSelectedRange(NSRange(location: range.location + insertion.count, length: 0))
+            DispatchQueue.main.async { self.text = tv.string }
+        }
+    }
+
+    /// Wraps the range with markers while preserving the cursor's relative
+    /// offset within the original text. For example `wo|rd` with `**`
+    /// becomes `**wo|rd**`.
+    private func wrapWordRange(_ range: NSRange, with marker: String, cursorOffset: Int) {
+        guard let tv = textView else { return }
+        let nsText = tv.string as NSString
+        let original = nsText.substring(with: range)
+        let newText = marker + original + marker
+        if tv.shouldChangeText(in: range, replacementString: newText) {
+            tv.replaceCharacters(in: range, with: newText)
+            tv.didChangeText()
+            tv.setSelectedRange(NSRange(location: range.location + marker.count + cursorOffset, length: 0))
+            DispatchQueue.main.async { self.text = tv.string }
+        }
     }
 
     private func insertEmptyMarkers(_ marker: String) {
@@ -261,6 +477,14 @@ extension NativeTextViewWrapper.Coordinator: NSMenuItemValidation {
         case #selector(didMarkdownItalic(_:)):
             menuItem.state = enclosingItalicToken(for: range, in: tv.string) != nil ? .on : .off
             return true
+        case #selector(didMarkdownStrikethrough(_:)):
+            menuItem.state = isSelectionStrikethrough(in: nsText, range: range) ? .on : .off
+            return true
+        case #selector(didMarkdownInlineCode(_:)):
+            menuItem.state = isSelectionInlineCode(in: nsText, range: range) ? .on : .off
+            return true
+        case #selector(didMarkdownBlockquote(_:)):
+            return !isSelectionBlockquote(in: nsText, range: range)
         case #selector(didMarkdownHeading(_:)):
             return !isSelectionHeading(level: menuItem.tag, in: nsText, range: range)
         case #selector(didMarkdownUnorderedList(_:)),

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -18,6 +18,16 @@ extension NativeTextViewWrapper.Coordinator {
                          menu: NSMenu,
                          for event: NSEvent,
                          at charIndex: Int) -> NSMenu? {
+        // Drop the system rich-text "Font" submenu (Bold/Italic/Show Colors…). Those apply
+        // NSFont traits/colors that do nothing in a markdown editor (the engine owns styling),
+        // so showing them would mislead. Identified by its font-panel action (locale-independent),
+        // with a title fallback.
+        if let fontIndex = menu.items.firstIndex(where: { item in
+            if item.title == "Font" { return true }
+            return item.submenu?.items.contains { $0.action == Selector("orderFrontFontPanel:") } ?? false
+        }) {
+            menu.removeItem(at: fontIndex)
+        }
         guard let build = onBuildContextMenu else { return menu }
         return build(menu, textView.selectedRange())
     }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
@@ -28,6 +28,42 @@ extension NativeTextViewCoordinator {
         didMarkdownHeading(item)
     }
 
+    @objc func handleStrikethroughNotification(_ notification: Notification) {
+        didMarkdownStrikethrough(nil)
+    }
+
+    @objc func handleInlineCodeNotification(_ notification: Notification) {
+        didMarkdownInlineCode(nil)
+    }
+
+    @objc func handleBlockquoteNotification(_ notification: Notification) {
+        didMarkdownBlockquote(nil)
+    }
+
+    @objc func handleUnorderedListNotification(_ notification: Notification) {
+        didMarkdownUnorderedList(nil)
+    }
+
+    @objc func handleOrderedListNotification(_ notification: Notification) {
+        didMarkdownOrderedList(nil)
+    }
+
+    @objc func handleLinkNotification(_ notification: Notification) {
+        didMarkdownLink(notification)
+    }
+
+    @objc func handleCodeBlockNotification(_ notification: Notification) {
+        didMarkdownCodeBlock(nil)
+    }
+
+    @objc func handleHorizontalRuleNotification(_ notification: Notification) {
+        didMarkdownHorizontalRule(nil)
+    }
+
+    @objc func handleImageNotification(_ notification: Notification) {
+        didMarkdownImage(notification)
+    }
+
     @objc func handleAppearanceChange(_ notification: Notification) {
         guard let tv = textView else { return }
         // Only react if the notification came from our own text view or from nil (system-wide)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -60,6 +60,9 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var layoutDelegate: MarkdownLayoutManagerDelegate?
     var onLinkClick: ((String) -> Void)?
     var onCaretRectChange: ((CGRect) -> Void)?
+    /// Embedder hook to build the right-click menu (the engine ships none). Gets the
+    /// default menu + current selection range, returns the menu to show.
+    var onBuildContextMenu: ((NSMenu, NSRange) -> NSMenu)?
     var onInlineSelectionChange: ((InlineSelectionState?) -> Void)?
     var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
     var didInitialFormatting: Bool = false

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -226,6 +226,51 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
                 self?.handleHeadingNotification(notification)
             })
         }
+        if let name = bus.applyStrikethroughRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleStrikethroughNotification(notification)
+            })
+        }
+        if let name = bus.applyInlineCodeRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleInlineCodeNotification(notification)
+            })
+        }
+        if let name = bus.applyBlockquoteRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleBlockquoteNotification(notification)
+            })
+        }
+        if let name = bus.applyUnorderedListRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleUnorderedListNotification(notification)
+            })
+        }
+        if let name = bus.applyOrderedListRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleOrderedListNotification(notification)
+            })
+        }
+        if let name = bus.applyLinkRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleLinkNotification(notification)
+            })
+        }
+        if let name = bus.applyCodeBlockRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleCodeBlockNotification(notification)
+            })
+        }
+        if let name = bus.applyHorizontalRuleRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleHorizontalRuleNotification(notification)
+            })
+        }
+        if let name = bus.applyImageRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleImageNotification(notification)
+            })
+        }
         if let name = bus.findScrollToRange {
             busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
                 self?.handleFindScrollToRange(notification)

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -83,6 +83,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// Fires whenever the caret rect inside an active wiki-link changes,
     /// so embedders can position a follow-the-caret UI.
     public var onCaretRectChange: ((CGRect) -> Void)?
+    /// Build the editor's right-click menu (the engine ships no menu). Receives the default
+    /// NSMenu + the current selection range; return the menu to display (or unchanged).
+    public var onBuildContextMenu: ((NSMenu, NSRange) -> NSMenu)?
     /// Fires when the caret enters or leaves a `[[Name]]` or `![[…]]`
     /// token. `nil` means the caret is no longer inside such a token.
     public var onInlineSelectionChange: ((InlineSelectionState?) -> Void)?
@@ -134,6 +137,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
+        onBuildContextMenu: ((NSMenu, NSRange) -> NSMenu)? = nil,
         onInlineSelectionChange: ((InlineSelectionState?) -> Void)? = nil,
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
         onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
@@ -155,6 +159,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
+        self.onBuildContextMenu = onBuildContextMenu
         self.onInlineSelectionChange = onInlineSelectionChange
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
@@ -296,6 +301,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.textView = textView
         context.coordinator.wikiLinkMetadata = initialState.metadata
         context.coordinator.onCaretRectChange = onCaretRectChange
+        context.coordinator.onBuildContextMenu = onBuildContextMenu
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
 
@@ -559,6 +565,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
 
         context.coordinator.onCaretRectChange = onCaretRectChange
+        context.coordinator.onBuildContextMenu = onBuildContextMenu
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         context.coordinator.didInitialFormatting = true

--- a/Tests/MarkdownEngineTests/FormattingActionTests.swift
+++ b/Tests/MarkdownEngineTests/FormattingActionTests.swift
@@ -1,0 +1,220 @@
+//
+//  FormattingActionTests.swift
+//  MarkdownEngineTests
+//
+//  Headless tests for formatting actions wired through the coordinator.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+import SwiftUI
+
+@MainActor
+@Suite("Formatting actions")
+struct FormattingActionTests {
+
+    /// Sets up a NativeTextView + Coordinator, sets initial text
+    /// and selection, then runs the action closure and returns
+    /// the resulting text view for assertion.
+    private func apply(
+        initialText: String,
+        selection: NSRange,
+        action: (NativeTextViewCoordinator) -> Void
+    ) -> NativeTextView {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let textView = NativeTextView(frame: scrollView.contentView.bounds)
+        textView.minSize = .zero
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.isEditable = true
+        textView.configuration = .default
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(""),
+            fontName: "SF Pro Text",
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        coordinator.textView = textView
+        textView.string = initialText
+        textView.setSelectedRange(selection)
+        action(coordinator)
+        return textView
+    }
+
+    // MARK: - Bold
+
+    @Test func boldWrapsSelection() {
+        let tv = apply(initialText: "hello world", selection: NSRange(location: 0, length: 5)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "**hello** world")
+        #expect(tv.selectedRange() == NSRange(location: 2, length: 5))
+    }
+
+    @Test func boldWrapsWord() {
+        let tv = apply(initialText: "hello world", selection: NSRange(location: 1, length: 0)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "**hello** world")
+    }
+
+    @Test func boldPreservesCursorOffset() {
+        let tv = apply(initialText: "hello world", selection: NSRange(location: 2, length: 0)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "**hello** world")
+        #expect(tv.selectedRange().location == 4)
+    }
+
+    @Test func boldInsertsEmptyMarkers() {
+        let tv = apply(initialText: "hello  world", selection: NSRange(location: 6, length: 0)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "hello **** world")
+        #expect(tv.selectedRange().location == 8)
+    }
+
+    @Test func boldTogglesOff() {
+        let tv = apply(initialText: "aa **bb** cc", selection: NSRange(location: 5, length: 2)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "aa bb cc")
+    }
+
+    @Test func boldTogglesOffByCursor() {
+        let tv = apply(initialText: "aa **bold** cc", selection: NSRange(location: 7, length: 0)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "aa bold cc")
+        #expect(tv.selectedRange().location == 3)
+    }
+
+    @Test func boldItalicTogglesToItalic() {
+        let tv = apply(initialText: "***both***", selection: NSRange(location: 4, length: 4)) {
+            $0.didMarkdownBold(nil)
+        }
+        #expect(tv.string == "*both*")
+    }
+
+    // MARK: - Strikethrough
+
+    @Test func strikethroughWrapsSelection() {
+        let tv = apply(initialText: "hello world", selection: NSRange(location: 6, length: 5)) {
+            $0.didMarkdownStrikethrough(nil)
+        }
+        #expect(tv.string == "hello ~~world~~")
+        #expect(tv.selectedRange() == NSRange(location: 8, length: 5))
+    }
+
+    @Test func strikethroughWrapsWord() {
+        let tv = apply(initialText: "hello world", selection: NSRange(location: 7, length: 0)) {
+            $0.didMarkdownStrikethrough(nil)
+        }
+        #expect(tv.string == "hello ~~world~~")
+    }
+
+    @Test func strikethroughTogglesOff() {
+        let tv = apply(initialText: "~~text~~", selection: NSRange(location: 3, length: 4)) {
+            $0.didMarkdownStrikethrough(nil)
+        }
+        #expect(tv.string == "text")
+    }
+
+    // MARK: - Inline code
+
+    @Test func inlineCodeWrapsSelection() {
+        let tv = apply(initialText: "var x = 1", selection: NSRange(location: 4, length: 5)) {
+            $0.didMarkdownInlineCode(nil)
+        }
+        #expect(tv.string == "var `x = 1`")
+    }
+
+    @Test func inlineCodeTogglesOff() {
+        let tv = apply(initialText: "call `fn()` here", selection: NSRange(location: 6, length: 4)) {
+            $0.didMarkdownInlineCode(nil)
+        }
+        #expect(tv.string == "call fn() here")
+    }
+
+    // MARK: - Blockquote
+
+    @Test func blockquoteAddsPrefix() {
+        let tv = apply(initialText: "a quote line\n", selection: NSRange(location: 3, length: 0)) {
+            $0.didMarkdownBlockquote(nil)
+        }
+        #expect(tv.string == "> a quote line\n")
+    }
+
+    @Test func blockquoteRemovesPrefix() {
+        let tv = apply(initialText: "> a quote\n", selection: NSRange(location: 4, length: 0)) {
+            $0.didMarkdownBlockquote(nil)
+        }
+        #expect(tv.string == "a quote\n")
+    }
+
+    // MARK: - Link
+
+    @Test func linkWrapsSelection() {
+        let tv = apply(initialText: "click here", selection: NSRange(location: 0, length: 5)) { coord in
+            let note = Notification(name: .init("test"), userInfo: ["url": "https://example.com"])
+            coord.didMarkdownLink(note)
+        }
+        #expect(tv.string == "[click](https://example.com) here")
+    }
+
+    @Test func linkInsertsEmptyBrackets() {
+        let tv = apply(initialText: "text", selection: NSRange(location: 4, length: 0)) { coord in
+            let note = Notification(name: .init("test"), userInfo: ["url": "https://a.b"])
+            coord.didMarkdownLink(note)
+        }
+        #expect(tv.string == "text[](https://a.b)")
+        #expect(tv.selectedRange().location == 5)
+    }
+
+    // MARK: - Code block
+
+    @Test func codeBlockInsertsAtEnd() {
+        let tv = apply(initialText: "a b", selection: NSRange(location: 1, length: 0)) {
+            $0.didMarkdownCodeBlock(nil)
+        }
+        #expect(tv.string == "a\n```\n\n```\n b")
+        #expect(tv.selectedRange().location == 6)
+    }
+
+    @Test func codeBlockInsertsMidText() {
+        let tv = apply(initialText: "before after", selection: NSRange(location: 6, length: 0)) {
+            $0.didMarkdownCodeBlock(nil)
+        }
+        #expect(tv.string == "before\n```\n\n```\n after")
+    }
+
+    // MARK: - Horizontal rule
+
+    @Test func horizontalRuleAtEnd() {
+        let tv = apply(initialText: "line\n", selection: NSRange(location: 5, length: 0)) {
+            $0.didMarkdownHorizontalRule(nil)
+        }
+        #expect(tv.string == "line\n---\n")
+    }
+
+    @Test func horizontalRuleMidText() {
+        let tv = apply(initialText: "a b", selection: NSRange(location: 1, length: 0)) {
+            $0.didMarkdownHorizontalRule(nil)
+        }
+        #expect(tv.string == "a\n---\n b")
+    }
+
+    // MARK: - Image
+
+    @Test func imageInserts() {
+        let tv = apply(initialText: "text", selection: NSRange(location: 4, length: 0)) { coord in
+            let note = Notification(name: .init("test"), userInfo: ["url": "img.png"])
+            coord.didMarkdownImage(note)
+        }
+        #expect(tv.string == "text![](img.png)")
+    }
+}


### PR DESCRIPTION

## Description

### Motivation

Embedders need to trigger text formatting from external UI — a SwiftUI toolbar, an AppKit menu bar, or a custom palette — without reaching into the engine's private `NSTextView`. Currently `MarkdownEditorBus` only exposes bold, italic, and heading. Strikethrough, inline code, blockquote, lists, link insertion, code blocks, and horizontal rules are missing from the notification bridge, forcing embedders to duplicate formatting logic or hack around private internals.

Additionally, inline-formatter UX is poor when the user hasn't made a text selection: the engine inserts empty markers (`****`) even when the cursor sits inside a word like `|word`. The expected behaviour in modern editors is to wrap the containing word.

### What this PR does

**9 new bus notification types** — `applyStrikethroughRequest`, `applyInlineCodeRequest`, `applyBlockquoteRequest`, `applyUnorderedListRequest`, `applyOrderedListRequest`, `applyLinkRequest`, `applyCodeBlockRequest`, `applyHorizontalRuleRequest`, `applyImageRequest`. Each mirrors the existing `applyBoldRequest` / `applyItalicRequest` / `applyHeadingRequest` pattern: embedders post via `NotificationCenter`, the coordinator applies the action.

**Corresponding `didMarkdown*` actions** on the coordinator: `didMarkdownStrikethrough`, `didMarkdownInlineCode`, `didMarkdownBlockquote`, `didMarkdownLink`, `didMarkdownCodeBlock`, `didMarkdownHorizontalRule`, `didMarkdownImage`. All callable directly or through the bus.

**Word-boundary auto-detect** in the four inline formatters (`didMarkdownBold`, `didMarkdownItalic`, `didMarkdownStrikethrough`, `didMarkdownInlineCode`): when the selection length is zero and the cursor is adjacent to alphanumeric / underscore characters, the containing word is auto-selected and wrapped. The cursor offset within the word is preserved (e.g. `wo|rd` → `**wo|rd**`). If no word character is found, empty markers are inserted as before.

**Bug fix** — blockquote removal no longer doubles trailing newlines.

**21 headless tests** in `FormattingActionTests` covering all new actions and edge cases.

### Breaking changes

None. All new bus properties and action methods are additive; existing embedders that supply a `MarkdownEditorBus` without the new names are unaffected. The word-boundary behaviour is a UX improvement and does not alter the text result of an existing selection.

---

### Note: potential split

This PR bundles two independent features:

1. **Bus extension + new formatting actions** (strikethrough, inline code, blockquote, link, lists, code block, hr, image)
2. **Word-boundary auto-detect** (applied to bold, italic, strikethrough, inline code)

If you prefer smaller / more focused PRs I can split them. Please let me know.