### PR TITLE
Wiki-links: UUID-robust labels/embeds + autocomplete keyboard nav

### DIFF
--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -32,6 +32,10 @@ public protocol WikiLinkResolver: Sendable {
     /// - Returns: A resolution if the link points at known content; `nil` otherwise.
     func resolve(displayName: String, range: NSRange) -> WikiLinkResolution?
 
+    /// Returns the target's CURRENT display name for a stable id, nil if unknown
+    /// (renderer falls back to the stored label).
+    func name(forID id: String) -> String?
+
     /// Coarse fingerprint of the resolver's known targets (typically IDs + names).
     /// A different value triggers a wiki-link restyle, so a rename refreshes link
     /// clickability/display without waiting for the next keystroke.
@@ -40,6 +44,7 @@ public protocol WikiLinkResolver: Sendable {
 
 public extension WikiLinkResolver {
     func fingerprint() -> AnyHashable { 0 }
+    func name(forID id: String) -> String? { nil }
 }
 
 /// The result of resolving a wiki-link.

--- a/Sources/MarkdownEngine/Services/WikiLinkService.swift
+++ b/Sources/MarkdownEngine/Services/WikiLinkService.swift
@@ -47,7 +47,7 @@ public enum WikiLinkService {
     }
 
     /// Regex pattern matching the storage form `[[Name|optional-id]]`.
-    public static let storagePattern = #"(?<!!)\[\[([^\|\]\r\n]*)(?:\|([^\]\r\n]+))?\]\]"#
+    public static let storagePattern = #"!?\[\[([^\|\]\r\n]*)(?:\|([^\]\r\n]+))?\]\]"#
     /// Regex pattern matching the display form `[[Name]]` (no `|`).
     public static let displayPattern = #"(?<!!)\[\[([^\]\r\n]*)\]\]"#
 
@@ -56,7 +56,15 @@ public enum WikiLinkService {
     private static let logger = Logger(subsystem: "com.markdownengine.wikilinks", category: "WikiLink")
 
     /// Convert storage form `[[Name|<id>]]` to display `[[Name]]`, returning a display-range metadata map.
-    public static func makeDisplayState(from storageText: String) -> (display: String, metadata: [RangeKey: LinkMetadata]) {
+    ///
+    /// When `nameForID` is supplied, each matched link's stored label is replaced in the
+    /// DISPLAY text by the target's current name looked up via the opaque suffix's uuid
+    /// (the suffix itself — uuid for links, uuid|width for images — is preserved unchanged
+    /// in the metadata). Unknown/empty/unsafe live names fall back to the stored label.
+    public static func makeDisplayState(
+        from storageText: String,
+        nameForID: ((String) -> String?)? = nil
+    ) -> (display: String, metadata: [RangeKey: LinkMetadata]) {
         let nsStorage = storageText as NSString
         let fullRange = NSRange(location: 0, length: nsStorage.length)
         var result = ""
@@ -77,10 +85,7 @@ public enum WikiLinkService {
 
             let nameRange = match.range(at: 1)
             let name = nsStorage.substring(with: nameRange)
-            let displayFragment = "[[\(name)]]"
-            let displayRange = NSRange(location: displayLength, length: displayFragment.utf16.count)
-            result.append(displayFragment)
-            displayLength += displayFragment.utf16.count
+            let isImage = nsStorage.character(at: match.range.location) == 0x21 // '!'
 
             var linkID: String? = nil
             if match.numberOfRanges > 2 {
@@ -89,6 +94,23 @@ public enum WikiLinkService {
                     linkID = nsStorage.substring(with: idRange)
                 }
             }
+
+            // Auto-sync the DISPLAY label to the target's current name (looked up by the
+            // uuid carried in the suffix). The suffix in metadata.id stays untouched.
+            var displayName = name
+            if let linkID, let nameForID {
+                let bareID = linkID.split(separator: "|", maxSplits: 1).first.map(String.init) ?? linkID
+                if let live = nameForID(bareID), !live.isEmpty,
+                   live.rangeOfCharacter(from: CharacterSet(charactersIn: "|]\n\r")) == nil {
+                    displayName = live
+                }
+            }
+
+            let displayFragment = isImage ? "![[\(displayName)]]" : "[[\(displayName)]]"
+            let displayRange = NSRange(location: displayLength, length: displayFragment.utf16.count)
+            result.append(displayFragment)
+            displayLength += displayFragment.utf16.count
+
             metadata[RangeKey(displayRange)] = LinkMetadata(id: linkID, storageRange: match.range)
             cursor = match.range.location + match.range.length
         }
@@ -118,7 +140,7 @@ public enum WikiLinkService {
         var cursor = 0
         var storageLength = 0
 
-        for matchRange in displayLinkRanges(nsDisplay) {
+        for (matchRange, isImage) in displayLinkRanges(nsDisplay) {
             let prefixLength = matchRange.location - cursor
             if prefixLength > 0 {
                 let prefixRange = NSRange(location: cursor, length: prefixLength)
@@ -128,8 +150,9 @@ public enum WikiLinkService {
                 cursor += prefixLength
             }
 
-            let contentLength = max(0, matchRange.length - 4)
-            let contentRange = NSRange(location: matchRange.location + 2, length: contentLength)
+            let openMarker = isImage ? 3 : 2
+            let contentLength = max(0, matchRange.length - (openMarker + 2))
+            let contentRange = NSRange(location: matchRange.location + openMarker, length: contentLength)
             let name = nsDisplay.substring(with: contentRange)
 
             var linkID: String? = nil
@@ -142,11 +165,12 @@ public enum WikiLinkService {
                 linkID = existingMetadata[RangeKey(matchRange)]?.id
             }
 
+            let marker = isImage ? "![[" : "[["
             let storageFragment: String
             if let linkID, !linkID.isEmpty {
-                storageFragment = "[[\(name)|\(linkID)]]"
+                storageFragment = "\(marker)\(name)|\(linkID)]]"
             } else {
-                storageFragment = "[[\(name)]]"
+                storageFragment = "\(marker)\(name)]]"
             }
             let fragmentLength = storageFragment.utf16.count
             let storageRange = NSRange(location: storageLength, length: fragmentLength)
@@ -166,16 +190,17 @@ public enum WikiLinkService {
     }
 
     /// Hand scan for display-form wiki links `(?<!!)\[\[...\]\]`, replacing the slow regex lookbehind.
-    static func displayLinkRanges(_ s: NSString) -> [NSRange] {
+    static func displayLinkRanges(_ s: NSString) -> [(range: NSRange, isImage: Bool)] {
         let len = s.length
         guard len >= 4 else { return [] }
         var buf = [unichar](repeating: 0, count: len)   // one bulk extract, then array access
         s.getCharacters(&buf, range: NSRange(location: 0, length: len))
-        var result: [NSRange] = []
+        var result: [(range: NSRange, isImage: Bool)] = []
         var i = 0
         while i + 1 < len {
             guard buf[i] == 0x5B, buf[i + 1] == 0x5B else { i += 1; continue }   // [[
-            if i > 0, buf[i - 1] == 0x21 { i += 2; continue }                    // preceded by ! → skip
+            let isImage = i > 0 && buf[i - 1] == 0x21                            // preceded by ! → image embed
+            let start = isImage ? i - 1 : i
             var j = i + 2
             var matched = false
             while j < len {
@@ -183,7 +208,7 @@ public enum WikiLinkService {
                 if c == 0x0A || c == 0x0D { break }                             // newline → no match
                 if c == 0x5D {                                                  // ]
                     if j + 1 < len, buf[j + 1] == 0x5D {                        // ]]
-                        result.append(NSRange(location: i, length: (j + 2) - i))
+                        result.append((NSRange(location: start, length: (j + 2) - start), isImage))
                         i = j + 2
                         matched = true
                     }

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Images.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Images.swift
@@ -118,8 +118,16 @@ extension MarkdownStyler {
             if MarkdownDetection.isInsideCodeBlock(range: token.range, codeTokens: ctx.codeTokens) { continue }
 
             let isActive = ctx.activeTokenIndices.contains(idx)
-            let rawContent = ctx.nsText.substring(with: token.contentRange)
-            guard let reference = ImageEmbedReference(content: rawContent) else {
+            let rawContent = ctx.nsText.substring(with: token.contentRange)  // = display name (no suffix)
+            // The uuid|width suffix lives in the `.wikiLinkID` side-channel (same as node links).
+            let suffix = ctx.wikiLinkIDProvider(token.range)
+            // Re-apply the attribute every restyle so makeStorageState can recover the suffix on
+            // save — even on the image-not-found path (mirrors styleWikiLink). Load-bearing.
+            if let suffix, !suffix.isEmpty {
+                attrs.append((token.contentRange, [.wikiLinkID: suffix]))
+            }
+            let referenceContent = (suffix?.isEmpty == false) ? "\(rawContent)|\(suffix!)" : rawContent
+            guard let reference = ImageEmbedReference(content: referenceContent) else {
                 appendSecondaryMarkers(for: token, to: &attrs, theme: ctx.configuration.theme)
                 continue
             }

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -29,6 +29,7 @@ extension MarkdownStyler {
         let codeBackgroundColor: NSColor
         let latexMarkerFont: NSFont
         let configuration: MarkdownEditorConfiguration
+        let wikiLinkIDProvider: (NSRange) -> String?
 
         var services: MarkdownEditorServices { configuration.services }
     }
@@ -73,7 +74,8 @@ enum MarkdownStyler {
             codeBackgroundColor: codeBackgroundColor,
             latexMarkerFont: NSFont(name: fontName, size: hiddenMarkerSize)
                 ?? NSFont.systemFont(ofSize: hiddenMarkerSize),
-            configuration: configuration
+            configuration: configuration,
+            wikiLinkIDProvider: wikiLinkIDProvider
         )
 
         var result: [StyledRange] = []

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -97,7 +97,6 @@ extension NativeTextViewWrapper.Coordinator {
             tv.didChangeText()
             let newSelectionLocation = token.range.location + leftReplacement.count
             tv.setSelectedRange(NSRange(location: newSelectionLocation, length: content.count))
-            DispatchQueue.main.async { self.text = tv.string }
         }
     }
 
@@ -136,7 +135,6 @@ extension NativeTextViewWrapper.Coordinator {
             tv.didChangeText()
             let newSel = NSRange(location: lineRange.location + prefix.count, length: content.count)
             tv.setSelectedRange(newSel)
-            DispatchQueue.main.async { self.text = tv.string }
         }
     }
 
@@ -163,7 +161,6 @@ extension NativeTextViewWrapper.Coordinator {
             tv.didChangeText()
             let newSel = NSRange(location: startLine.location + prefix.count, length: content.count)
             tv.setSelectedRange(newSel)
-            DispatchQueue.main.async { self.text = tv.string }
         }
     }
 
@@ -221,7 +218,6 @@ extension NativeTextViewWrapper.Coordinator {
             tv.replaceCharacters(in: range, with: insertion)
             tv.didChangeText()
             tv.setSelectedRange(NSRange(location: range.location + marker.count, length: 0))
-            DispatchQueue.main.async { self.text = tv.string }
         }
     }
 
@@ -243,7 +239,6 @@ extension NativeTextViewWrapper.Coordinator {
             tv.didChangeText()
             let newRange = NSRange(location: range.location + leadingWS + marker.count, length: core.count)
             tv.setSelectedRange(newRange)
-            DispatchQueue.main.async { self.text = tv.string }
         }
     }
 }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -20,7 +20,8 @@ extension NativeTextViewCoordinator {
         invalidateLayout: Bool = false
     ) {
         // Storage is raw Markdown; only wiki links transform on display.
-        let displayState = WikiLinkService.makeDisplayState(from: text)
+        let services = configuration.services
+        let displayState = WikiLinkService.makeDisplayState(from: text) { services.wikiLinks.name(forID: $0) }
         let displayText = displayState.display
         wikiLinkMetadata = displayState.metadata
 
@@ -63,6 +64,11 @@ extension NativeTextViewCoordinator {
             layoutBridge: layoutBridge,
             caretLocation: caretLocation,
             activeTokenIndices: activeTokenIndices,
+            // FIX: apply .wikiLinkID attributes on load/node-switch too. Without this the uuid
+            // survived only in the range-keyed wikiLinkMetadata; once a later writeback shifted a
+            // link's range the metadata key missed and makeStorageState wrote [[Name]] (uuid lost).
+            // wikiLinkMetadata was just refreshed by makeDisplayState above, so ranges match here.
+            wikiLinkIDProvider: { [weak self] range in self?.wikiLinkID(for: range) },
             precomputedTokens: tokens,
             configuration: configuration
         )
@@ -249,16 +255,11 @@ extension NativeTextViewCoordinator {
             return
         }
 
-        let replacementDisplay: String
-        let linkID: String?
-        if request.isImageEmbedMode {
-            replacementDisplay = request.storageFragment
-            linkID = nil
-        } else {
-            let replacementInfo = WikiLinkService.displayFragmentAndID(from: request.storageFragment)
-            replacementDisplay = replacementInfo.display
-            linkID = replacementInfo.id
-        }
+        // Image embeds and node links share one path: insert DISPLAY form `![[Name]]` / `[[Name]]`
+        // with the opaque suffix on the `.wikiLinkID` side-channel (displayFragmentAndID handles `!`).
+        let replacementInfo = WikiLinkService.displayFragmentAndID(from: request.storageFragment)
+        let replacementDisplay = replacementInfo.display
+        let linkID = replacementInfo.id
 
         let undoActionName = request.isImageEmbedMode ? "Insert Image Embed" : "Insert Link"
         textView.breakUndoCoalescing()
@@ -273,9 +274,11 @@ extension NativeTextViewCoordinator {
         textView.textStorage?.replaceCharacters(in: range, with: replacementDisplay)
 
         if let linkID, !linkID.isEmpty {
-            let contentLength = max(0, (replacementDisplay as NSString).length - 4)
+            let isImage = replacementDisplay.hasPrefix("![[")
+            let openLen = isImage ? 3 : 2
+            let contentLength = max(0, (replacementDisplay as NSString).length - (openLen + 2))
             if contentLength > 0 {
-                let contentRange = NSRange(location: range.location + 2, length: contentLength)
+                let contentRange = NSRange(location: range.location + openLen, length: contentLength)
                 textView.textStorage?.addAttribute(.wikiLinkID, value: linkID, range: contentRange)
             }
         }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -218,6 +218,43 @@ extension NativeTextViewCoordinator {
         let prevActive = activeTokenIndices
         activeTokenIndices = MarkdownDetection.computeActiveTokenIndices(selectionRange: selRange, tokens: tokens, in: nsText, suppressed: !tv.isEditable)
         filterImageEmbedActiveTokens(parsed: parsed, text: nsText, selectionLocation: selRange.location)
+
+        // Snap-back: when the caret LEFT a wiki/image token, re-sync its displayed name to the live target name.
+        if selRange.length == 0,
+           currentEventType != .leftMouseDragged, currentEventType != .periodic,
+           !isProgrammaticEdit, !tv.hasMarkedText() {
+            let leftTokens = prevActive.subtracting(activeTokenIndices)
+            for idx in leftTokens.sorted() where idx >= 0 && idx < tokens.count {
+                let token = tokens[idx]
+                guard token.kind == .wikiLink || token.kind == .imageEmbed else { continue }
+                if let newCaret = resyncWikiLinkNameOnLeave(tv, token: token, caretLoc: selRange.location) {
+                    // Dismiss any inline preview before the early return (the nested setSelectedRange
+                    // re-entry recomputes it for the final caret, but clear it here too — mirrors :203-205).
+                    isImageEmbedActive = false
+                    isWikiLinkActive = false
+                    onInlineSelectionChange?(nil)
+                    let clamped = min(max(newCaret, 0), (tv.string as NSString).length)
+                    // Only re-settle (and suppress the reveal) when the caret actually moved. If the
+                    // link was AFTER the caret the location is unchanged → setSelectedRange would be a
+                    // no-op that never consumes suppressAutoRevealOnce, leaking it onto the next reveal.
+                    if clamped != selRange.location {
+                        (tv as? NativeTextView)?.suppressAutoRevealOnce = true
+                        tv.setSelectedRange(NSRange(location: clamped, length: 0))
+                    }
+                    // The snap-back's didChangeText restyles the CARET's paragraph, not the LINK's, so
+                    // the link keeps its pre-leave ACTIVE styling (raw [[ ]] stays visible). Restyle the
+                    // link's own paragraph (token.range.location is before the in-name edit, so it's
+                    // stable) — the caret is now outside, so its markers collapse to a rendered link.
+                    let healedNS = tv.string as NSString
+                    if healedNS.length > 0 {
+                        let linkPara = healedNS.paragraphRange(for: NSRange(location: min(token.range.location, healedNS.length - 1), length: 0))
+                        restyleParagraphs([linkPara], in: tv)
+                    }
+                    return
+                }
+            }
+        }
+
         updateAutocorrectSettings(
             tv,
             caretLocation: selLoc,
@@ -336,7 +373,20 @@ extension NativeTextViewCoordinator {
         if let inlineContext {
             let openingMarkerLength = inlineContext.selectionKind == .imageEmbed ? 3 : 2
             let displayRange = selectionDisplayRange(for: inlineContext.token, openingMarkerLength: openingMarkerLength)
-            let placeholder = nsString.substring(with: displayRange)
+            // Image embeds: rebuild the placeholder as the STORAGE form (`![[Name|uuid|width]]`) so
+            // NodeLinkPreview's ImageEmbedReference.parse can recover the width on re-pick. The width
+            // no longer lives in the editor text — it sits in the `.wikiLinkID` side-channel.
+            let placeholder: String
+            if case .imageEmbed(let token) = inlineContext {
+                let embedName = nsString.substring(with: token.contentRange)
+                if let suffix = wikiLinkID(for: token.range), !suffix.isEmpty {
+                    placeholder = "![[\(embedName)|\(suffix)]]"
+                } else {
+                    placeholder = "![[\(embedName)]]"
+                }
+            } else {
+                placeholder = nsString.substring(with: displayRange)
+            }
             let storageRange = inlineContext.selectionKind == .wikiLink
                 ? storageRange(containingDisplayLocation: selLocation) ?? storageRange(forDisplayRange: displayRange)
                 : nil

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -482,7 +482,7 @@ extension NativeTextViewCoordinator {
             switch commandSelector {
             case #selector(NSResponder.moveUp(_:)): key = .moveUp
             case #selector(NSResponder.moveDown(_:)): key = .moveDown
-            case #selector(NSResponder.insertNewline(_:)): key = .confirm
+            case #selector(NSResponder.insertNewline(_:)): key = .confirm   // ⌘↵ → handled in performKeyEquivalent
             case #selector(NSResponder.cancelOperation(_:)): key = .cancel
             default: key = nil
             }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -393,8 +393,11 @@ extension NativeTextViewCoordinator {
             let previewRect = tv.viewRect(forCharacterRange: displayRange, using: layoutBridge)
                 ?? tv.viewRect(forCharacterRange: tv.selectedRange(), using: layoutBridge)
 
+            // Only autocomplete while TYPING — not when the caret merely lands in an existing link via
+            // a click (mirrors the image-embed gate). Clicking into a complete [[Name]] shouldn't pop
+            // the picker; typing a name does.
             let shouldShowInlinePreview =
-                inlineContext.selectionKind == .wikiLink
+                (inlineContext.selectionKind == .wikiLink && isTyping)
                 || (inlineContext.selectionKind == .imageEmbed && imageEmbedShowsInlinePreview)
             if shouldShowInlinePreview, let previewRect {
                 let selection = WikiLinkSelection(
@@ -471,6 +474,19 @@ extension NativeTextViewCoordinator {
     public func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
         if commandSelector == #selector(NSResponder.insertBacktab(_:)) {
             return handleBacktab(textView)
+        }
+        // While an inline [[…]] / ![[…]] preview is open, route ↑/↓/Enter/Esc to the embedder's
+        // autocomplete list (it returns true to consume the key; false → normal editor handling).
+        if (isWikiLinkActive || isImageEmbedActive), let handler = onInlinePreviewKey {
+            let key: InlinePreviewKey?
+            switch commandSelector {
+            case #selector(NSResponder.moveUp(_:)): key = .moveUp
+            case #selector(NSResponder.moveDown(_:)): key = .moveDown
+            case #selector(NSResponder.insertNewline(_:)): key = .confirm
+            case #selector(NSResponder.cancelOperation(_:)): key = .cancel
+            default: key = nil
+            }
+            if let key, handler(key) { return true }
         }
         return false
     }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -476,6 +476,33 @@ extension NativeTextViewCoordinator {
     }
 
     public func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+        // Edit zone: a click on the outer ~30% of a node link's first/last name char places the caret
+        // just outside the markers (before '[[' / after ']]') to reveal the source for editing instead
+        // of navigating. Editable views only — read-only links must stay navigable.
+        if textView.isEditable, let storage = textView.textStorage {
+            var linkRange = NSRange(location: NSNotFound, length: 0)
+            let editZoneMinNameLength = 3   // 1–2 char names stay fully clickable for navigation
+            if storage.attribute(.link, at: charIndex, longestEffectiveRange: &linkRange,
+                                 in: NSRange(location: 0, length: storage.length)) != nil,
+               linkRange.length >= editZoneMinNameLength {
+                // Caret lands on the token's markers (no .link there, so the mouse-on-link guard in
+                // textViewDidChangeSelection doesn't suppress the reveal).
+                let token = parsedDocument(for: textView.string).tokens
+                    .first { $0.kind == .wikiLink && NSLocationInRange(charIndex, $0.range) }
+                let edgeFraction: CGFloat = 0.3
+                let frac = clickFractionThroughGlyph(textView, charIndex: charIndex)
+                if charIndex == linkRange.location, frac.map({ $0 <= edgeFraction }) ?? true {
+                    let caret = token?.range.location ?? linkRange.location          // before '[['
+                    textView.setSelectedRange(NSRange(location: caret, length: 0))
+                    return true
+                }
+                if charIndex == NSMaxRange(linkRange) - 1, frac.map({ $0 >= 1 - edgeFraction }) ?? true {
+                    let caret = token.map { NSMaxRange($0.range) } ?? NSMaxRange(linkRange)  // after ']]'
+                    textView.setSelectedRange(NSRange(location: caret, length: 0))
+                    return true
+                }
+            }
+        }
         guard let target = WikiLinkService.resolveIdentifier(link: link, textView: textView, at: charIndex) else {
             return false
         }
@@ -485,6 +512,26 @@ extension NativeTextViewCoordinator {
             self.onLinkClick?(target)
         }
         return true
+    }
+
+    /// Horizontal fraction (0 = leading, 1 = trailing) of the current click through the glyph at
+    /// `charIndex`, or nil if unresolved. Coordinates mirror NativeTextView+CursorRects.
+    private func clickFractionThroughGlyph(_ textView: NSTextView, charIndex: Int) -> CGFloat? {
+        guard let event = NSApp.currentEvent,
+              let tlm = textView.textLayoutManager,
+              let tcm = tlm.textContentManager,
+              let start = tcm.location(tlm.documentRange.location, offsetBy: charIndex),
+              let end = tcm.location(start, offsetBy: 1),
+              let range = NSTextRange(location: start, end: end) else { return nil }
+        let viewPoint = textView.convert(event.locationInWindow, from: nil)
+        let containerX = viewPoint.x - textView.textContainerOrigin.x
+        var glyphFrame: CGRect?
+        tlm.enumerateTextSegments(in: range, type: .standard, options: []) { _, segFrame, _, _ in
+            glyphFrame = segFrame
+            return false
+        }
+        guard let f = glyphFrame, f.width > 0 else { return nil }
+        return (containerX - f.minX) / f.width
     }
 
     func updateSelectionStates(_ tv: NSTextView) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WikiLinkSnapback.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WikiLinkSnapback.swift
@@ -1,0 +1,64 @@
+//
+//  NativeTextViewCoordinator+WikiLinkSnapback.swift
+//  MarkdownEngine
+//
+//  Snap-back: when the caret LEAVES a `[[Name]]` / `![[Name]]` token, re-sync the
+//  token's DISPLAYED name to the target node's CURRENT name (via the resolver) —
+//  so a manually-edited/drifted label corrects itself the moment you click/move
+//  out of the link, like a Notion mention. This is the live-editing counterpart
+//  to `WikiLinkService.makeDisplayState`, which only re-injects the live name on a
+//  full rebuild/load. The on-disk storage then heals via the normal
+//  `makeStorageState` writeback on the next `textDidChange`.
+//
+//  Modeled on the proven surgical core of `applyInlineReplacement`
+//  (+Restyling.swift) but stripped to the snap-back job and owning its own caret
+//  + undo contract (one isolated, named "Update Link Name" step).
+//
+
+import AppKit
+
+extension NativeTextViewCoordinator {
+    /// When the caret LEAVES a `[[Name]]` / `![[Name]]` token, re-sync the displayed
+    /// name to the target node's current name (via the resolver). Returns the caret
+    /// location the caller should re-settle to (delta-adjusted), or nil if it did nothing.
+    @discardableResult
+    func resyncWikiLinkNameOnLeave(_ textView: NSTextView, token: MarkdownToken, caretLoc: Int) -> Int? {
+        guard !isProgrammaticEdit, !textView.hasMarkedText(), !isWritingToolsActive else { return nil }
+        guard token.kind == .wikiLink || token.kind == .imageEmbed else { return nil }
+        guard let storage = textView.textStorage else { return nil }
+        let contentRange = token.contentRange
+        let docLen = storage.length
+        guard contentRange.location != NSNotFound, contentRange.length > 0,
+              NSMaxRange(contentRange) <= docLen else { return nil }
+        // Defensive: only re-sync once the caret has actually LEFT the token (the caret-delta math below assumes it).
+        guard !NSLocationInRange(caretLoc, contentRange) else { return nil }
+        // Opaque suffix (uuid or uuid|width) lives in .wikiLinkID, uniform over the name run.
+        guard let suffix = storage.attribute(.wikiLinkID, at: contentRange.location, effectiveRange: nil) as? String,
+              !suffix.isEmpty else { return nil }
+        let bareID = suffix.split(separator: "|", maxSplits: 1).first.map(String.init) ?? suffix
+        // Reject names with [[ ]] grammar chars (incl. '[') so a bracketed node name falls back to the stored label.
+        guard let live = configuration.services.wikiLinks.name(forID: bareID), !live.isEmpty,
+              live.rangeOfCharacter(from: CharacterSet(charactersIn: "|]\n\r[")) == nil else { return nil }
+        let currentName = (storage.string as NSString).substring(with: contentRange)
+        guard live != currentName else { return nil } // no churn + loop terminator
+
+        textView.breakUndoCoalescing()
+        isProgrammaticEdit = true
+        defer { isProgrammaticEdit = false }
+        guard textView.shouldChangeText(in: contentRange, replacementString: live) else { return nil }
+        storage.replaceCharacters(in: contentRange, with: live)
+        let newContentRange = NSRange(location: contentRange.location, length: (live as NSString).length)
+        storage.addAttribute(.wikiLinkID, value: suffix, range: newContentRange)
+        // Suppress the auto-reveal that didChangeText's writeback can trigger (a tall image embed
+        // would otherwise scroll-jump on snap-back). The caller suppresses the final setSelectedRange too.
+        (textView as? NativeTextView)?.suppressAutoRevealOnce = true
+        textView.didChangeText()
+        textView.undoManager?.setActionName("Update Link Name")
+        textView.breakUndoCoalescing()
+
+        let delta = (live as NSString).length - contentRange.length
+        // Caret is OUTSIDE the token (it just left). Shift only if the link is before the caret.
+        let newCaret = (NSMaxRange(contentRange) <= caretLoc) ? caretLoc + delta : caretLoc
+        return newCaret
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -61,6 +61,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var onLinkClick: ((String) -> Void)?
     var onCaretRectChange: ((CGRect) -> Void)?
     var onInlineSelectionChange: ((InlineSelectionState?) -> Void)?
+    var onInlinePreviewKey: ((InlinePreviewKey) -> Bool)?
     var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
     var didInitialFormatting: Bool = false
     /// One-shot guard so `updateCodeBlockSelection` only forces a full-document layout once per document.

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
@@ -1,0 +1,24 @@
+//
+//  NativeTextView+CmdReturn.swift
+//  MarkdownEngine
+//
+//  ⌘↵ ("link & open") for the inline [[…]] preview. AppKit does NOT route ⌘+Return
+//  through doCommandBy(insertNewline:), so we intercept it as a key equivalent — which
+//  fires first for ⌘-combos — and forward `.confirmAndOpen` to the embedder.
+//
+
+import AppKit
+
+extension NativeTextView {
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+           event.keyCode == 36 || event.keyCode == 76,            // Return / keypad Enter
+           let coord = delegate as? NativeTextViewCoordinator,
+           coord.isWikiLinkActive || coord.isImageEmbedActive,
+           let handler = coord.onInlinePreviewKey,
+           handler(.confirmAndOpen) {
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -325,10 +325,25 @@ extension NativeTextView {
         tlm.enumerateTextLayoutFragments(from: start, options: [.ensuresLayout]) { fragment in
             let cv = scrollView.contentView
             let insetsTop = scrollView.contentInsets.top
-            // Fragment frames are text-view-local; the scroll offset below is in
-            // document-view space, so lift them by the text view's offset inside the
-            // container (the header band).
-            let frame = fragment.layoutFragmentFrame.offsetBy(dx: 0, dy: self.frame.origin.y)
+            // Reveal the CARET's line, not the whole layout fragment. An active image/latex embed
+            // renders its block below the source line via paragraphSpacing, so layoutFragmentFrame is
+            // as tall as the image; revealing its maxY would scroll the viewport down by the block
+            // height even though the caret sits on the source line at the top. Frames are text-view-
+            // local; lift by the text view's offset inside the container (the header band).
+            var revealRect = fragment.layoutFragmentFrame
+            // Reveal the ACTUAL caret location's segment (not the stepped-back revealOffset), so a
+            // freshly soft-wrapped last line at the document end still scrolls into view; fall back to
+            // the stepped-back offset only when the true end-of-document has no segment of its own.
+            for segOffset in [min(range.location, docLength), revealOffset] {
+                guard let segLoc = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: segOffset) else { continue }
+                var found = false
+                tlm.enumerateTextSegments(in: NSTextRange(location: segLoc), type: .standard, options: []) { _, segFrame, _, _ in
+                    if segFrame.height > 0 { revealRect = segFrame; found = true }   // caret rect = its line, not the block
+                    return false
+                }
+                if found { break }
+            }
+            let frame = revealRect.offsetBy(dx: 0, dy: self.frame.origin.y)
             let visibleTop = cv.bounds.origin.y + insetsTop
             let visibleBottom = cv.bounds.origin.y + cv.bounds.height
             let margin: CGFloat = 24

--- a/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
@@ -50,6 +50,13 @@ public struct InlineSelectionState: Sendable {
     }
 }
 
+/// A keyboard command forwarded to an open inline preview (the `[[…]]` autocomplete)
+/// via ``NativeTextViewWrapper/onInlinePreviewKey``. The embedder returns `true` to
+/// consume the key (it drove its list), or `false` to let the editor handle it normally.
+public enum InlinePreviewKey: Sendable {
+    case moveUp, moveDown, confirm, cancel
+}
+
 /// Request to replace an inline token's source with a new storage fragment.
 ///
 /// Embedders push one of these into

--- a/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
@@ -54,7 +54,7 @@ public struct InlineSelectionState: Sendable {
 /// via ``NativeTextViewWrapper/onInlinePreviewKey``. The embedder returns `true` to
 /// consume the key (it drove its list), or `false` to let the editor handle it normally.
 public enum InlinePreviewKey: Sendable {
-    case moveUp, moveDown, confirm, cancel
+    case moveUp, moveDown, confirm, confirmAndOpen, cancel
 }
 
 /// Request to replace an inline token's source with a new storage fragment.

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -230,7 +230,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.isEditable = isEditable
         textView.isSelectable = true
         textView.isRichText = true
-        let initialState = WikiLinkService.makeDisplayState(from: text)
+        let initialState = WikiLinkService.makeDisplayState(from: text) { configuration.services.wikiLinks.name(forID: $0) }
         textView.string = initialState.display
         textView.delegate = context.coordinator
         textView.isVerticallyResizable = true

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -86,6 +86,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// Fires when the caret enters or leaves a `[[Name]]` or `![[…]]`
     /// token. `nil` means the caret is no longer inside such a token.
     public var onInlineSelectionChange: ((InlineSelectionState?) -> Void)?
+    /// Fires on ↑/↓/Enter/Esc while an inline `[[…]]` preview is open, so the
+    /// embedder can drive its autocomplete list. Return `true` to consume the key.
+    public var onInlinePreviewKey: ((InlinePreviewKey) -> Bool)?
     /// Fires when the set of visible code blocks changes, so embedders can
     /// overlay copy buttons (see ``CodeBlockButton``).
     public var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
@@ -130,6 +133,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
         onInlineSelectionChange: ((InlineSelectionState?) -> Void)? = nil,
+        onInlinePreviewKey: ((InlinePreviewKey) -> Bool)? = nil,
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
         onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
         placeholder: NSAttributedString? = nil,
@@ -150,6 +154,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
         self.onInlineSelectionChange = onInlineSelectionChange
+        self.onInlinePreviewKey = onInlinePreviewKey
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
         self.placeholder = placeholder
@@ -289,6 +294,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.wikiLinkMetadata = initialState.metadata
         context.coordinator.onCaretRectChange = onCaretRectChange
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
+        context.coordinator.onInlinePreviewKey = onInlinePreviewKey
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
 
         textView.recalcOverscroll(for: scrollView)
@@ -551,6 +557,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
         context.coordinator.onCaretRectChange = onCaretRectChange
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
+        context.coordinator.onInlinePreviewKey = onInlinePreviewKey
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         context.coordinator.didInitialFormatting = true
     }
@@ -569,6 +576,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.lastImageFingerprint = configuration.services.images.fingerprint()
         coordinator.lastWikiFingerprint = configuration.services.wikiLinks.fingerprint()
         coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
+        coordinator.onInlinePreviewKey = onInlinePreviewKey
         coordinator.userPrefersContinuousSpellChecking = configuration.spellChecking.continuousSpellChecking
         coordinator.userPrefersGrammarChecking = configuration.spellChecking.grammarChecking
         coordinator.userPrefersAutomaticSpellingCorrection = configuration.spellChecking.automaticSpellingCorrection


### PR DESCRIPTION
## Summary
Wiki-link/image-embed robustness + a fully keyboard-driven inline `[[…]]` autocomplete.

**UUID-robust links & embeds** (`cd44967`)
- Display↔storage round-trip keeps the `|UUID` (and `|uuid|width` for embeds) in the `.wikiLinkID` side-channel; node-link UUID loss on load/restyle is fixed (the restyle now re-applies `.wikiLinkID`).
- Image embeds go through the same generalized `WikiLinkService` transform (UUID hidden in the editor like node links).
- Optional `WikiLinkResolver.name(forID:)` lets the displayed label auto-sync to the target node's current name (Notion-style), with immediate snap-back when the caret leaves a drifted label.

**Forgiving edit zone** (`f18d5b0`)
- A click on the outer sliver of a node link's first/last name glyph places the caret just outside the markers (reveals the `[[ ]]` source to edit) instead of navigating. Editable views only; centre still navigates.

**Inline-preview keyboard nav** (`05f8ba9`, `2243c9a`)
- New `onInlinePreviewKey` callback forwards ↑/↓/Enter/Esc to the embedder while a preview is open (returns `true` to consume).
- Wiki-link preview now gates on `isTyping` (like image embeds) — clicking into an existing `[[Name]]` no longer pops the picker.
- `⌘↵` ("link & open") via `performKeyEquivalent` (AppKit doesn't route ⌘+Return through `doCommandBy`).

131 tests pass.