### PR TITLE
feat: add ==highlight== inline markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `true`, `mouseMoved:` skips calling `super.mouseMoved` to avoid NSTextView's
   built-in I-beam cursor, setting the arrow cursor instead. Exposed through
   `NativeTextViewWrapper.isCursorExcluded`.
+- `==highlight==` inline markup: double-equals markers around text apply a
+  background color (configurable via `MarkdownEditorTheme.highlightColor`,
+  default `.systemOrange.withAlphaComponent(0.4)`). Content is recursively parsed so nested emphasis,
+  code, etc. work inside highlights.
+- `MarkdownEditorBus.applyHighlightRequest` /
+  `selectionHighlightDidChange`: bus notification names for driving a
+  highlight toolbar button from host UI.
 
 ## [0.7.1] - 2026-06-20
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ checkboxes.
 
 ## Features
 
-- **Live Markdown styling** — bold, italic, strikethrough, headings, lists, blockquotes, GFM tables, code, links, task checkboxes, horizontal rules 
+- **Live Markdown styling** — bold, italic, strikethrough, highlight, headings, lists, blockquotes, GFM tables, code, links, task checkboxes, horizontal rules 
 - **Wiki-style linking** with two-form storage / display roundtripping
   (`[[Name|<id>]]` ↔ `[[Name]]`)
 - **Image embeds** — both `![[Name]]` (Obsidian-style, embedder supplies the                           

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -74,6 +74,11 @@ public struct MarkdownEditorTheme: Sendable {
     /// (e.g. completed task list items, horizontal rules).
     public var strikethroughColor: NSColor
 
+    // MARK: Highlight
+
+    /// Background color used for `==highlight==` inline markup.
+    public var highlightColor: NSColor
+
     // MARK: Init
 
     public init(
@@ -87,7 +92,8 @@ public struct MarkdownEditorTheme: Sendable {
         findCurrentMatchHighlight: NSColor = .systemYellow,
         latexLightModeText: NSColor = .black,
         latexDarkModeText: NSColor = .white,
-        strikethroughColor: NSColor = .labelColor
+        strikethroughColor: NSColor = .labelColor,
+        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4)
     ) {
         self.bodyText = bodyText
         self.mutedText = mutedText
@@ -100,6 +106,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.latexLightModeText = latexLightModeText
         self.latexDarkModeText = latexDarkModeText
         self.strikethroughColor = strikethroughColor
+        self.highlightColor = highlightColor
     }
 
     /// System-native palette built from `NSColor` dynamic system colors.

--- a/Sources/MarkdownEngine/Parser/InlineASTAdapter.swift
+++ b/Sources/MarkdownEngine/Parser/InlineASTAdapter.swift
@@ -53,6 +53,11 @@ enum InlineASTAdapter {
                                         contentRange: between(markers), markerRanges: markers))
             children.forEach { append($0, to: &result) }
 
+        case .highlight(let range, let markers, let children):
+            result.append(MarkdownToken(kind: .highlight, range: range,
+                                        contentRange: between(markers), markerRanges: markers))
+            children.forEach { append($0, to: &result) }
+
         case .inlineLatex(let range, let content, let markers):
             result.append(MarkdownToken(kind: .inlineLatex, range: range, contentRange: content, markerRanges: markers))
 

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -49,6 +49,8 @@ indirect enum InlineNode: Equatable {
     case imageEmbed(range: NSRange, target: NSRange, markers: [NSRange])
     /// `~~text~~`. `markers` is `[openMarker, closeMarker]`; content recursively parsed.
     case strikethrough(range: NSRange, markers: [NSRange], children: [InlineNode])
+    /// `==text==`. `markers` is `[openMarker, closeMarker]`; content recursively parsed.
+    case highlight(range: NSRange, markers: [NSRange], children: [InlineNode])
     /// `$math$` — opaque. `markers` is `[ "$", "$" ]`.
     case inlineLatex(range: NSRange, content: NSRange, markers: [NSRange])
     /// Backslash escape `\x`; `marker` is the `\`, `character` the now-literal punctuation.
@@ -69,6 +71,7 @@ enum InlineParser {
     private static let pipe: unichar = 0x7C
     private static let backslash: unichar = 0x5C
     private static let tilde: unichar = 0x7E
+    private static let equals: unichar = 0x3D
     private static let dollar: unichar = 0x24
 
     // MARK: - Entry point
@@ -100,6 +103,7 @@ enum InlineParser {
         case wikiLink(range: NSRange, name: NSRange, id: NSRange?, markers: [NSRange])
         case imageEmbed(range: NSRange, target: NSRange, markers: [NSRange])
         case strikethrough(range: NSRange, contentRange: NSRange, markers: [NSRange])
+        case highlight(range: NSRange, contentRange: NSRange, markers: [NSRange])
         case inlineLatex(range: NSRange, content: NSRange, markers: [NSRange])
         case escape(range: NSRange, character: NSRange, marker: NSRange)
 
@@ -107,7 +111,7 @@ enum InlineParser {
             switch self {
             case .code(let r, _), .emphasis(_, let r, _, _), .link(let r, _, _, _),
                  .image(let r, _, _, _), .wikiLink(let r, _, _, _), .imageEmbed(let r, _, _),
-                 .strikethrough(let r, _, _), .inlineLatex(let r, _, _), .escape(let r, _, _):
+                 .strikethrough(let r, _, _), .highlight(let r, _, _), .inlineLatex(let r, _, _), .escape(let r, _, _):
                 return r
             }
         }
@@ -216,6 +220,7 @@ enum InlineParser {
         if c == bang, c1 == lbracket { return matchImage(ns, len, start: i) }
         if c == lbracket { return matchLink(ns, len, start: i) }
         if c == tilde, c1 == tilde { return matchStrikethrough(ns, len, start: i) }
+        if c == equals, c1 == equals { return matchHighlight(ns, len, start: i) }
         if c == dollar, c1 != dollar { return matchInlineLatex(ns, len, start: i) }
         return nil
     }
@@ -329,6 +334,28 @@ enum InlineParser {
     }
 
     /// `$ math $` — single dollars, content has no `$`, passes the math heuristic.
+    /// `== text ==` — text has no `=`; not part of a longer `=` run.
+    private static func matchHighlight(_ ns: NSString, _ len: Int, start i: Int) -> Span? {
+        if i > 0, ns.character(at: i - 1) == equals { return nil }
+        let contentStart = i + 2
+        var k = contentStart
+        while k < len {
+            let ch = ns.character(at: k)
+            if ch == newline { return nil }
+            if ch == equals {
+                guard peek(ns, k + 1, len) == equals else { return nil }
+                guard k > contentStart else { return nil }
+                return .highlight(
+                    range: NSRange(location: i, length: (k + 2) - i),
+                    contentRange: NSRange(location: contentStart, length: k - contentStart),
+                    markers: [NSRange(location: i, length: 2), NSRange(location: k, length: 2)]
+                )
+            }
+            k += 1
+        }
+        return nil
+    }
+
     private static func matchInlineLatex(_ ns: NSString, _ len: Int, start i: Int) -> Span? {
         if i > 0, ns.character(at: i - 1) == dollar { return nil }
         let contentStart = i + 1
@@ -592,6 +619,9 @@ enum InlineParser {
             case .strikethrough(let range, let contentRange, let markers):
                 result.append(.strikethrough(range: range, markers: markers,
                                              children: reparse(contentRange, ns: ns)))
+            case .highlight(let range, let contentRange, let markers):
+                result.append(.highlight(range: range, markers: markers,
+                                         children: reparse(contentRange, ns: ns)))
             case .inlineLatex(let range, let content, let markers):
                 result.append(.inlineLatex(range: range, content: content, markers: markers))
             case .escape(let range, let character, let marker):
@@ -627,6 +657,7 @@ enum InlineParser {
         case .wikiLink(let r, let n, let id, let m): return .wikiLink(range: s(r), name: s(n), id: id.map(s), markers: m.map(s))
         case .imageEmbed(let r, let t, let m): return .imageEmbed(range: s(r), target: s(t), markers: m.map(s))
         case .strikethrough(let r, let m, let ch): return .strikethrough(range: s(r), markers: m.map(s), children: offsetNodes(ch, by: d))
+        case .highlight(let r, let m, let ch): return .highlight(range: s(r), markers: m.map(s), children: offsetNodes(ch, by: d))
         case .inlineLatex(let r, let c, let m): return .inlineLatex(range: s(r), content: s(c), markers: m.map(s))
         case .escape(let r, let c, let m): return .escape(range: s(r), character: s(c), marker: s(m))
         }

--- a/Sources/MarkdownEngine/Parser/MarkdownToken.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownToken.swift
@@ -31,6 +31,7 @@ enum MarkdownTokenKind {
     case imageEmbed
     case imageLink
     case strikethrough
+    case highlight
     case table
     /// A CommonMark backslash escape; marker is the `\`, content the escaped literal char.
     case backslashEscape

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -195,10 +195,14 @@ public struct MarkdownEditorBus: Sendable {
     /// Posted by the host UI to request the engine apply a heading level.
     /// Expected `userInfo["level"] as? Int`.
     public var applyHeadingRequest: Notification.Name?
+    /// Posted by the host UI to request the engine apply highlight styling.
+    public var applyHighlightRequest: Notification.Name?
     /// Posted by the engine after every selection change with `userInfo["isBold"] as? Bool`.
     public var selectionBoldDidChange: Notification.Name?
     /// Posted by the engine after every selection change with `userInfo["isItalic"] as? Bool`.
     public var selectionItalicDidChange: Notification.Name?
+    /// Posted by the engine after every selection change with `userInfo["isHighlight"] as? Bool`.
+    public var selectionHighlightDidChange: Notification.Name?
     /// Posted by the host UI to scroll an in-document find match into view
     /// and highlight all matches. Expected `userInfo["range"] as? NSRange`,
     /// `userInfo["currentIndex"] as? Int`, `userInfo["allRanges"] as? [NSRange]`.
@@ -220,8 +224,10 @@ public struct MarkdownEditorBus: Sendable {
         applyBoldRequest: Notification.Name? = nil,
         applyItalicRequest: Notification.Name? = nil,
         applyHeadingRequest: Notification.Name? = nil,
+        applyHighlightRequest: Notification.Name? = nil,
         selectionBoldDidChange: Notification.Name? = nil,
         selectionItalicDidChange: Notification.Name? = nil,
+        selectionHighlightDidChange: Notification.Name? = nil,
         findScrollToRange: Notification.Name? = nil,
         findClearHighlights: Notification.Name? = nil,
         findQuery: Notification.Name? = nil,
@@ -230,8 +236,10 @@ public struct MarkdownEditorBus: Sendable {
         self.applyBoldRequest = applyBoldRequest
         self.applyItalicRequest = applyItalicRequest
         self.applyHeadingRequest = applyHeadingRequest
+        self.applyHighlightRequest = applyHighlightRequest
         self.selectionBoldDidChange = selectionBoldDidChange
         self.selectionItalicDidChange = selectionItalicDidChange
+        self.selectionHighlightDidChange = selectionHighlightDidChange
         self.findScrollToRange = findScrollToRange
         self.findClearHighlights = findClearHighlights
         self.findQuery = findQuery

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -88,7 +88,7 @@ enum MarkdownASTStyler {
                 switch node {
                 case .code(let range, _): ranges.append(range)
                 case .emphasis(_, _, _, let children), .strikethrough(_, _, let children),
-                     .link(_, _, _, _, let children): walk(children)
+                     .highlight(_, _, let children), .link(_, _, _, _, let children): walk(children)
                 default: break
                 }
             }
@@ -432,6 +432,12 @@ enum MarkdownASTStyler {
                 ]))
                 styleInlines(children, font: font, ctx: ctx, into: &attrs)
 
+            case .highlight(_, let markers, let children):
+                attrs.append((content(of: markers), [
+                    .backgroundColor: ctx.theme.highlightColor,
+                ]))
+                styleInlines(children, font: font, ctx: ctx, into: &attrs)
+
             case .code(let range, let contentRange):
                 attrs.append((contentRange, [.font: ctx.codeFont, .backgroundColor: ctx.codeBackground]))
                 // Suppress spell-check underlines on inline `code` spans (markers + content).
@@ -529,6 +535,10 @@ enum MarkdownASTStyler {
                 if !active { shrink(markers, ctx: ctx, into: &attrs) }
                 shrinkInlineMarkers(children, ctx: ctx, forceReveal: active, into: &attrs)
             case .strikethrough(let range, let markers, let children):
+                let active = forceReveal || ctx.isActive(range)
+                if !active { shrink(markers, ctx: ctx, into: &attrs) }
+                shrinkInlineMarkers(children, ctx: ctx, forceReveal: active, into: &attrs)
+            case .highlight(let range, let markers, let children):
                 let active = forceReveal || ctx.isActive(range)
                 if !active { shrink(markers, ctx: ctx, into: &attrs) }
                 shrinkInlineMarkers(children, ctx: ctx, forceReveal: active, into: &attrs)

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -230,6 +230,13 @@ extension MarkdownStyler {
                         .strikethroughColor: theme.bodyText
                     ], range: NSRange(location: start, length: out.length - start))
                 }
+            case .highlight(_, _, let children):
+                let start = out.length
+                recurse(children, font)
+                if out.length > start {
+                    out.addAttribute(.backgroundColor, value: theme.highlightColor,
+                                     range: NSRange(location: start, length: out.length - start))
+                }
             case .code(_, let content):
                 out.append(NSAttributedString(string: ns.substring(with: content), attributes: [
                     .font: codeFont, .backgroundColor: codeBackgroundColor, .foregroundColor: theme.bodyText

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -81,6 +81,18 @@ extension NativeTextViewWrapper.Coordinator {
         return enclosingItalicToken(for: range, in: nsText as String) != nil
     }
 
+    /// Returns the smallest highlight token that fully contains the selection, or nil.
+    func enclosingHighlightToken(for selection: NSRange, in text: String) -> MarkdownToken? {
+        let tokens = parsedDocument(for: text).tokens
+        return tokens.first { token in
+            token.kind == .highlight && tokenEncloses(token, selection: selection)
+        }
+    }
+
+    func isSelectionHighlight(in nsText: NSString, range: NSRange) -> Bool {
+        return enclosingHighlightToken(for: range, in: nsText as String) != nil
+    }
+
     private func tokenEncloses(_ token: MarkdownToken, selection: NSRange) -> Bool {
         return selection.location >= token.range.location
             && NSMaxRange(selection) <= NSMaxRange(token.range)
@@ -213,6 +225,23 @@ extension NativeTextViewWrapper.Coordinator {
         wrapSelection(with: "*")
     }
 
+    @objc func didMarkdownHighlight(_ sender: Any?) {
+        guard let tv = textView else { return }
+        let range = tv.selectedRange()
+
+        if let token = enclosingHighlightToken(for: range, in: tv.string) {
+            unwrapToken(token, leftReplacement: "", rightReplacement: "")
+            return
+        }
+
+        if range.length == 0 {
+            insertEmptyMarkers("==")
+            return
+        }
+
+        wrapSelection(with: "==")
+    }
+
     private func insertEmptyMarkers(_ marker: String) {
         guard let tv = textView else { return }
         let range = tv.selectedRange()
@@ -260,6 +289,9 @@ extension NativeTextViewWrapper.Coordinator: NSMenuItemValidation {
             return true
         case #selector(didMarkdownItalic(_:)):
             menuItem.state = enclosingItalicToken(for: range, in: tv.string) != nil ? .on : .off
+            return true
+        case #selector(didMarkdownHighlight(_:)):
+            menuItem.state = enclosingHighlightToken(for: range, in: tv.string) != nil ? .on : .off
             return true
         case #selector(didMarkdownHeading(_:)):
             return !isSelectionHeading(level: menuItem.tag, in: nsText, range: range)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
@@ -21,6 +21,10 @@ extension NativeTextViewCoordinator {
         didMarkdownItalic(nil)
     }
 
+    @objc func handleHighlightNotification(_ notification: Notification) {
+        didMarkdownHighlight(nil)
+    }
+
     @objc func handleHeadingNotification(_ notification: Notification) {
         guard let level = notification.userInfo?["level"] as? Int else { return }
         let item = NSMenuItem()

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -454,6 +454,12 @@ extension NativeTextViewCoordinator {
                 userInfo: ["isItalic": isSelectionItalic(in: nsText, range: selRange)]
             )
         }
+        if let name = bus.selectionHighlightDidChange {
+            center.post(
+                name: name, object: nil,
+                userInfo: ["isHighlight": isSelectionHighlight(in: nsText, range: selRange)]
+            )
+        }
     }
 
     func handleBacktab(_ textView: NSTextView) -> Bool {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -226,6 +226,11 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
                 self?.handleHeadingNotification(notification)
             })
         }
+        if let name = bus.applyHighlightRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleHighlightNotification(notification)
+            })
+        }
         if let name = bus.findScrollToRange {
             busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
                 self?.handleFindScrollToRange(notification)

--- a/Tests/MarkdownEngineTests/InlineParserTests.swift
+++ b/Tests/MarkdownEngineTests/InlineParserTests.swift
@@ -229,6 +229,37 @@ struct InlineParserTests {
         ])
     }
 
+    // MARK: - Highlight
+
+    @Test("highlight, content recursively parsed")
+    func highlight() {
+        #expect(InlineParser.parse("==x==") == [
+            .highlight(range: r(0, 5), markers: [r(0, 2), r(3, 2)], children: [.text(r(2, 1))]),
+        ])
+    }
+
+    @Test("triple equals do not highlight")
+    func tripleEqualsNotHighlight() {
+        #expect(InlineParser.parse("===x===") == [.text(r(0, 7))])
+    }
+
+    @Test("==abc=== matches ==abc==, trailing = is plain text")
+    func highlightToleratesTrailingTripleEquals() {
+        #expect(InlineParser.parse("==abc===") == [
+            .highlight(range: r(0, 7), markers: [r(0, 2), r(5, 2)], children: [.text(r(2, 3))]),
+            .text(r(7, 1)),
+        ])
+    }
+
+    @Test("highlight wraps emphasis")
+    func highlightWrapsEmphasis() {
+        #expect(InlineParser.parse("==*x*==") == [
+            .highlight(range: r(0, 7), markers: [r(0, 2), r(5, 2)], children: [
+                .emphasis(.italic, range: r(2, 3), markers: [r(2, 1), r(4, 1)], children: [.text(r(3, 1))]),
+            ]),
+        ])
+    }
+
     // MARK: - Backslash escapes
 
     @Test("escaped punctuation becomes an escape node")

--- a/Tests/MarkdownEngineTests/TableCellTests.swift
+++ b/Tests/MarkdownEngineTests/TableCellTests.swift
@@ -61,6 +61,12 @@ struct TableCellTests {
         #expect(s.attribute(.strikethroughStyle, at: 0, effectiveRange: nil) != nil)
     }
 
+    @Test func highlightIsApplied() {
+        let s = cell("==note==")
+        #expect(s.string == "note")
+        #expect(s.attribute(.backgroundColor, at: 0, effectiveRange: nil) != nil)
+    }
+
     @Test func headerCellStartsBold() {
         #expect(traits(cell("h", header: true), "h").contains(.bold))
     }


### PR DESCRIPTION
Closes #22.
This PR adds ==highlight== inline markup to the Markdown engine, following the same pattern as the existing ~~strikethrough~~ implementation.  While not part of the CommonMark specification, this syntax is already supported by many editors and has become a de facto standard for inline text highlighting.

Changes
- Parser — InlineParser matches ==text== markers; rejects === (triple equals) to avoid ambiguity. Content is recursively parsed so nested emphasis, code, links etc. render correctly inside highlights.
- AST — New .highlight case on MarkdownTokenKind, InlineNode, and InlineASTAdapter.
- Styling — MarkdownASTStyler applies the background color from MarkdownEditorTheme.highlightColor (default .systemOrange.withAlphaComponent(0.4)). Markers shrink when the selection is outside the highlight region.
- Table cells — Highlight styling works inside GFM table cells.
- Context menu — "Highlight" toggle item with correct on/off state validation.
- Event bus — MarkdownEditorBus.applyHighlightRequest / selectionHighlightDidChange for driving a toolbar button from host UI.
- Configuration — MarkdownEditorTheme.highlightColor added.
- Tests — Parser tests (basic highlight, triple-equals rejection, trailing equals tolerance, nested emphasis) and table cell test.
- README — Highlight added to the feature list.