### PR TITLE
feat(cursor): add isCursorExcluded closure to suppress I-beam over exclusion zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   displayed text differs from the source — e.g. node links rendered shorter than `[[Name|UUID]]`,
   LaTeX, or images — which the legacy `findScrollToRange` (host-computed source-coordinate ranges)
   highlighted at the wrong offset. Opt-in; `findScrollToRange` is unchanged for existing embedders.
+- `NativeTextView.isCursorExcluded: ((CGPoint) -> Bool)?` — embedder-supplied
+  predicate that suppresses the edit-mode I-beam cursor when the mouse is inside
+  a defined exclusion zone (e.g. a formatting toolbar). When the closure returns
+  `true`, `mouseMoved:` skips calling `super.mouseMoved` to avoid NSTextView's
+  built-in I-beam cursor, setting the arrow cursor instead. Exposed through
+  `NativeTextViewWrapper.isCursorExcluded`.
 
 ## [0.7.1] - 2026-06-20
 
@@ -34,8 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Scroll position is remembered per document across switches, and Writing Tools
   results stay styled and visible after accept. (#70)
 - Empty-file placeholder no longer clips to one line after a view rebuild. (#69)
-
-## [Unreleased]
 
 ### Added
 - Scroll-away header: `NativeTextViewWrapper` gains `header: AnyView?`,

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -12,13 +12,28 @@ import AppKit
 extension NativeTextView {
 
     override func mouseMoved(with event: NSEvent) {
-        super.mouseMoved(with: event)
-        applyReadOnlyCursor(for: event)
+        if isInCursorExclusionZone(event) {
+            NSCursor.arrow.set()
+        } else {
+            super.mouseMoved(with: event)
+            applyReadOnlyCursor(for: event)
+        }
     }
 
     override func mouseEntered(with event: NSEvent) {
         super.mouseEntered(with: event)
-        applyReadOnlyCursor(for: event)
+        if isInCursorExclusionZone(event) {
+            NSCursor.arrow.set()
+        } else {
+            applyReadOnlyCursor(for: event)
+        }
+    }
+
+    /// True when the mouse is inside an embedder-defined exclusion zone
+    /// (e.g. a formatting toolbar) and edit-mode I-beam should be suppressed.
+    private func isInCursorExclusionZone(_ event: NSEvent) -> Bool {
+        guard isEditable, let excluded = isCursorExcluded else { return false }
+        return excluded(event.locationInWindow)
     }
 
     /// In read-only mode, override NSTextView's I-beam: pointing hand over a

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -57,6 +57,12 @@ final class NativeTextView: NSTextView {
     /// managed by `NativeTextView+Placeholder.swift`.
     weak var placeholderView: PlaceholderLabelView?
 
+    // MARK: Cursor exclusion
+    /// Embedder-supplied predicate that suppresses the I-beam cursor in edit mode.
+    /// Called on every mouse-move with the event location in window coordinates.
+    /// Return `true` to show the arrow cursor instead of the edit-mode I-beam.
+    var isCursorExcluded: ((CGPoint) -> Bool)?
+
     // MARK: Wide-table overlay state
     /// Live NSScrollView per wide table; keyed by source-ID hash.
     var wideTableOverlays: [Int: WideTableOverlay] = [:]

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -117,6 +117,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// documentIds whose scroll offset to keep; others are forgotten. `nil` keeps all.
     public var retainedScrollDocumentIds: Set<String>?
 
+    /// Embedder-supplied predicate that suppresses the I-beam cursor in edit mode.
+    /// Called on mouse-move with the event location in window coordinates.
+    /// Return `true` to show the arrow cursor instead of the I-beam.
+    public var isCursorExcluded: ((CGPoint) -> Bool)?
+
     public init(
         text: Binding<String>,
         isWikiLinkActive: Binding<Bool> = .constant(false),
@@ -136,7 +141,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         header: AnyView? = nil,
         headerCollapsedHeight: CGFloat = 0,
         headerExpanded: Bool = true,
-        retainedScrollDocumentIds: Set<String>? = nil
+        retainedScrollDocumentIds: Set<String>? = nil,
+        isCursorExcluded: ((CGPoint) -> Bool)? = nil
     ) {
         self._text = text
         self._isWikiLinkActive = isWikiLinkActive
@@ -157,6 +163,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.headerCollapsedHeight = headerCollapsedHeight
         self.headerExpanded = headerExpanded
         self.retainedScrollDocumentIds = retainedScrollDocumentIds
+        self.isCursorExcluded = isCursorExcluded
     }
 
     public func sizeThatFits(
@@ -246,6 +253,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.font = font
         textView.baseFont = font
         textView.allowsUndo = true
+        textView.isCursorExcluded = isCursorExcluded
         textView.isAutomaticSpellingCorrectionEnabled = configuration.spellChecking.automaticSpellingCorrection
         textView.isContinuousSpellCheckingEnabled = configuration.spellChecking.continuousSpellChecking
         textView.isGrammarCheckingEnabled = configuration.spellChecking.grammarChecking
@@ -402,6 +410,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
 
         textView.onPasteImage = onPasteImage
+        textView.isCursorExcluded = isCursorExcluded
         textView.setPlaceholder(placeholder)
         // Sync heightBehavior across all three layers (scroll view, text view,
         // coordinator) so a runtime switch fully reconfigures.


### PR DESCRIPTION
## Summary

Add `NativeTextView.isCursorExcluded` — a closure-based API that lets embedders define mouse regions where the edit-mode I-beam cursor should be suppressed in favor of the standard arrow cursor.

## Problem

`NSTextView` unconditionally sets the I-beam cursor in its `mouseMoved:` implementation. This is correct while the mouse hovers over editable text, but there is no way for embedders to carve out exceptions — for example, a floating formatting toolbar rendered as a sibling `NSView` above the scroll view. The embedder's cursor rects and tracking areas on the toolbar have no effect because `NSTextView`'s own `mouseMoved:` fires on every pixel movement and overrides them.

We encountered this while building a formatting toolbar overlay (`HStack` of bold, italic, heading buttons, etc.) that floats at the bottom of the editor viewport in my project. The toolbar is an AppKit `NSView` (hosting SwiftUI buttons) laid out as a sibling above the scroll view, and we needed it to show the arrow cursor instead of the I-beam.

Attempted workarounds that **do not** work:
- Adding `cursorRect` to the toolbar view — `NSTextView`'s deeper cursor rect takes priority.
- `NSTrackingArea` with `.cursorUpdate` — fires, but `NSTextView.mouseMoved:` fires afterward and resets to I-beam.
- `NSCursor.push()/pop()` — `NSTextView.mouseMoved:` calls `set()`, not `push()`, so it still overrides.

The clean solution is to give the embedder a way to tell the engine "skip the I-beam here."

## Solution

A new optional predicate on `NativeTextView`:

```swift
NativeTextViewWrapper(
    text: $text,
    configuration: ...,
    isCursorExcluded: { [weak toolbarContainer] point in
        guard let tc = toolbarContainer, !tc.isHidden else { return false }
        return tc.convert(tc.bounds, to: nil).contains(point)
    }
)
```