### PR TITLE
feat(links): give web links the same click edit-zone as wiki links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   color while the caret is inside the corresponding span, matching the existing
   behavior of inline code backticks and link/wiki-link brackets. This makes
   highlight `==` markers visually distinct from body text in edit state.
+- Web links `[text](url)` now share the wiki-link "edit zone": clicking the outer
+  ~30% of the link's first/last visible character places the caret just outside the
+  markers (before `[` / after `)`) and reveals the source for editing instead of
+  navigating, matching `[[…]]` behavior. Previously the edit zone only resolved
+  `.wikiLink` tokens, so a web link dropped the caret between its brackets and did
+  not reveal. Middle-of-link clicks still navigate; read-only links stay navigable.
+- Auto-linking (`NSDataDetector`) no longer linkifies a URL that sits inside a
+  markdown or wiki link's own range. A link's `(url)` previously got its own
+  competing `.link` attribute on top of the link — making the raw URL independently
+  navigable and offsetting the click edit zone. Bare URLs outside links still
+  autolink; URLs inside code were already excluded.
 
 ## [0.8.0] - 2026-06-28
 

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -74,7 +74,8 @@ enum MarkdownASTStyler {
         // Text/regex passes (AST-agnostic); AST code ranges drive the "skip inside code" checks.
         let codeRanges = collectCodeRanges(in: blocks)
         let checkboxRanges = collectCheckboxRanges(in: blocks)
-        styleAutoLinks(ctx: ctx, codeRanges: codeRanges, into: &attrs)
+        let linkRanges = collectLinkRanges(in: blocks)
+        styleAutoLinks(ctx: ctx, codeRanges: codeRanges, linkRanges: linkRanges, into: &attrs)
         styleIncompleteLinkBrackets(ctx: ctx, codeRanges: codeRanges, checkboxRanges: checkboxRanges, into: &attrs)
         return attrs
     }
@@ -108,6 +109,39 @@ enum MarkdownASTStyler {
 
     private static func isInCode(_ range: NSRange, _ codeRanges: [NSRange]) -> Bool {
         codeRanges.contains { NSIntersectionRange($0, range).length > 0 }
+    }
+
+    /// Full ranges of markdown links `[text](url)` and wiki links `[[…]]`. The NSDataDetector
+    /// auto-link pass skips URLs inside these, so a link's own `(url)` isn't independently
+    /// linkified into a second, competing `.link` region overlapping the link (which offsets
+    /// the click edit-zone and makes the raw URL navigable).
+    private static func collectLinkRanges(in blocks: [BlockNode]) -> [NSRange] {
+        var ranges: [NSRange] = []
+        func walk(_ nodes: [InlineNode]) {
+            for node in nodes {
+                switch node {
+                case .link(let range, _, _, _, let children):
+                    ranges.append(range)
+                    walk(children)
+                case .wikiLink(let range, _, _, _):
+                    ranges.append(range)
+                case .emphasis(_, _, _, let children), .strikethrough(_, _, let children),
+                     .highlight(_, _, let children):
+                    walk(children)
+                default: break
+                }
+            }
+        }
+        for block in blocks {
+            switch block {
+            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines):
+                walk(inlines)
+            case .list(_, let items):
+                for item in items { walk(item.inlines) }
+            default: break
+            }
+        }
+        return ranges
     }
 
     /// Checkbox boxes (`[ ]`/`[x]`), excluded so the incomplete-link pass doesn't repaint their brackets.
@@ -197,11 +231,15 @@ enum MarkdownASTStyler {
         }
     }
 
-    private static func styleAutoLinks(ctx: Ctx, codeRanges: [NSRange], into attrs: inout [StyledRange]) {
+    private static func styleAutoLinks(ctx: Ctx, codeRanges: [NSRange], linkRanges: [NSRange], into attrs: inout [StyledRange]) {
         guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return }
         for scan in ctx.scanRanges {
             detector.enumerateMatches(in: ctx.text, range: scan) { match, _, _ in
-                guard let match, let url = match.url, !isInCode(match.range, codeRanges) else { return }
+                // Skip URLs inside code and inside a markdown/wiki link's own range — a link's
+                // `(url)` must not become a second `.link` region competing with the link itself.
+                guard let match, let url = match.url,
+                      !isInCode(match.range, codeRanges),
+                      !isInCode(match.range, linkRanges) else { return }
                 attrs.append((match.range, [.link: url]))
             }
         }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -492,28 +492,32 @@ extension NativeTextViewCoordinator {
     }
 
     public func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
-        // Edit zone: a click on the outer ~30% of a node link's first/last name char places the caret
-        // just outside the markers (before '[[' / after ']]') to reveal the source for editing instead
-        // of navigating. Editable views only — read-only links must stay navigable.
+        // Edit zone: a click on the outer ~30% of a link's first/last visible char places the caret
+        // just outside the markers (before '[[' / '[' , after ']]' / ')') to reveal the source for
+        // editing instead of navigating. Applies to both wiki links [[…]] and web links [text](url).
+        // Editable views only — read-only links must stay navigable.
         if textView.isEditable, let storage = textView.textStorage {
             var linkRange = NSRange(location: NSNotFound, length: 0)
             let editZoneMinNameLength = 3   // 1–2 char names stay fully clickable for navigation
             if storage.attribute(.link, at: charIndex, longestEffectiveRange: &linkRange,
                                  in: NSRange(location: 0, length: storage.length)) != nil,
                linkRange.length >= editZoneMinNameLength {
-                // Caret lands on the token's markers (no .link there, so the mouse-on-link guard in
-                // textViewDidChangeSelection doesn't suppress the reveal).
+                // Caret lands on the token's outer markers ('[['/'[' or ']]'/')'), which carry no
+                // .link, so the mouse-on-link guard in textViewDidChangeSelection doesn't suppress
+                // the reveal. Web links (.link) get the same edit zone as wiki links (.wikiLink); the
+                // .link attribute only spans the visible text, so without the full token range a web
+                // link would drop the caret between its brackets instead of just outside them.
                 let token = parsedDocument(for: textView.string).tokens
-                    .first { $0.kind == .wikiLink && NSLocationInRange(charIndex, $0.range) }
+                    .first { ($0.kind == .wikiLink || $0.kind == .link) && NSLocationInRange(charIndex, $0.range) }
                 let edgeFraction: CGFloat = 0.3
                 let frac = clickFractionThroughGlyph(textView, charIndex: charIndex)
                 if charIndex == linkRange.location, frac.map({ $0 <= edgeFraction }) ?? true {
-                    let caret = token?.range.location ?? linkRange.location          // before '[['
+                    let caret = token?.range.location ?? linkRange.location          // before '[[' / '['
                     textView.setSelectedRange(NSRange(location: caret, length: 0))
                     return true
                 }
                 if charIndex == NSMaxRange(linkRange) - 1, frac.map({ $0 >= 1 - edgeFraction }) ?? true {
-                    let caret = token.map { NSMaxRange($0.range) } ?? NSMaxRange(linkRange)  // after ']]'
+                    let caret = token.map { NSMaxRange($0.range) } ?? NSMaxRange(linkRange)  // after ']]' / ')'
                     textView.setSelectedRange(NSRange(location: caret, length: 0))
                     return true
                 }


### PR DESCRIPTION
## What

Web links `[text](url)` now behave like wiki links `[[…]]` on click. **Edit zone:** clicking the outer ~30% of the link's first/last visible character places the caret just outside the link (before `[` / after `)`) and reveals the source for editing instead of navigating. Middle-of-link clicks still navigate; read-only links stay navigable.

## Root cause of the "web link edge doesn't work" report

`styleAutoLinks` (`NSDataDetector`) linkified the raw URL inside a markdown link's `(url)`, creating a **second** `.link` region competing with the link itself. Clicking that URL navigated, and the edit-zone measured edges against the URL's `.link` range while placing the caret from the markdown token → offset. (Confirmed with print instrumentation: `linkRange` was the 53-char URL, `tokenRange` the full 76-char `[text](url)`.)

## Fix

- `styleAutoLinks` now skips URLs that sit inside a markdown/wiki link's range — mirroring the existing skip-inside-code guard — so a link carries exactly one `.link`.
- The click edit-zone resolves `.link` tokens too (not only `.wikiLink`), so a web link lands the caret just outside the full `[text](url)` token instead of between its brackets.

## Testing

- `swift build` ✓ · `swift test --filter MarkdownASTStylerTests` ✓ (9/9)
- Verified live in the Nodes app via a local package override (print-instrumented click path; prints removed before commit).

## Follow-up

- Image links `![alt](url)` have the same double-linkify risk; this change is scoped to `.link` + `.wikiLink`. Can extend the same invariant to images if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
