### PR TITLE
feat(callout): GFM-style callout block rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately; the current document's undo stack is dropped on a switch
   because undo actions recorded against the other mode's display text would
   replay at stale ranges. Default `false` — existing embedders are unaffected.
+- Callout block support: `[!NOTE]`, `[!WARNING]`, `[!TIP]`, `[!IMPORTANT]`, and
+  `[!CAUTION]` blocks inside blockquotes are now rendered with a rounded
+  background fill, color-coded left accent bar, SF Symbol icon, and bold title
+  text. In reading mode the raw Markdown source is hidden and replaced by the
+  rendered overlay; in edit mode (`isActive`) the raw source is visible with
+  muted styling. Custom titles after the type (e.g. `[!NOTE] My Title`) are
+  supported. A new `CalloutAttribute` class consolidates callout metadata (type,
+  title, edit-state flag) under a single `.callout` attributed-string key. Edits
+  inside a callout block trigger full-block paragraph restyling to keep the
+  block visually consistent.
 
 ### Fixed
 - Inline syntax markers (`**`, `*`, `~~`, `==`) now use `mutedText` foreground
@@ -34,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   competing `.link` attribute on top of the link — making the raw URL independently
   navigable and offsetting the click edit zone. Bare URLs outside links still
   autolink; URLs inside code were already excluded.
-
 ## [0.8.0] - 2026-06-28
 
 ### Added

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -32,6 +32,23 @@ extension NSAttributedString.Key {
     static let scrollableBlockTotalHeight = NSAttributedString.Key("ScrollableBlockTotalHeight")
     /// NSValue(range:) — full multi-line range of the wide-table source, used to scope width-change restyles.
     static let scrollableBlockFullRange = NSAttributedString.Key("ScrollableBlockFullRange")
+    /// Consolidated callout metadata (type + title + editing flag).
+    static let callout = NSAttributedString.Key("Callout")
+    /// Marks the literal `[!TYPE]` marker of a callout so later regex passes
+    /// (e.g. incomplete-link highlighting) leave it alone.
+    static let calloutMarker = NSAttributedString.Key("CalloutMarker")
+}
+
+final class CalloutAttribute {
+    let type: String
+    let title: String
+    var isEditing: Bool
+
+    init(type: String, title: String, isEditing: Bool = false) {
+        self.type = type
+        self.title = title
+        self.isEditing = isEditing
+    }
 }
 
 final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
@@ -79,20 +96,26 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         // 2. LaTeX images (behind text — hidden markers are invisible anyway)
         drawLatexImages(at: point, in: context)
 
-        // 3. Normal text
+        // 3. Callout backgrounds/bars (behind text)
+        drawCalloutBackgrounds(at: point, in: context)
+
+        // 4. Normal text
         super.draw(at: point, in: context)
 
-        // 4. Task checkboxes (on top of hidden [ ]/[x] markers)
+        // 5. Callout icons/titles (on top of hidden source text)
+        drawCalloutOverlays(at: point, in: context)
+
+        // 6. Task checkboxes (on top of hidden [ ]/[x] markers)
         drawTaskCheckboxes(at: point, in: context)
 
-        // 4b. Bullet glyphs (on top of hidden -/*/+ markers)
+        // 5b. Bullet glyphs (on top of hidden -/*/+ markers)
         drawBulletMarkers(at: point, in: context)
 
-        // 5. Thematic breaks (full-width line, painted last so it doesn't
+        // 6. Thematic breaks (full-width line, painted last so it doesn't
         //    fight with anything that already drew at the line's center)
         drawThematicBreaks(at: point, in: context)
 
-        // 6. Blockquote bars (left gutter, behind nothing — text is indented)
+        // 7. Blockquote bars (left gutter, behind nothing — text is indented)
         drawBlockquoteBars(at: point, in: context)
     }
 
@@ -101,8 +124,12 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
     /// NSRange in the document for this fragment's content.
     private var fragmentNSRange: NSRange? {
         guard let tcs = textLayoutManager?.textContentManager as? NSTextContentStorage else { return nil }
-        let start = tcs.offset(from: tcs.documentRange.location, to: rangeInElement.location)
-        let end = tcs.offset(from: tcs.documentRange.location, to: rangeInElement.endLocation)
+        return Self.nsRange(for: self, in: tcs)
+    }
+
+    private static func nsRange(for fragment: NSTextLayoutFragment, in tcs: NSTextContentStorage) -> NSRange? {
+        let start = tcs.offset(from: tcs.documentRange.location, to: fragment.rangeInElement.location)
+        let end = tcs.offset(from: tcs.documentRange.location, to: fragment.rangeInElement.endLocation)
         guard start != NSNotFound, end != NSNotFound, end > start else { return nil }
         return NSRange(location: start, length: end - start)
     }
@@ -452,14 +479,17 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
     /// run of quote lines reads as one continuous bar.
     private func drawBlockquoteBars(at point: CGPoint, in context: CGContext) {
         guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard !hasCallout(in: range, textStorage: ts) else { return }
         var anyLevel = false
         ts.enumerateAttribute(.blockquoteLevel, in: range, options: []) { value, _, stop in
             if value is Int { anyLevel = true; stop.pointee = true }
         }
         guard anyLevel else { return }
 
-        let theme = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
-            .configuration.theme ?? .default
+        let textView = textLayoutManager?.textContainer?.textView
+        let baseFont = (textView as? NativeTextView)?.baseFont
+            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+        let theme = (textView as? NativeTextView)?.configuration.theme ?? .default
         let indentPerLevel = Self.blockquoteIndentPerLevel
         let barWidth = Self.blockquoteBarWidth
 
@@ -471,6 +501,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         let fragLocation = fragmentNSRange?.location ?? 0
         let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let isLastFragment = isLastBlockquoteFragment(in: range, textStorage: ts)
+        let lastRealLine = textLineFragments.last { fragLocation + $0.characterRange.location < ts.length }
+
         for lineFragment in textLineFragments {
             let lr = lineFragment.characterRange
             let docStart = fragLocation + lr.location
@@ -482,13 +515,311 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             if let level = ts.attribute(.blockquoteLevel, at: docStart, effectiveRange: nil) as? Int {
                 // tb.origin.y is already relative to this layout fragment.
                 let barY = point.y + tb.origin.y
+                let extend = isLastFragment && lineFragment === lastRealLine
+                let fontHeight = baseFont.ascender - baseFont.descender
+                let bottomPadding = max(0, tb.height - fontHeight)
+                let barHeight = tb.height + (extend ? bottomPadding : 0)
                 for i in 0..<level {
                     let barX = leftEdge + CGFloat(i) * indentPerLevel + indentPerLevel * 0.25
                     NSBezierPath(rect: CGRect(
-                        x: barX, y: barY, width: barWidth, height: tb.height
+                        x: barX, y: barY, width: barWidth, height: barHeight
                     )).fill()
                 }
             }
+        }
+    }
+
+    // MARK: - Callouts
+
+    /// Draw a callout background + left accent bar behind text. The icon/title
+    /// overlay is drawn afterward in `drawCalloutOverlays` so it renders on top
+    /// of the hidden source text.
+    private func drawCalloutBackgrounds(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard let ca = calloutAttribute(in: range, textStorage: ts) else { return }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+        NSGraphicsContext.current = nsContext
+
+        let style = Self.calloutStyle(for: ca.type)
+        let containerWidth = textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
+        let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let level = calloutLevel(in: range, textStorage: ts) ?? 1
+
+        // Vertical span of the whole callout block.
+        var firstY: CGFloat?
+        var lastMaxY: CGFloat?
+        for lineFragment in textLineFragments {
+            let tb = lineFragment.typographicBounds
+            let y = point.y + tb.origin.y
+            let maxY = y + tb.height
+            if firstY == nil { firstY = y }
+            lastMaxY = max(lastMaxY ?? y, maxY)
+        }
+        guard let firstY = firstY, var lastMaxY = lastMaxY else { return }
+
+        // Add bottom padding equal to the natural top padding inside a fixed-
+        // height line, so the box looks vertically centered around the text.
+        // Enforce a minimum so the padding is always visible.
+        let textView = textLayoutManager?.textContainer?.textView
+        let baseFont = (textView as? NativeTextView)?.baseFont
+            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+        let lineHeight = textLineFragments.first?.typographicBounds.height ?? 0
+        let fontHeight = baseFont.ascender - baseFont.descender
+        let bottomPadding = max(4, lineHeight - fontHeight)
+
+        // Background fill. Middle fragments are plain rectangles; only the first
+        // fragment rounds its top corners and the last fragment rounds its bottom
+        // corners, so adjacent fragments merge into one continuous rounded box.
+        let isFirst = isFirstCalloutFragment(in: range, textStorage: ts)
+        let isLast = isLastCalloutFragment(in: range, textStorage: ts)
+        if isLast { lastMaxY += bottomPadding }
+        let bgRect = CGRect(x: leftEdge, y: firstY, width: containerWidth, height: lastMaxY - firstY)
+        let bgPath = Self.roundedRectPath(
+            rect: bgRect,
+            topLeft: isFirst ? 6 : 0,
+            topRight: isFirst ? 6 : 0,
+            bottomLeft: isLast ? 6 : 0,
+            bottomRight: isLast ? 6 : 0
+        )
+        style.color.withAlphaComponent(0.1).setFill()
+        bgPath.fill()
+
+        // Left accent bar, aligned with the innermost blockquote bar for this level.
+        let barX = leftEdge + CGFloat(level - 1) * Self.blockquoteIndentPerLevel + Self.blockquoteIndentPerLevel * 0.25
+        let barRect = CGRect(x: barX, y: firstY, width: Self.blockquoteBarWidth, height: lastMaxY - firstY)
+        style.color.setFill()
+        NSBezierPath(rect: barRect).fill()
+    }
+
+    /// Draw the SF Symbol icon and rendered title for a callout. Called after
+    /// `super.draw` so the replacement text appears on top of the hidden source.
+    private func drawCalloutOverlays(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard let ca = calloutAttribute(in: range, textStorage: ts) else { return }
+
+        // In edit mode the raw Markdown is visible, so skip the rendered icon/title.
+        guard !ca.isEditing else { return }
+
+        // Icon + title only on the first fragment of the callout block.
+        guard isFirstCalloutFragment(in: range, textStorage: ts),
+              let firstLine = textLineFragments.first else { return }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+        NSGraphicsContext.current = nsContext
+
+        let style = Self.calloutStyle(for: ca.type)
+        let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let level = calloutLevel(in: range, textStorage: ts) ?? 1
+        let indent = CGFloat(level) * Self.blockquoteIndentPerLevel
+
+        let tb = firstLine.typographicBounds
+        let lineY = point.y + tb.origin.y
+        let lineHeight = tb.height
+
+        let textView = textLayoutManager?.textContainer?.textView
+        let baseFont = (textView as? NativeTextView)?.baseFont
+            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+        let titleFont = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
+
+        // Match TextKit's bottom-alignment within a fixed line height. The raw
+        // Markdown text in edit mode sits on the baseline at
+        // `lineHeight + baseFont.descender`; drawing the rendered title from
+        // that same baseline keeps the two modes pixel-aligned.
+        let baselineY = lineY + lineHeight + baseFont.descender
+
+        // Fixed icon dimensions: height matches the full text height
+        // (ascender − descender) so the icon reads as part of the line.
+        // Width is slightly larger (4pt) for visual balance with SF Symbols.
+        let iconHeight = ceil(baseFont.ascender - baseFont.descender)
+        let iconWidth = iconHeight + 4
+        let iconX = leftEdge + indent + Self.blockquoteIndentPerLevel * 0.5
+        // Center the icon vertically on the title's cap height so it stays
+        // aligned with the text.
+        let iconCenterY = baselineY - titleFont.capHeight / 2
+        let iconY = iconCenterY - iconHeight / 2
+
+        if let baseSymbol = NSImage(systemSymbolName: style.icon, accessibilityDescription: nil) {
+            let colorConfig = NSImage.SymbolConfiguration(hierarchicalColor: style.color)
+            // Use a fixed reference pointSize so we can derive the symbol's
+            // natural aspect ratio, then scale proportionally to iconHeight.
+            let refConfig = NSImage.SymbolConfiguration(pointSize: 20, weight: .regular)
+            let refSymbol = baseSymbol.withSymbolConfiguration(refConfig.applying(colorConfig)) ?? baseSymbol
+            let refSize = refSymbol.size
+            let scale = iconHeight / refSize.height
+            let drawWidth = refSize.width * scale
+            let drawX = iconX + (iconWidth - drawWidth) / 2
+            refSymbol.draw(in: CGRect(x: drawX, y: iconY, width: drawWidth, height: iconHeight))
+        }
+
+        let title = ca.title
+        let theme = (textView as? NativeTextView)?.configuration.theme ?? .default
+        let titleAttrs: [NSAttributedString.Key: Any] = [
+            .font: titleFont,
+            .foregroundColor: theme.bodyText,
+        ]
+        let titleX = iconX + iconWidth + 6
+        // `draw(at:)` in a flipped context uses the top edge of the text box.
+        let titleY = baselineY - titleFont.ascender
+        (title as NSString).draw(at: CGPoint(x: titleX, y: titleY), withAttributes: titleAttrs)
+    }
+
+    private func isFirstCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        guard let tlm = textLayoutManager,
+              let tcm = tlm.textContentManager as? NSTextContentStorage else { return true }
+        guard let prevLocation = tcm.location(rangeInElement.location, offsetBy: -1),
+              let prevFragment = tlm.textLayoutFragment(for: prevLocation),
+              let prevRange = Self.nsRange(for: prevFragment, in: tcm) else { return true }
+        return !hasCallout(in: prevRange, textStorage: textStorage)
+    }
+
+    private func isLastCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        // Check the text storage directly: if the character right after this
+        // fragment's range does NOT carry .callout, this is the last
+        // fragment of the callout block.  This avoids edge cases in the
+        // NSTextLayoutManager fragment graph (e.g. synthetic trailing lines)
+        // that can cause isLast to be incorrect for some callout types.
+        let nextIndex = NSMaxRange(range)
+        guard nextIndex < textStorage.length else { return true }
+        let nextCallout = textStorage.attribute(.callout, at: nextIndex, effectiveRange: nil) as? CalloutAttribute
+        return nextCallout == nil
+    }
+
+    private func isLastBlockquoteFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        guard let tlm = textLayoutManager,
+              let tcm = tlm.textContentManager as? NSTextContentStorage else { return true }
+        guard let nextLocation = tcm.location(rangeInElement.endLocation, offsetBy: 1),
+              let nextFragment = tlm.textLayoutFragment(for: nextLocation),
+              let nextRange = Self.nsRange(for: nextFragment, in: tcm) else { return true }
+        var nextHasBlockquote = false
+        var nextHasCallout = false
+        textStorage.enumerateAttribute(.blockquoteLevel, in: nextRange, options: []) { value, _, stop in
+            if value is Int { nextHasBlockquote = true; stop.pointee = true }
+        }
+        textStorage.enumerateAttribute(.callout, in: nextRange, options: []) { value, _, stop in
+            if value is CalloutAttribute { nextHasCallout = true; stop.pointee = true }
+        }
+        // A plain blockquote bar ends when the next fragment is not a blockquote,
+        // or when it becomes a callout (callouts draw their own accent bar).
+        return !nextHasBlockquote || nextHasCallout
+    }
+
+    private func calloutAttribute(in range: NSRange, textStorage: NSTextStorage) -> CalloutAttribute? {
+        var result: CalloutAttribute?
+        textStorage.enumerateAttribute(.callout, in: range, options: []) { value, _, stop in
+            if let ca = value as? CalloutAttribute {
+                result = ca
+                stop.pointee = true
+            }
+        }
+        return result
+    }
+
+    private func hasCallout(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        calloutAttribute(in: range, textStorage: textStorage) != nil
+    }
+
+    private func calloutLevel(in range: NSRange, textStorage: NSTextStorage) -> Int? {
+        var result: Int?
+        textStorage.enumerateAttribute(.blockquoteLevel, in: range, options: []) { value, _, stop in
+            if let level = value as? Int {
+                result = level
+                stop.pointee = true
+            }
+        }
+        return result
+    }
+
+    /// Build a rectangle path with independent corner radii. A radius of 0
+    /// produces a sharp corner for that quadrant.
+    private static func roundedRectPath(
+        rect: CGRect,
+        topLeft: CGFloat,
+        topRight: CGFloat,
+        bottomLeft: CGFloat,
+        bottomRight: CGFloat
+    ) -> NSBezierPath {
+        let path = NSBezierPath()
+        let minX = rect.minX
+        let maxX = rect.maxX
+        let minY = rect.minY
+        let maxY = rect.maxY
+
+        path.move(to: CGPoint(x: minX + topLeft, y: minY))
+        path.line(to: CGPoint(x: maxX - topRight, y: minY))
+        if topRight > 0 {
+            path.appendArc(
+                withCenter: CGPoint(x: maxX - topRight, y: minY + topRight),
+                radius: topRight,
+                startAngle: 270,
+                endAngle: 360,
+                clockwise: false
+            )
+        }
+        path.line(to: CGPoint(x: maxX, y: maxY - bottomRight))
+        if bottomRight > 0 {
+            path.appendArc(
+                withCenter: CGPoint(x: maxX - bottomRight, y: maxY - bottomRight),
+                radius: bottomRight,
+                startAngle: 0,
+                endAngle: 90,
+                clockwise: false
+            )
+        }
+        path.line(to: CGPoint(x: minX + bottomLeft, y: maxY))
+        if bottomLeft > 0 {
+            path.appendArc(
+                withCenter: CGPoint(x: minX + bottomLeft, y: maxY - bottomLeft),
+                radius: bottomLeft,
+                startAngle: 90,
+                endAngle: 180,
+                clockwise: false
+            )
+        }
+        path.line(to: CGPoint(x: minX, y: minY + topLeft))
+        if topLeft > 0 {
+            path.appendArc(
+                withCenter: CGPoint(x: minX + topLeft, y: minY + topLeft),
+                radius: topLeft,
+                startAngle: 180,
+                endAngle: 270,
+                clockwise: false
+            )
+        }
+        path.close()
+        return path
+    }
+
+    static func calloutStyle(for type: String) -> (color: NSColor, icon: String) {
+        switch type.lowercased() {
+        case "note":
+            return (NSColor(srgbRed: 8 / 255, green: 109 / 255, blue: 221 / 255, alpha: 1), "note.text")
+        case "abstract", "summary", "tldr":
+            return (NSColor(srgbRed: 0 / 255, green: 191 / 255, blue: 188 / 255, alpha: 1), "doc.text")
+        case "info", "todo":
+            return (NSColor(srgbRed: 8 / 255, green: 109 / 255, blue: 221 / 255, alpha: 1), "info.circle")
+        case "tip", "hint", "important":
+            return (NSColor(srgbRed: 0 / 255, green: 191 / 255, blue: 188 / 255, alpha: 1), "lightbulb")
+        case "success", "check", "done":
+            return (NSColor(srgbRed: 8 / 255, green: 185 / 255, blue: 78 / 255, alpha: 1), "checkmark.circle")
+        case "question", "help", "faq":
+            return (NSColor(srgbRed: 138 / 255, green: 92 / 255, blue: 245 / 255, alpha: 1), "questionmark.circle")
+        case "warning", "caution", "attention":
+            return (NSColor(srgbRed: 245 / 255, green: 127 / 255, blue: 23 / 255, alpha: 1), "exclamationmark.triangle")
+        case "failure", "fail", "missing":
+            return (NSColor(srgbRed: 211 / 255, green: 47 / 255, blue: 47 / 255, alpha: 1), "xmark.circle")
+        case "danger", "error", "bug":
+            return (NSColor(srgbRed: 211 / 255, green: 47 / 255, blue: 47 / 255, alpha: 1), "flame")
+        case "example":
+            return (NSColor(srgbRed: 120 / 255, green: 82 / 255, blue: 238 / 255, alpha: 1), "list.number")
+        case "quote", "cite":
+            return (NSColor(srgbRed: 158 / 255, green: 158 / 255, blue: 158 / 255, alpha: 1), "quote.opening")
+        default:
+            return (NSColor(srgbRed: 8 / 255, green: 109 / 255, blue: 221 / 255, alpha: 1), "info.circle")
         }
     }
 

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -43,11 +43,13 @@ final class CalloutAttribute {
     let type: String
     let title: String
     var isEditing: Bool
+    let id: UUID
 
-    init(type: String, title: String, isEditing: Bool = false) {
+    init(type: String, title: String, isEditing: Bool = false, id: UUID = UUID()) {
         self.type = type
         self.title = title
         self.isEditing = isEditing
+        self.id = id
     }
 }
 
@@ -71,13 +73,20 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
     /// Extend rendering bounds for code-block backgrounds (full container width)
     /// and block images drawn below text via paragraphSpacing.
+    private static let calloutBottomPadding: CGFloat = 15
+
     override var renderingSurfaceBounds: CGRect {
         var bounds = super.renderingSurfaceBounds
         if hasCodeBlockBackground || hasThematicBreak || hasBlockquote {
             let containerWidth = textLayoutManager?.textContainer?.size.width ?? bounds.width
-            // Extend left to container edge
             bounds.origin.x = -layoutFragmentFrame.origin.x
-            bounds.size.width = containerWidth
+            bounds.size.width = containerWidth + layoutFragmentFrame.origin.x
+        }
+        // Extend vertical bounds for callout bottom padding on the last fragment.
+        if hasCalloutInFragment,
+           let ts = textStorage, let range = fragmentNSRange,
+           isLastCalloutFragment(in: range, textStorage: ts) {
+            bounds.size.height += Self.calloutBottomPadding
         }
         // Extend bounds to cover block images that render below the text line
         // (visibleSource mode uses paragraphSpacing to create space for the image).
@@ -85,6 +94,11 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             bounds = bounds.union(rect)
         }
         return bounds
+    }
+
+    private var hasCalloutInFragment: Bool {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return false }
+        return hasCallout(in: range, textStorage: ts)
     }
 
     // MARK: - Drawing
@@ -560,22 +574,12 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         }
         guard let firstY = firstY, var lastMaxY = lastMaxY else { return }
 
-        // Add bottom padding equal to the natural top padding inside a fixed-
-        // height line, so the box looks vertically centered around the text.
-        // Enforce a minimum so the padding is always visible.
-        let textView = textLayoutManager?.textContainer?.textView
-        let baseFont = (textView as? NativeTextView)?.baseFont
-            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
-        let lineHeight = textLineFragments.first?.typographicBounds.height ?? 0
-        let fontHeight = baseFont.ascender - baseFont.descender
-        let bottomPadding = max(4, lineHeight - fontHeight)
-
         // Background fill. Middle fragments are plain rectangles; only the first
         // fragment rounds its top corners and the last fragment rounds its bottom
         // corners, so adjacent fragments merge into one continuous rounded box.
         let isFirst = isFirstCalloutFragment(in: range, textStorage: ts)
         let isLast = isLastCalloutFragment(in: range, textStorage: ts)
-        if isLast { lastMaxY += bottomPadding }
+        if isLast { lastMaxY += Self.calloutBottomPadding }
         let bgRect = CGRect(x: leftEdge, y: firstY, width: containerWidth, height: lastMaxY - firstY)
         let bgPath = Self.roundedRectPath(
             rect: bgRect,
@@ -619,18 +623,16 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         let tb = firstLine.typographicBounds
         let lineY = point.y + tb.origin.y
-        let lineHeight = tb.height
 
         let textView = textLayoutManager?.textContainer?.textView
         let baseFont = (textView as? NativeTextView)?.baseFont
             ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
         let titleFont = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
 
-        // Match TextKit's bottom-alignment within a fixed line height. The raw
-        // Markdown text in edit mode sits on the baseline at
-        // `lineHeight + baseFont.descender`; drawing the rendered title from
-        // that same baseline keeps the two modes pixel-aligned.
-        let baselineY = lineY + lineHeight + baseFont.descender
+        let titleTopPadding: CGFloat = 15
+        let titleRightPadding: CGFloat = Self.blockquoteIndentPerLevel * 0.5
+
+        let titleTopY = lineY + titleTopPadding
 
         // Fixed icon dimensions: height matches the full text height
         // (ascender − descender) so the icon reads as part of the line.
@@ -638,9 +640,8 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         let iconHeight = ceil(baseFont.ascender - baseFont.descender)
         let iconWidth = iconHeight + 4
         let iconX = leftEdge + indent + Self.blockquoteIndentPerLevel * 0.5
-        // Center the icon vertically on the title's cap height so it stays
-        // aligned with the text.
-        let iconCenterY = baselineY - titleFont.capHeight / 2
+        // Center the icon vertically on the first line of text at the baseline.
+        let iconCenterY = titleTopY + titleFont.ascender - titleFont.capHeight / 2
         let iconY = iconCenterY - iconHeight / 2
 
         if let baseSymbol = NSImage(systemSymbolName: style.icon, accessibilityDescription: nil) {
@@ -658,35 +659,51 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         let title = ca.title
         let theme = (textView as? NativeTextView)?.configuration.theme ?? .default
+        let titlePara = NSMutableParagraphStyle()
+        titlePara.lineSpacing = 3
         let titleAttrs: [NSAttributedString.Key: Any] = [
             .font: titleFont,
             .foregroundColor: theme.bodyText,
+            .paragraphStyle: titlePara,
         ]
         let titleX = iconX + iconWidth + 6
-        // `draw(at:)` in a flipped context uses the top edge of the text box.
-        let titleY = baselineY - titleFont.ascender
-        (title as NSString).draw(at: CGPoint(x: titleX, y: titleY), withAttributes: titleAttrs)
+        let titleY = titleTopY
+
+        let containerWidth = textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
+        let availableWidth = max(0, leftEdge + containerWidth - titleX - titleRightPadding)
+        let titleRect = NSRect(x: titleX, y: titleY, width: max(0, availableWidth), height: .greatestFiniteMagnitude)
+        (title as NSString).draw(with: titleRect, options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: titleAttrs)
     }
 
     private func isFirstCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        let currentCallout = calloutAttribute(in: range, textStorage: textStorage)
         guard let tlm = textLayoutManager,
               let tcm = tlm.textContentManager as? NSTextContentStorage else { return true }
         guard let prevLocation = tcm.location(rangeInElement.location, offsetBy: -1),
               let prevFragment = tlm.textLayoutFragment(for: prevLocation),
               let prevRange = Self.nsRange(for: prevFragment, in: tcm) else { return true }
-        return !hasCallout(in: prevRange, textStorage: textStorage)
+        guard let prevCallout = calloutAttribute(in: prevRange, textStorage: textStorage) else { return true }
+        return prevCallout.id != currentCallout?.id
     }
 
     private func isLastCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
-        // Check the text storage directly: if the character right after this
-        // fragment's range does NOT carry .callout, this is the last
-        // fragment of the callout block.  This avoids edge cases in the
-        // NSTextLayoutManager fragment graph (e.g. synthetic trailing lines)
-        // that can cause isLast to be incorrect for some callout types.
-        let nextIndex = NSMaxRange(range)
+        let currentCallout = calloutAttribute(in: range, textStorage: textStorage)
+        var nextIndex = NSMaxRange(range)
+        let nsText = textStorage.string as NSString
+        while nextIndex < textStorage.length {
+            let ch = nsText.character(at: nextIndex)
+            if ch == 0x0A || ch == 0x0D {
+                nextIndex += 1
+                continue
+            }
+            break
+        }
         guard nextIndex < textStorage.length else { return true }
-        let nextCallout = textStorage.attribute(.callout, at: nextIndex, effectiveRange: nil) as? CalloutAttribute
-        return nextCallout == nil
+        guard let nextCallout = textStorage.attribute(.callout, at: nextIndex, effectiveRange: nil) as? CalloutAttribute
+        else { return true }
+        // Adjacent callout blocks have distinct UUIDs; same id → continuation
+        // of the same callout, different id → this is the last fragment of its own.
+        return nextCallout.id != currentCallout?.id
     }
 
     private func isLastBlockquoteFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -250,11 +250,16 @@ enum MarkdownASTStyler {
                         #"\[[^\]\r\n]+\]\([^)\r\n]*$"#, #"\[[^\]\r\n]+\]\(\)"#]
         let muted = ctx.theme.mutedText
         let faded = ctx.theme.incompleteLink.withAlphaComponent(ctx.config.link.incompleteLinkAlpha)
+        let calloutMarkerRanges = attrs.compactMap { entry -> NSRange? in
+            entry.attributes[.calloutMarker] != nil ? entry.range : nil
+        }
         for pattern in patterns {
             guard let re = regex(pattern, false) else { continue }
             for scan in ctx.scanRanges {
               for m in re.matches(in: ctx.text, options: [], range: scan)
-                  where !isInCode(m.range, codeRanges) && !isInCode(m.range, checkboxRanges) {
+                  where !isInCode(m.range, codeRanges)
+                    && !isInCode(m.range, checkboxRanges)
+                    && !calloutMarkerRanges.contains(where: { NSIntersectionRange($0, m.range).length > 0 }) {
                 for (i, ch) in ctx.ns.substring(with: m.range).enumerated() {
                     let r = NSRange(location: m.range.location + i, length: 1)
                     let isBracket = ch == "[" || ch == "]" || ch == "(" || ch == ")"
@@ -326,8 +331,8 @@ enum MarkdownASTStyler {
             styleInlines(inlines, font: headingFont, ctx: ctx, into: &attrs)
 
         case .blockquote(let range, let inlines):
-            styleBlockquote(range: range, ctx: ctx, into: &attrs)
             styleInlines(inlines, font: font, ctx: ctx, into: &attrs)
+            styleBlockquote(range: range, ctx: ctx, into: &attrs)
 
         case .list(_, let items):
             for item in items {
@@ -344,14 +349,23 @@ enum MarkdownASTStyler {
         }
     }
 
+    private static let calloutRegex = try! NSRegularExpression(
+        pattern: #"^\s*\[!([A-Za-z]+)\]\s*(.*)$"#,
+        options: []
+    )
+
     /// Per-line blockquote: indent, mute content, hide/show `>` markers, tag first char with bar level.
     private static func styleBlockquote(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
         let indentPerLevel = MarkdownTextLayoutFragment.blockquoteIndentPerLevel
+        let active = ctx.isActive(range)
+        let callout = detectCallout(in: range, ctx: ctx, into: &attrs)
+
         var lineStart = range.location
         let end = NSMaxRange(range)
         while lineStart < end {
             let line = ctx.ns.lineRange(for: NSRange(location: lineStart, length: 0))
             let lineEnd = NSMaxRange(line)
+            let isFirstLine = lineStart == range.location
             var i = line.location
             var indent = 0
             while i < lineEnd, indent < 3, ctx.ns.character(at: i) == 0x20 || ctx.ns.character(at: i) == 0x09 {
@@ -376,11 +390,13 @@ enum MarkdownASTStyler {
             let contentRange = NSRange(location: j, length: max(0, contentEnd - j))
             let tokenRange = NSRange(location: line.location, length: contentEnd - line.location)
 
+            // Paragraph metrics.
             let textIndent = CGFloat(level) * indentPerLevel + indentPerLevel * 0.5
             let para = NSMutableParagraphStyle()
             para.firstLineHeadIndent = textIndent
             para.headIndent = textIndent
-            let lineHeight = ctx.baseLineHeight + ctx.config.blockquote.extraLineHeight
+            let calloutExtraHeight: CGFloat = (callout != nil) ? 2 : 0
+            let lineHeight = ctx.baseLineHeight + ctx.config.blockquote.extraLineHeight + calloutExtraHeight
             para.minimumLineHeight = lineHeight
             para.maximumLineHeight = lineHeight
             // Inner quote lines stay tight (0); the LAST line gets the normal
@@ -388,16 +404,117 @@ enum MarkdownASTStyler {
             para.paragraphSpacingBefore = 0
             attrs.append((ctx.ns.paragraphRange(for: tokenRange), [.paragraphStyle: para]))
 
-            if contentRange.length > 0 {
-                attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
-            }
-            if ctx.isActive(tokenRange) {
-                attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
-            } else {
-                attrs.append((markerRange, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
-            }
-            // Whole line, not just the first char, so each soft-wrapped visual line
+            // Content styling: callouts get special treatment; plain blockquotes get muted text.
+            styleCalloutContent(
+                callout: callout, active: active, isFirstLine: isFirstLine,
+                tokenRange: tokenRange, contentRange: contentRange, markerRange: markerRange,
+                ctx: ctx, into: &attrs
+            )
+
             attrs.append((tokenRange, [.blockquoteLevel: level]))
+        }
+    }
+
+    // MARK: - Callout Detection
+
+    private struct CalloutInfo {
+        let type: String
+        let title: String
+    }
+
+    private static func detectCallout(in range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) -> CalloutInfo? {
+        let firstLine = ctx.ns.lineRange(for: NSRange(location: range.location, length: 0))
+        var i = firstLine.location
+        var indent = 0
+        while i < NSMaxRange(firstLine), indent < 3,
+              ctx.ns.character(at: i) == 0x20 || ctx.ns.character(at: i) == 0x09 {
+            i += 1; indent += 1
+        }
+        var level = 0
+        var j = i
+        while j < NSMaxRange(firstLine), ctx.ns.character(at: j) == 0x3E /* > */ {
+            level += 1; j += 1
+            if j < NSMaxRange(firstLine), ctx.ns.character(at: j) == 0x20 || ctx.ns.character(at: j) == 0x09 {
+                j += 1
+            }
+        }
+        guard level > 0 else { return nil }
+        var firstContentEnd = NSMaxRange(firstLine)
+        if firstContentEnd > j {
+            let last = ctx.ns.character(at: firstContentEnd - 1)
+            if last == 0x0A || last == 0x0D { firstContentEnd -= 1 }
+        }
+        let firstContentRange = NSRange(location: j, length: max(0, firstContentEnd - j))
+        guard firstContentRange.length > 0 else { return nil }
+
+        let contentStr = ctx.ns.substring(with: firstContentRange)
+        let contentNS = contentStr as NSString
+        guard let match = calloutRegex.firstMatch(
+            in: contentStr,
+            options: [],
+            range: NSRange(location: 0, length: contentNS.length)
+        ) else { return nil }
+
+        let type = contentNS.substring(with: match.range(at: 1)).lowercased()
+        let rawTitle = contentNS.substring(with: match.range(at: 2))
+        let trimmedTitle = rawTitle.trimmingCharacters(in: .whitespaces)
+        let title = trimmedTitle.isEmpty ? type.capitalized : trimmedTitle
+
+        // Mark the literal `[!TYPE]` range so later regex passes leave it alone.
+        let matchRange = match.range(at: 0)
+        let open = contentNS.range(of: "[", options: [], range: matchRange)
+        let close = contentNS.range(of: "]", options: .backwards, range: matchRange)
+        if open.location != NSNotFound, close.location != NSNotFound {
+            let markerDocRange = NSRange(
+                location: firstContentRange.location + open.location,
+                length: close.location - open.location + 1
+            )
+            attrs.append((markerDocRange, [.calloutMarker: true]))
+        }
+
+        return CalloutInfo(type: type, title: title)
+    }
+
+    /// Assign callout-specific attributes to a blockquote line's content and marker.
+    private static func styleCalloutContent(
+        callout: CalloutInfo?, active: Bool, isFirstLine: Bool,
+        tokenRange: NSRange, contentRange: NSRange, markerRange: NSRange,
+        ctx: Ctx, into attrs: inout [StyledRange]
+    ) {
+        if let callout {
+            let ca = CalloutAttribute(type: callout.type, title: callout.title, isEditing: active)
+            attrs.append((tokenRange, [.callout: ca]))
+            if active {
+                if isFirstLine {
+                    attrs.append((contentRange, [
+                        .foregroundColor: ctx.theme.mutedText,
+                        .backgroundColor: NSColor.clear,
+                    ]))
+                } else if contentRange.length > 0 {
+                    attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+                }
+            } else {
+                if isFirstLine {
+                    attrs.append((contentRange, [
+                        .foregroundColor: NSColor.clear,
+                        .backgroundColor: NSColor.clear,
+                        .font: ctx.inlineMarkerFont,
+                    ]))
+                } else if contentRange.length > 0 {
+                    attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+                }
+            }
+        } else if contentRange.length > 0 {
+            attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+        }
+
+        // `>` marker visibility.
+        if active && callout != nil {
+            attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
+        } else if ctx.isActive(tokenRange) {
+            attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
+        } else {
+            attrs.append((markerRange, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
         }
     }
 

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -29,7 +29,8 @@ enum MarkdownASTStyler {
         caretLocation: Int = -1,
         wikiLinkIDProvider: @escaping (NSRange) -> String? = { _ in nil },
         scopedRanges: [NSRange]? = nil,
-        configuration: MarkdownEditorConfiguration = .default
+        configuration: MarkdownEditorConfiguration = .default,
+        contentWidth: CGFloat = 720
     ) -> [StyledRange] {
         let baseFont = NSFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
         let baseLineHeight = ceil(baseFont.ascender - baseFont.descender + baseFont.leading)
@@ -62,7 +63,8 @@ enum MarkdownASTStyler {
             caret: caretLocation,
             config: configuration,
             wikiLinkID: wikiLinkIDProvider,
-            scopedRanges: scopedRanges
+            scopedRanges: scopedRanges,
+            contentWidth: contentWidth
         )
         let blocks = DocumentAST.parse(text, scopedRanges: scopedRanges)
         var attrs: [StyledRange] = []
@@ -285,6 +287,7 @@ enum MarkdownASTStyler {
         let config: MarkdownEditorConfiguration
         let wikiLinkID: (NSRange) -> String?
         let scopedRanges: [NSRange]?
+        let contentWidth: CGFloat
 
         /// Active (syntax revealed) when the caret is inside the range or at its end (minus a newline).
         func isActive(_ range: NSRange) -> Bool {
@@ -359,6 +362,9 @@ enum MarkdownASTStyler {
         let indentPerLevel = MarkdownTextLayoutFragment.blockquoteIndentPerLevel
         let active = ctx.isActive(range)
         let callout = detectCallout(in: range, ctx: ctx, into: &attrs)
+        // One CalloutAttribute instance per block (shared UUID) so the renderer
+        // can distinguish adjacent callout blocks via `id`.
+        let calloutAttr = callout.map { CalloutAttribute(type: $0.type, title: $0.title, isEditing: active) }
 
         var lineStart = range.location
         let end = NSMaxRange(range)
@@ -396,17 +402,35 @@ enum MarkdownASTStyler {
             para.firstLineHeadIndent = textIndent
             para.headIndent = textIndent
             let calloutExtraHeight: CGFloat = (callout != nil) ? 2 : 0
-            let lineHeight = ctx.baseLineHeight + ctx.config.blockquote.extraLineHeight + calloutExtraHeight
-            para.minimumLineHeight = lineHeight
-            para.maximumLineHeight = lineHeight
-            // Inner quote lines stay tight (0); the LAST line gets the normal
-            para.paragraphSpacing = (lineEnd >= end) ? ctx.baseParagraphSpacing : 0
+            var lineHeight = ctx.baseLineHeight + ctx.config.blockquote.extraLineHeight + calloutExtraHeight
+            if !active, let callout, isFirstLine {
+                let titleFont = NSFontManager.shared.convert(ctx.baseFont, toHaveTrait: .boldFontMask)
+                let neededHeight = Self.estimatedTitleHeight(
+                    title: callout.title,
+                    font: titleFont,
+                    level: level,
+                    indentPerLevel: indentPerLevel,
+                    baseLineHeight: ctx.baseLineHeight,
+                    contentWidth: ctx.contentWidth
+                )
+                lineHeight = max(lineHeight, neededHeight)
+                para.minimumLineHeight = lineHeight
+            } else {
+                para.minimumLineHeight = lineHeight
+                para.maximumLineHeight = lineHeight
+            }
+            // Inner quote lines stay tight (0); the LAST line gets the normal,
+            // bumped up for callouts so the bottom background padding doesn't overlap
+            // with the next line's cursor area.
+            para.paragraphSpacing = (lineEnd >= end)
+                ? max(ctx.baseParagraphSpacing, calloutAttr != nil ? Self.bottomPadding : 0)
+                : 0
             para.paragraphSpacingBefore = 0
             attrs.append((ctx.ns.paragraphRange(for: tokenRange), [.paragraphStyle: para]))
 
             // Content styling: callouts get special treatment; plain blockquotes get muted text.
             styleCalloutContent(
-                callout: callout, active: active, isFirstLine: isFirstLine,
+                calloutAttr: calloutAttr, active: active, isFirstLine: isFirstLine,
                 tokenRange: tokenRange, contentRange: contentRange, markerRange: markerRange,
                 ctx: ctx, into: &attrs
             )
@@ -477,13 +501,18 @@ enum MarkdownASTStyler {
 
     /// Assign callout-specific attributes to a blockquote line's content and marker.
     private static func styleCalloutContent(
-        callout: CalloutInfo?, active: Bool, isFirstLine: Bool,
+        calloutAttr: CalloutAttribute?, active: Bool, isFirstLine: Bool,
         tokenRange: NSRange, contentRange: NSRange, markerRange: NSRange,
         ctx: Ctx, into attrs: inout [StyledRange]
     ) {
-        if let callout {
-            let ca = CalloutAttribute(type: callout.type, title: callout.title, isEditing: active)
+        if let ca = calloutAttr {
             attrs.append((tokenRange, [.callout: ca]))
+            let bodyFont: NSFont = {
+                let desc = ctx.baseFont.fontDescriptor.addingAttributes([
+                    .traits: [NSFontDescriptor.TraitKey.weight: NSFont.Weight.medium]
+                ])
+                return NSFont(descriptor: desc, size: ctx.baseFont.pointSize) ?? ctx.baseFont
+            }()
             if active {
                 if isFirstLine {
                     attrs.append((contentRange, [
@@ -491,7 +520,10 @@ enum MarkdownASTStyler {
                         .backgroundColor: NSColor.clear,
                     ]))
                 } else if contentRange.length > 0 {
-                    attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+                    attrs.append((contentRange, [
+                        .font: bodyFont,
+                        .foregroundColor: ctx.theme.bodyText,
+                    ]))
                 }
             } else {
                 if isFirstLine {
@@ -501,7 +533,10 @@ enum MarkdownASTStyler {
                         .font: ctx.inlineMarkerFont,
                     ]))
                 } else if contentRange.length > 0 {
-                    attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+                    attrs.append((contentRange, [
+                        .font: bodyFont,
+                        .foregroundColor: ctx.theme.bodyText,
+                    ]))
                 }
             }
         } else if contentRange.length > 0 {
@@ -509,13 +544,48 @@ enum MarkdownASTStyler {
         }
 
         // `>` marker visibility.
-        if active && callout != nil {
+        if active && calloutAttr != nil {
             attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
         } else if ctx.isActive(tokenRange) {
             attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
         } else {
             attrs.append((markerRange, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
         }
+    }
+
+    private static let titleTopPadding: CGFloat = 15
+    private static let titleBottomPadding: CGFloat = 8
+    private static let titleLineSpacing: CGFloat = 3
+    private static let bottomPadding: CGFloat = 15
+
+    private static func estimatedTitleHeight(
+        title: String,
+        font: NSFont,
+        level: Int,
+        indentPerLevel: CGFloat,
+        baseLineHeight: CGFloat,
+        contentWidth: CGFloat
+    ) -> CGFloat {
+        guard !title.isEmpty else { return baseLineHeight }
+
+        let indent = CGFloat(level) * indentPerLevel + indentPerLevel * 0.5
+        let iconWidth = ceil(font.ascender - font.descender) + 4
+        let titleInset = indent + iconWidth + 6
+        let rightPadding = indentPerLevel * 0.5
+        let availableWidth = max(1, contentWidth - titleInset - rightPadding)
+
+        let titlePara = NSMutableParagraphStyle()
+        titlePara.lineSpacing = titleLineSpacing
+        let attrs: [NSAttributedString.Key: Any] = [.font: font, .paragraphStyle: titlePara]
+        let size = CGSize(width: availableWidth, height: .greatestFiniteMagnitude)
+        let boundingRect = (title as NSString).boundingRect(
+            with: size,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attrs
+        )
+
+        let result = max(baseLineHeight, ceil(boundingRect.height) + titleTopPadding + titleBottomPadding)
+        return result
     }
 
     private static func styleCodeBlock(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -51,7 +51,8 @@ enum MarkdownStyler {
         wikiLinkIDProvider: @escaping (NSRange) -> String? = { _ in nil },
         precomputedTokens: [MarkdownToken]? = nil,
         scopedRanges: [NSRange]? = nil,
-        configuration: MarkdownEditorConfiguration = .default
+        configuration: MarkdownEditorConfiguration = .default,
+        contentWidth: CGFloat = 720
     ) -> [StyledRange] {
         let tokens = precomputedTokens ?? MarkdownTokenizer.parseTokensViaAST(in: text)
         let nsText = text as NSString
@@ -83,7 +84,8 @@ enum MarkdownStyler {
         result += MarkdownASTStyler.styleAttributes(
             text: text, fontName: fontName, fontSize: fontSize,
             caretLocation: caretLocation, wikiLinkIDProvider: wikiLinkIDProvider,
-            scopedRanges: scopedRanges, configuration: configuration
+            scopedRanges: scopedRanges, configuration: configuration,
+            contentWidth: contentWidth
         )
         // NSImage rendering reuses the existing, proven machinery.
         result += styleBlockLatex(ctx)

--- a/Sources/MarkdownEngine/Styling/TextStylingService.swift
+++ b/Sources/MarkdownEngine/Styling/TextStylingService.swift
@@ -83,6 +83,15 @@ struct TextStylingService {
             configuration: configuration
         )
 
+        // Block-level attributes like `.callout` can span multiple paragraphs.
+        // Make sure every touched paragraph is reset and restyled so the whole
+        // block stays consistent, not just the edited paragraph.
+        let fullText = textView.string as NSString
+        let calloutRanges = styledRanges.compactMap { entry -> NSRange? in
+            entry.attributes[.callout] != nil ? entry.range : nil
+        }
+        let affectedParagraphs = normalize(paragraphs + calloutRanges.map { fullText.paragraphRange(for: $0) })
+
         let spellingDisabledRanges = styledRanges.compactMap { (range, attrs) -> NSRange? in
             attrs[.spellingState] as? Int == 0 ? range : nil
         }
@@ -96,7 +105,7 @@ struct TextStylingService {
         for disabledRange in spellingDisabledRanges {
             textView.textStorage?.addAttribute(.spellingState, value: 0, range: disabledRange)
         }
-        for paragraph in paragraphs {
+        for paragraph in affectedParagraphs {
             textView.textStorage?.setAttributes([
                 .font: baseFont,
                 .foregroundColor: configuration.theme.bodyText,

--- a/Sources/MarkdownEngine/Styling/TextStylingService.swift
+++ b/Sources/MarkdownEngine/Styling/TextStylingService.swift
@@ -70,6 +70,13 @@ struct TextStylingService {
             return
         }
 
+        let rawWidth = textView.textContainer?.size.width
+        let containerWidth: CGFloat = {
+            if let w = rawWidth, w > 0, w.isFinite, w < 10000 { return w }
+            guard textView.bounds.width > 0 else { return 720 }
+            return textView.bounds.width - textView.textContainerInset.width * 2
+        }()
+
         let styledRanges = MarkdownStyler.styleAttributes(
             text: textView.string,
             fontName: baseFont.fontName,
@@ -80,7 +87,8 @@ struct TextStylingService {
             wikiLinkIDProvider: wikiLinkIDProvider,
             precomputedTokens: precomputedTokens,
             scopedRanges: paragraphs,
-            configuration: configuration
+            configuration: configuration,
+            contentWidth: containerWidth
         )
 
         // Block-level attributes like `.callout` can span multiple paragraphs.
@@ -125,7 +133,7 @@ struct TextStylingService {
         (textView as? NativeTextView)?.ensureVisibleLayout()
     }
 
-    private static func normalize(_ candidates: [NSRange]) -> [NSRange] {
+    static func normalize(_ candidates: [NSRange]) -> [NSRange] {
         var result: [NSRange] = []
         for candidate in candidates where candidate.location != NSNotFound && candidate.length > 0 {
             if result.contains(where: { $0.location == candidate.location && $0.length == candidate.length }) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -69,6 +69,13 @@ extension NativeTextViewCoordinator {
                 suppressed: !textView.isEditable
             )
 
+            let rawWidth = textView.textContainer?.size.width
+            let contentWidthForStyle: CGFloat = {
+                if let w = rawWidth, w > 0, w.isFinite, w < 10000 { return w }
+                guard textView.bounds.width > 0 else { return 720 }
+                return textView.bounds.width - textView.textContainerInset.width * 2
+            }()
+
             let ranges = MarkdownStyler.styleAttributes(
                 text: displayText,
                 fontName: fontName,
@@ -82,7 +89,8 @@ extension NativeTextViewCoordinator {
                 // wikiLinkMetadata was just refreshed by makeDisplayState above, so ranges match here.
                 wikiLinkIDProvider: { [weak self] range in self?.wikiLinkID(for: range) },
                 precomputedTokens: tokens,
-                configuration: configuration
+                configuration: configuration,
+                contentWidth: contentWidthForStyle
             )
             for (range, attrs) in ranges {
                 for (key, value) in attrs {
@@ -127,10 +135,12 @@ extension NativeTextViewCoordinator {
             configuration: configuration
         )
 
+        let expandedCandidates = expandCalloutParagraphs(paragraphCandidates, in: textView)
+
         TextStylingService.restyle(
             textView: textView,
             layoutBridge: layoutBridge,
-            paragraphCandidates: paragraphCandidates,
+            paragraphCandidates: expandedCandidates,
             baseFont: baseFont,
             paragraphStyle: paragraphStyle,
             caretLocation: textView.isEditable ? textView.selectedRange().location : -1,
@@ -258,6 +268,25 @@ extension NativeTextViewCoordinator {
             suppressed: !textView.isEditable
         )
         restyleTextView(textView, paragraphCandidates: paragraphs, tokens: tokens)
+    }
+
+    private func expandCalloutParagraphs(_ candidates: [NSRange], in textView: NSTextView) -> [NSRange] {
+        guard let ts = textView.textStorage else { return candidates }
+        let nsText = textView.string as NSString
+        var result = candidates
+        var idx = 0
+        while idx < ts.length {
+            var attrRange = NSRange(location: 0, length: 0)
+            guard ts.attribute(.callout, at: idx, effectiveRange: &attrRange) is CalloutAttribute else {
+                idx = NSMaxRange(attrRange); continue
+            }
+            let paraRange = nsText.paragraphRange(for: attrRange)
+            if candidates.contains(where: { NSIntersectionRange($0, paraRange).length > 0 }) {
+                result.append(paraRange)
+            }
+            idx = NSMaxRange(attrRange)
+        }
+        return TextStylingService.normalize(result)
     }
 
     func applyInlineReplacement(_ request: InlineReplacementRequest, to textView: NSTextView) {

--- a/Tests/MarkdownEngineTests/CalloutRenderTests.swift
+++ b/Tests/MarkdownEngineTests/CalloutRenderTests.swift
@@ -1,0 +1,63 @@
+//
+//  CalloutRenderTests.swift
+//  MarkdownEngineTests
+//
+//  Temporary visual regression test for callout rendering.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Callout rendering")
+struct CalloutRenderTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    @MainActor
+    @Test("Callout title is visibly rendered in render mode")
+    func calloutTitleIsVisible() throws {
+        _ = NSApplication.shared
+        let text = "> [!info] Important note\n> First body line\n> Another line"
+
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        let baseFont = NSFont.systemFont(ofSize: base)
+        textView.baseFont = baseFont
+        textView.font = baseFont
+        textView.string = text
+        let layoutDelegate = MarkdownLayoutManagerDelegate()
+        textView.textLayoutManager?.delegate = layoutDelegate
+
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: -1
+        )
+        textView.textStorage?.beginEditing()
+        for (range, a) in attrs {
+            textView.textStorage?.addAttributes(a, range: range)
+        }
+        textView.textStorage?.endEditing()
+
+        textView.layout()
+        textView.display()
+
+        guard let bitmap = textView.bitmapImageRepForCachingDisplay(in: textView.bounds) else {
+            Issue.record("failed to create bitmap rep")
+            return
+        }
+        textView.cacheDisplay(in: textView.bounds, to: bitmap)
+
+        // Sample a point on the rendered title line where the title text
+        // (not the blue background) should appear.
+        let sampleX = 80
+        let sampleY = 5
+        let color = bitmap.colorAt(x: sampleX, y: sampleY)
+        let background = MarkdownTextLayoutFragment.calloutStyle(for: "info").color.withAlphaComponent(0.1)
+        #expect(color != background, "expected visible title pixel, got background color")
+        #expect(color?.alphaComponent != 0, "expected non-transparent title pixel")
+    }
+}

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -203,7 +203,7 @@ struct MarkdownASTStylerTests {
         #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
 
         let bodyRange = ns.range(of: "body line")
-        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.bodyText)
     }
 
     @Test("Multi-line callout tags every line including escaped body lines")
@@ -272,9 +272,9 @@ struct MarkdownASTStylerTests {
         let gtRange = ns.range(of: "> ")
         #expect(color(in: attrs, at: gtRange.location) == MarkdownEditorTheme.default.mutedText)
 
-        // Body line is muted like a normal blockquote.
+        // Body line uses semibold with bodyText color in callout blocks.
         let bodyRange = ns.range(of: "body line")
-        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.mutedText)
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.bodyText)
     }
 }
 

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -178,6 +178,104 @@ struct MarkdownASTStylerTests {
             #expect(isHiddenMarkerFont(in: attrs, at: pos), "marker at \(pos) should be shrunk")
         }
     }
+
+    @Test("Callout attributes are emitted per line")
+    func calloutAttributes() {
+        let text = "> [!INFO] My Title\n> body line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let ns = text as NSString
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 2)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "My Title")
+            #expect(ca?.isEditing == false)
+        }
+
+        let titleRange = ns.range(of: "My Title")
+        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+
+        let markerRange = ns.range(of: "[!INFO]")
+        #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
+
+        let bodyRange = ns.range(of: "body line")
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("Multi-line callout tags every line including escaped body lines")
+    func multiLineCallout() {
+        let text = "> [!info] Important note\n> \\Escaped body line\n> Another line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 3)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "Important note")
+        }
+    }
+
+    @Test("Callout attributes are emitted for a realistic multi-line example")
+    func calloutAttributesForRealisticExample() {
+        let text = "> [!info] Important note\n> First body line\n> Another line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let ns = text as NSString
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 3)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "Important note")
+        }
+
+        let titleRange = ns.range(of: "Important note")
+        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+
+        let markerRange = ns.range(of: "[!info]")
+        #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
+    }
+
+    @Test("Callout stays in callout mode while the caret is inside")
+    func calloutRevealedWhenActive() {
+        let text = "> [!INFO] My Title\n> body line"
+        let ns = text as NSString
+        let caret = ns.range(of: "body line").location + 1
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: caret
+        )
+
+        // The whole block remains a callout in edit mode.
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 2)
+        let editingRanges = attrs.filter { ($0.attributes[.callout] as? CalloutAttribute)?.isEditing == true }
+        #expect(editingRanges.count == 2)
+
+        // Raw title text is visible instead of hidden, styled like blockquote content.
+        let titleRange = ns.range(of: "My Title")
+        #expect(!isHiddenMarkerFont(in: attrs, at: titleRange.location))
+        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) != true)
+        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // The `[!INFO]` marker is also muted, not callout-colored.
+        let markerRange = ns.range(of: "[!INFO]")
+        #expect(!isHiddenMarkerFont(in: attrs, at: markerRange.location))
+        #expect(color(in: attrs, at: markerRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // The `>` marker is muted like a normal blockquote marker.
+        let gtRange = ns.range(of: "> ")
+        #expect(color(in: attrs, at: gtRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // Body line is muted like a normal blockquote.
+        let bodyRange = ns.range(of: "body line")
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.mutedText)
+    }
 }
 
 /// Canonical, order-independent string of styled ranges so two style runs can be


### PR DESCRIPTION
## Summary

Adds GFM-style callout block rendering. Blockquotes starting with `[!NOTE]`, `[!WARNING]`, `[!TIP]`, and other callout markers are detected and rendered with a colored background, left accent bar, SF Symbol icon, and bold title — matching the rich visual treatment found in platforms like GitHub.

## Motivation

Callout blocks are a widely adopted GFM extension for calling attention to important information within documents. They improve readability by visually distinguishing notes, warnings, tips, and other contextual messages from plain paragraphs and blockquotes. Having native engine support means embedders get consistent, high-quality callout rendering without implementing their own overlay logic on top of raw attributed-string attributes.

## What it does

- **Detection**: regex-based `[!TYPE]` marker detection in blockquote first lines during `styleBlockquote`
- **Rendering** (two-phase):
  1. `drawCalloutBackgrounds` — rounded background fill + color-coded left accent bar, drawn *before* `super.draw` so it sits behind text
  2. `drawCalloutOverlays` — SF Symbol icon + bold title text, drawn *after* `super.draw` so it appears on top of the hidden source Markdown
- **Edit mode**: when `isActive`, the raw `> [!NOTE]` source is shown with muted styling for editing
- **Reading mode**: source is hidden; the rendered icon + title replacement is drawn instead
- **Custom titles**: `[!NOTE] My Custom Title` is supported; if omitted, the type name is capitalized as the default title
- **Nested blockquotes**: callouts respect blockquote nesting level for proper indentation
- **`CalloutAttribute`**: a single `.callout` key consolidates type, title, and edit-state metadata (previously spread across three separate attributed-string keys)
- **Block-level restyling**: edits inside a callout trigger full-block paragraph restyling via `TextStylingService`, keeping all fragment instances consistent

## Design decisions

- **Two-phase drawing**: backgrounds before `super.draw`, overlays after. This ensures the accent bar and fill are behind text, while the icon/title cover the hidden source without interacting with TextKit layout
- **First-fragment-only icon/title**: icons and titles are drawn only on the first layout fragment of a callout block, preventing duplicate rendering across fragment boundaries
- **Separate `.calloutMarker` key**: the `[!TYPE]` bracket range is tagged so downstream regex passes (e.g. incomplete-link highlighting) don't incorrectly highlight brackets inside callout markers

## Supported types

| Type | Aliases | Color | Icon |
|------|---------|-------|------|
| `[!NOTE]` | — | Blue | `note.text` |
| `[!ABSTRACT]` | `summary`, `tldr` | Teal | `doc.text` |
| `[!INFO]` | `todo` | Blue | `info.circle` |
| `[!TIP]` | `hint`, `important` | Teal | `lightbulb` |
| `[!SUCCESS]` | `check`, `done` | Green | `checkmark.circle` |
| `[!QUESTION]` | `help`, `faq` | Purple | `questionmark.circle` |
| `[!WARNING]` | `caution`, `attention` | Orange | `exclamationmark.triangle` |
| `[!FAILURE]` | `fail`, `missing` | Red | `xmark.circle` |
| `[!DANGER]` | `error`, `bug` | Red | `flame` |
| `[!EXAMPLE]` | — | Purple | `list.number` |
| `[!QUOTE]` | `cite` | Gray | `quote.opening` |

Unknown types fall back to the blue `info.circle` style.

## Not in scope

- Foldable/collapsible callouts
- Nested inline formatting within the callout title
- Title text selection or inline editing within the overlay

## Screenshots
<img width="679" height="1139" alt="Screenshot 2026-07-03 at 15 52 26" src="https://github.com/user-attachments/assets/b4b707cd-3caf-47be-b165-3c97c2627edd" />
