### PR TITLE
Inline syntax markers render in bodyText color while editing, inconsistent with inline code and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to swift-markdown-engine are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Inline syntax markers (`**`, `*`, `~~`, `==`) now use `mutedText` foreground
+  color while the caret is inside the corresponding span, matching the existing
+  behavior of inline code backticks and link/wiki-link brackets. This makes
+  highlight `==` markers visually distinct from body text in edit state.
+
 ## [0.8.0] - 2026-06-28
 
 ### Added

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -420,22 +420,31 @@ enum MarkdownASTStyler {
             case .text:
                 break
 
-            case .emphasis(let kind, _, let markers, let children):
+            case .emphasis(let kind, let range, let markers, let children):
                 let composed = adding(traits(for: kind), to: font)
                 attrs.append((content(of: markers), [.font: composed]))
+                if ctx.isActive(range) {
+                    for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+                }
                 styleInlines(children, font: composed, ctx: ctx, into: &attrs)
 
-            case .strikethrough(_, let markers, let children):
+            case .strikethrough(let range, let markers, let children):
                 attrs.append((content(of: markers), [
                     .strikethroughStyle: NSUnderlineStyle.single.rawValue,
                     .strikethroughColor: ctx.theme.strikethroughColor,
                 ]))
+                if ctx.isActive(range) {
+                    for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+                }
                 styleInlines(children, font: font, ctx: ctx, into: &attrs)
 
-            case .highlight(_, let markers, let children):
+            case .highlight(let range, let markers, let children):
                 attrs.append((content(of: markers), [
                     .backgroundColor: ctx.theme.highlightColor,
                 ]))
+                if ctx.isActive(range) {
+                    for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+                }
                 styleInlines(children, font: font, ctx: ctx, into: &attrs)
 
             case .code(let range, let contentRange):

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -101,6 +101,83 @@ struct MarkdownASTStylerTests {
         #expect(spellingStates(intersecting: inlineSpan).contains(0))
         #expect(spellingStates(intersecting: prose).isEmpty)
     }
+
+    /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
+    private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.foregroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    /// Whether the last `.font` attribute covering `pos` is the hidden marker font.
+    private func isHiddenMarkerFont(in attrs: [StyledRange], at pos: Int, configuration: MarkdownEditorConfiguration = .default) -> Bool {
+        let hiddenSize = configuration.markers.hiddenMarkerFontSize
+        let hiddenFont = NSFont(name: fontName, size: hiddenSize) ?? .systemFont(ofSize: hiddenSize)
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result?.pointSize == hiddenFont.pointSize
+    }
+
+    @Test("highlight == markers use mutedText while the caret is inside")
+    func highlightMarkersAreMutedWhenActive() {
+        let text = "==text=="
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: 4, configuration: .default
+        )
+        #expect(color(in: attrs, at: 0) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 1) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 6) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 7) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("bold ** markers use mutedText while the caret is inside")
+    func boldMarkersAreMutedWhenActive() {
+        let text = "**bold**"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: 4, configuration: .default
+        )
+        #expect(color(in: attrs, at: 0) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 1) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 6) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 7) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("italic * marker uses mutedText while the caret is inside")
+    func italicMarkerIsMutedWhenActive() {
+        let text = "*italic*"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: 4, configuration: .default
+        )
+        #expect(color(in: attrs, at: 0) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 7) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("strikethrough ~~ markers use mutedText while the caret is inside")
+    func strikethroughMarkersAreMutedWhenActive() {
+        let text = "~~strike~~"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: 5, configuration: .default
+        )
+        #expect(color(in: attrs, at: 0) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 1) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 8) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: 9) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("inline markers shrink instead of taking muted color when the caret is outside")
+    func inactiveMarkersShrinkInsteadOfColored() {
+        let text = "a ==text== b **bold** c ~~strike~~ d *italic* e"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: 0, configuration: .default
+        )
+        for pos in [2, 3, 8, 9, 13, 14, 19, 20, 24, 25, 32, 33, 37, 44] {
+            #expect(isHiddenMarkerFont(in: attrs, at: pos), "marker at \(pos) should be shrunk")
+        }
+    }
 }
 
 /// Canonical, order-independent string of styled ranges so two style runs can be


### PR DESCRIPTION
When the caret is inside an inline markup span, the syntax markers for `**bold**`, `*italic*`, `~~strikethrough~~`, and `==highlight==` are drawn in the same foreground color as the surrounding body text. This makes it hard to visually distinguish the Markdown syntax from the actual content — especially for `==highlight==`, where the content already has a colored background and the `==` markers blend in.

In contrast, inline code backticks (`` `code` ``) and link/wiki-link brackets already use `theme.mutedText` for their markers in edit state, so they feel clearly "secondary".

**Expected behavior**

All inline syntax markers should use the same de-emphasized foreground color (`mutedText`) when the caret is inside the span, creating a consistent visual hierarchy across inline formats.

**Root cause**

In `MarkdownASTStyler.styleInlines`, the `.emphasis`, `.strikethrough`, and `.highlight` cases do not set a foreground color on the marker ranges. They rely on the default `bodyText` color inherited from the text view. Only `.code`, `.link`, and `.wikiLink` explicitly apply `mutedText` to their markers.

**Proposed fix**

Apply `ctx.theme.mutedText` to the marker ranges of `.emphasis`, `.strikethrough`, and `.highlight` when `ctx.isActive(range)` is true. Inactive markers continue to be hidden via the existing `shrinkInactiveMarkers` pass, so this change only affects the edit-state appearance.

**Files changed**

- `Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift`
- `Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift`
- `CHANGELOG.md`
