### PR TITLE
feat(callout): callout block pipeline with config-driven endering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately; the current document's undo stack is dropped on a switch
   because undo actions recorded against the other mode's display text would
   replay at stale ranges. Default `false` — existing embedders are unaffected.
+- Callout block support: GFM-style `> [!NOTE]`, `> [!WARNING]`, `> [!TIP]`,
+  `> [!IMPORTANT]`, `> [!CAUTION]` and more are recognized as a separate block
+  type distinct from plain blockquotes. Each callout renders a full-width
+  background fill, color-coded left accent bar, and an SF Symbol icon. Title
+  text after the type marker (e.g. `> [!NOTE] My Title`) is always visible
+  and auto-wrapping; in render mode the `[!TYPE]` syntax marker is hidden,
+  in edit mode it is revealed. Colors and icons are config-driven through
+  `CalloutConfiguration` — embedders supply a type-to-color+icon mapping and
+  the engine renders accordingly. Activation is a one-liner:
+  `BlockParser.calloutTypes = config.callout.activeTypes`. Callout blocks use
+  the same single-token-per-block model as fenced code blocks, so incremental
+  editing naturally expands to the full block range.
 
 ### Fixed
 - Inline syntax markers (`**`, `*`, `~~`, `==`) now use `mutedText` foreground
@@ -34,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   competing `.link` attribute on top of the link — making the raw URL independently
   navigable and offsetting the click edit zone. Bare URLs outside links still
   autolink; URLs inside code were already excluded.
-
 ## [0.8.0] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,6 +151,57 @@ Need a different highlighter library entirely? Implement
 above for the declaration) and reference the bundled bridge in
 `Sources/MarkdownEngineCodeBlocks/` as a working example.
 
+### Callouts
+
+Callouts render GFM-style `> [!TYPE] Title` blocks with configurable
+colors and SF Symbol icons, entirely independent of plain blockquotes.
+The engine ships with no built-in style mapping — embedders define their
+own types via `CalloutConfiguration`:
+
+```swift
+var configuration = MarkdownEditorConfiguration.default
+configuration.callout = CalloutConfiguration(types: [
+    "note":     CalloutConfiguration.CalloutStyle(color: .systemBlue,   icon: "note.text"),
+    "warning":  CalloutConfiguration.CalloutStyle(color: .systemOrange, icon: "exclamationmark.triangle"),
+    "tip":      CalloutConfiguration.CalloutStyle(color: .systemTeal,   icon: "lightbulb"),
+    "info":     CalloutConfiguration.CalloutStyle(color: .systemBlue,   icon: "info.circle"),
+    "danger":   CalloutConfiguration.CalloutStyle(color: .systemRed,    icon: "flame"),
+    "success":  CalloutConfiguration.CalloutStyle(color: .systemGreen,  icon: "checkmark.circle"),
+    "question": CalloutConfiguration.CalloutStyle(color: .systemPurple, icon: "questionmark.circle"),
+    "example":  CalloutConfiguration.CalloutStyle(color: .systemPurple, icon: "list.number"),
+    "quote":    CalloutConfiguration.CalloutStyle(color: .systemGray,   icon: "quote.opening"),
+])
+```
+
+Type names are case-insensitive. Multiple aliases can map to the same style
+(e.g. `"hint"` and `"important"` both aliased to the `"tip"` color+icon).
+
+**Activation**: Set `BlockParser.calloutTypes` once at startup — the engine
+reads this static variable internally and requires no method signature changes:
+
+```swift
+BlockParser.calloutTypes = configuration.callout.activeTypes
+```
+
+When `callout` is `.none` (the default), `> [!TYPE]` lines render as plain
+blockquotes, preserving backward compatibility.
+
+**Writing callouts in Markdown**:
+
+```markdown
+> [!NOTE] Useful information
+> This is the callout body. It supports **bold**, *italic*, and other
+> inline Markdown formatting on body lines.
+
+> [!WARNING] Breaking Change
+> Multi-line callouts work naturally — just continue with `>` on each
+> body line. A blank line separates adjacent callout blocks.
+```
+
+The title text after the type marker is always visible and auto-wraps
+to multiple lines when needed. The `[!TYPE]` syntax marker is hidden in
+reading mode and revealed while editing.
+
 ### LaTeX Rendering
 
 **Recommended path: depend on the `MarkdownEngineLatex` product and use

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -38,6 +38,7 @@ public struct MarkdownEditorConfiguration: Sendable {
     public var inlineLatex: InlineLatexStyle
     public var checkbox: CheckboxStyle
     public var blockquote: BlockquoteStyle
+    public var callout: CalloutConfiguration
     public var link: LinkStyle
     public var paragraph: ParagraphStyle
     public var overscroll: OverscrollPolicy
@@ -84,6 +85,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         inlineLatex: InlineLatexStyle = .default,
         checkbox: CheckboxStyle = .default,
         blockquote: BlockquoteStyle = .default,
+        callout: CalloutConfiguration = .none,
         link: LinkStyle = .default,
         paragraph: ParagraphStyle = .default,
         overscroll: OverscrollPolicy = .default,
@@ -108,6 +110,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.inlineLatex = inlineLatex
         self.checkbox = checkbox
         self.blockquote = blockquote
+        self.callout = callout
         self.link = link
         self.paragraph = paragraph
         self.overscroll = overscroll
@@ -448,6 +451,31 @@ public struct BlockquoteStyle: Sendable {
     }
 
     public static let `default` = BlockquoteStyle()
+}
+
+// MARK: - Callouts
+
+public struct CalloutConfiguration: Sendable {
+    public let types: [String: CalloutStyle]
+
+    public var activeTypes: Set<String> { Set(types.keys.map { $0.lowercased() }) }
+    public var isEmpty: Bool { types.isEmpty }
+
+    public init(types: [String: CalloutStyle] = [:]) {
+        self.types = types
+    }
+
+    public static let none = CalloutConfiguration()
+
+    public struct CalloutStyle: Sendable {
+        public let color: NSColor
+        public let icon: String
+
+        public init(color: NSColor, icon: String) {
+            self.color = color
+            self.icon = icon
+        }
+    }
 }
 
 // MARK: - Links

--- a/Sources/MarkdownEngine/Parser/BlockLevelTokenizer.swift
+++ b/Sources/MarkdownEngine/Parser/BlockLevelTokenizer.swift
@@ -47,6 +47,7 @@ enum BlockLevelTokenizer {
         case .fencedCode:  return codeBlock(in: sub)
         case .heading:     return heading(in: sub)
         case .blockquote:  return blockquote(in: sub)
+        case .callout:     return calloutTokens(in: sub)
         case .table:       return table(in: sub)
         case .blockLatex:  return blockLatex(in: sub)
         case .paragraph, .list, .thematicBreak, .blank:
@@ -104,6 +105,23 @@ enum BlockLevelTokenizer {
             lineStart = nextStart
         }
         return tokens
+    }
+
+    // MARK: - Callout  (single token spans the entire block, like codeBlock)
+
+    private static func calloutTokens(in s: NSString) -> [MarkdownToken] {
+        let len = s.length
+        guard len > 0 else { return [] }
+        var contentEnd = len
+        if contentEnd > 0 {
+            let last = s.character(at: contentEnd - 1)
+            if last == lf || last == cr { contentEnd -= 1 }
+        }
+        return [MarkdownToken(
+            kind: .callout,
+            range: NSRange(location: 0, length: len),
+            contentRange: NSRange(location: 0, length: contentEnd),
+            markerRanges: [])]
     }
 
     // MARK: - Fenced code  (legacy ```lang\n…\n```)

--- a/Sources/MarkdownEngine/Parser/BlockParser.swift
+++ b/Sources/MarkdownEngine/Parser/BlockParser.swift
@@ -33,6 +33,7 @@ enum BlockKind: Equatable {
     case table           // GFM table — opaque (rendered as a unit)
     case thematicBreak   // `---` / `***` / `___` — produces no token today
     case blank           // blank / whitespace-only line(s) — separator
+    case callout(type: String, title: String?)  // `> [!TYPE] title` — inline-bearing, like blockquote
 }
 
 /// One block; `range` is the absolute UTF-16 span of its lines, tiling with no gaps.
@@ -46,6 +47,11 @@ enum BlockParser {
     private static let cacheLock = NSLock()
     private static var cachedChars: [unichar]?     // UTF-16 buffer of the last parse
     private static var cachedBlocks: [Block]?
+
+    /// When non-nil and non-empty, `> [!TYPE]` lines whose TYPE is in this set
+    /// are classified as `.callout` instead of `.blockquote`. Set once by the
+    /// embedder before any text is parsed.
+    static var calloutTypes: Set<String>?
 
     /// Splits `text` into gap-free tiling blocks; memoizes the last parse so both per-keystroke callers share one line-scan.
     static func parse(_ text: String) -> [Block] {
@@ -222,6 +228,13 @@ enum BlockParser {
                 blocks.append(Block(kind: .heading, range: lines[i]))
                 i += 1
 
+            } else if let cts = Self.calloutTypes, !cts.isEmpty, isBlockquote(line),
+                      let info = calloutInfo(line, calloutTypes: cts) {
+                var end = i
+                while end + 1 < lines.count, isBlockquote(lineText(end + 1)) { end += 1 }
+                blocks.append(Block(kind: .callout(type: info.type, title: info.title), range: union(lines[i...end])))
+                i = end + 1
+
             } else if isBlockquote(line) {
                 var end = i
                 while end + 1 < lines.count, isBlockquote(lineText(end + 1)) { end += 1 }
@@ -342,6 +355,36 @@ enum BlockParser {
     /// A block-LaTeX opener: a line whose content starts with `$$`.
     private static func isBlockLatexOpen(_ line: String) -> Bool {
         line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("$$")
+    }
+
+    /// Extract (type, title) from a callout line `> [!TYPE] Title`, or nil.
+    /// Only called when `isBlockquote(line)` already passed, so we know the
+    /// line starts with `>` after optional indent.
+    private static func calloutInfo(_ line: String, calloutTypes: Set<String>) -> (type: String, title: String)? {
+        var rest = Substring(line).drop { $0 == " " || $0 == "\t" }
+        var indent = 0
+        while indent < 3, let c = rest.first, c == " " || c == "\t" { rest = rest.dropFirst(); indent += 1 }
+        guard rest.first == ">" else { return nil }
+        rest = rest.dropFirst()
+        while let c = rest.first, c == " " || c == "\t" { rest = rest.dropFirst() }
+        guard let first = rest.first, first == "[" else { return nil }
+        guard rest.count >= 4 else { return nil }
+        let afterBracket = rest.dropFirst()
+        guard afterBracket.first == "!" else { return nil }
+        let rest2 = afterBracket.dropFirst()
+        var typeChars = ""
+        var idx = rest2.startIndex
+        while idx < rest2.endIndex, rest2[idx].isLetter { typeChars.append(rest2[idx]); idx = rest2.index(after: idx) }
+        guard !typeChars.isEmpty, calloutTypes.contains(typeChars.lowercased()) else {
+            return nil
+        }
+        guard idx < rest2.endIndex, rest2[idx] == "]" else { return nil }
+        idx = rest2.index(after: idx)
+        if idx < rest2.endIndex, rest2[idx] == " " || rest2[idx] == "\t" { idx = rest2.index(after: idx) }
+        let tail = rest2[idx...]
+        let trimmed = tail.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = trimmed.isEmpty ? typeChars.capitalized : trimmed
+        return (typeChars.lowercased(), title)
     }
 
     private static func union(_ ranges: ArraySlice<NSRange>) -> NSRange {

--- a/Sources/MarkdownEngine/Parser/MarkdownAST.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownAST.swift
@@ -35,12 +35,13 @@ indirect enum BlockNode: Equatable {
     case table(range: NSRange)
     case thematicBreak(range: NSRange)
     case blank(range: NSRange)
+    case callout(type: String, title: String, range: NSRange, inlines: [InlineNode])
 
     var range: NSRange {
         switch self {
         case .paragraph(let r, _), .heading(_, let r, _, _), .blockquote(let r, _),
              .list(let r, _), .codeBlock(let r), .blockLatex(let r), .table(let r),
-             .thematicBreak(let r), .blank(let r):
+             .thematicBreak(let r), .blank(let r), .callout(_, _, let r, _):
             return r
         }
     }
@@ -81,6 +82,9 @@ enum DocumentAST {
             return .codeBlock(range: block.range)
         case .blockLatex:
             return .blockLatex(range: block.range)
+        case .callout(let type, let title):
+            return .callout(type: type, title: title ?? type.capitalized, range: block.range,
+                            inlines: scoped ? InlineParser.parse(ns, range: block.range) : [])
         case .table:
             return .table(range: block.range)
         case .thematicBreak:

--- a/Sources/MarkdownEngine/Parser/MarkdownToken.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownToken.swift
@@ -24,6 +24,8 @@ enum MarkdownTokenKind {
     case heading
     /// One blockquote line; `markerRanges[0]` is the `>` run, nesting = count of `>`.
     case blockquote
+    /// One callout line (GFM-style `> [!TYPE] Title`); per-line token like blockquote.
+    case callout
     case codeBlock
     case inlineCode
     case blockLatex

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -32,6 +32,29 @@ extension NSAttributedString.Key {
     static let scrollableBlockTotalHeight = NSAttributedString.Key("ScrollableBlockTotalHeight")
     /// NSValue(range:) — full multi-line range of the wide-table source, used to scope width-change restyles.
     static let scrollableBlockFullRange = NSAttributedString.Key("ScrollableBlockFullRange")
+    /// Consolidated callout metadata (type + title + editing flag).
+    static let callout = NSAttributedString.Key("Callout")
+    /// Marks the literal `[!TYPE]` marker of a callout so later regex passes
+    /// (e.g. incomplete-link highlighting) leave it alone.
+    static let calloutMarker = NSAttributedString.Key("CalloutMarker")
+}
+
+final class CalloutAttribute {
+    let type: String
+    let title: String
+    let color: NSColor
+    let icon: String
+    var isEditing: Bool
+    let id: UUID
+
+    init(type: String, title: String, color: NSColor, icon: String, isEditing: Bool = false, id: UUID = UUID()) {
+        self.type = type
+        self.title = title
+        self.color = color
+        self.icon = icon
+        self.isEditing = isEditing
+        self.id = id
+    }
 }
 
 final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
@@ -54,13 +77,14 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
     /// Extend rendering bounds for code-block backgrounds (full container width)
     /// and block images drawn below text via paragraphSpacing.
+    private static let calloutBottomPadding: CGFloat = 15
+
     override var renderingSurfaceBounds: CGRect {
         var bounds = super.renderingSurfaceBounds
         if hasCodeBlockBackground || hasThematicBreak || hasBlockquote {
             let containerWidth = textLayoutManager?.textContainer?.size.width ?? bounds.width
-            // Extend left to container edge
             bounds.origin.x = -layoutFragmentFrame.origin.x
-            bounds.size.width = containerWidth
+            bounds.size.width = containerWidth + layoutFragmentFrame.origin.x
         }
         // Extend bounds to cover block images that render below the text line
         // (visibleSource mode uses paragraphSpacing to create space for the image).
@@ -79,20 +103,26 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         // 2. LaTeX images (behind text — hidden markers are invisible anyway)
         drawLatexImages(at: point, in: context)
 
-        // 3. Normal text
+        // 3. Callout backgrounds/bars (behind text)
+        drawCalloutBackgrounds(at: point, in: context)
+
+        // 4. Normal text
         super.draw(at: point, in: context)
 
-        // 4. Task checkboxes (on top of hidden [ ]/[x] markers)
+        // 5. Callout icons/titles (on top of hidden source text)
+        drawCalloutOverlays(at: point, in: context)
+
+        // 6. Task checkboxes (on top of hidden [ ]/[x] markers)
         drawTaskCheckboxes(at: point, in: context)
 
-        // 4b. Bullet glyphs (on top of hidden -/*/+ markers)
+        // 5b. Bullet glyphs (on top of hidden -/*/+ markers)
         drawBulletMarkers(at: point, in: context)
 
-        // 5. Thematic breaks (full-width line, painted last so it doesn't
+        // 6. Thematic breaks (full-width line, painted last so it doesn't
         //    fight with anything that already drew at the line's center)
         drawThematicBreaks(at: point, in: context)
 
-        // 6. Blockquote bars (left gutter, behind nothing — text is indented)
+        // 7. Blockquote bars (left gutter, behind nothing — text is indented)
         drawBlockquoteBars(at: point, in: context)
     }
 
@@ -101,8 +131,12 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
     /// NSRange in the document for this fragment's content.
     private var fragmentNSRange: NSRange? {
         guard let tcs = textLayoutManager?.textContentManager as? NSTextContentStorage else { return nil }
-        let start = tcs.offset(from: tcs.documentRange.location, to: rangeInElement.location)
-        let end = tcs.offset(from: tcs.documentRange.location, to: rangeInElement.endLocation)
+        return Self.nsRange(for: self, in: tcs)
+    }
+
+    private static func nsRange(for fragment: NSTextLayoutFragment, in tcs: NSTextContentStorage) -> NSRange? {
+        let start = tcs.offset(from: tcs.documentRange.location, to: fragment.rangeInElement.location)
+        let end = tcs.offset(from: tcs.documentRange.location, to: fragment.rangeInElement.endLocation)
         guard start != NSNotFound, end != NSNotFound, end > start else { return nil }
         return NSRange(location: start, length: end - start)
     }
@@ -452,14 +486,17 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
     /// run of quote lines reads as one continuous bar.
     private func drawBlockquoteBars(at point: CGPoint, in context: CGContext) {
         guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard !hasCallout(in: range, textStorage: ts) else { return }
         var anyLevel = false
         ts.enumerateAttribute(.blockquoteLevel, in: range, options: []) { value, _, stop in
             if value is Int { anyLevel = true; stop.pointee = true }
         }
         guard anyLevel else { return }
 
-        let theme = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
-            .configuration.theme ?? .default
+        let textView = textLayoutManager?.textContainer?.textView
+        let baseFont = (textView as? NativeTextView)?.baseFont
+            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+        let theme = (textView as? NativeTextView)?.configuration.theme ?? .default
         let indentPerLevel = Self.blockquoteIndentPerLevel
         let barWidth = Self.blockquoteBarWidth
 
@@ -471,6 +508,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         let fragLocation = fragmentNSRange?.location ?? 0
         let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let isLastFragment = isLastBlockquoteFragment(in: range, textStorage: ts)
+        let lastRealLine = textLineFragments.last { fragLocation + $0.characterRange.location < ts.length }
+
         for lineFragment in textLineFragments {
             let lr = lineFragment.characterRange
             let docStart = fragLocation + lr.location
@@ -482,14 +522,191 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             if let level = ts.attribute(.blockquoteLevel, at: docStart, effectiveRange: nil) as? Int {
                 // tb.origin.y is already relative to this layout fragment.
                 let barY = point.y + tb.origin.y
+                let extend = isLastFragment && lineFragment === lastRealLine
+                let fontHeight = baseFont.ascender - baseFont.descender
+                let bottomPadding = max(0, tb.height - fontHeight)
+                let barHeight = tb.height + (extend ? bottomPadding : 0)
                 for i in 0..<level {
                     let barX = leftEdge + CGFloat(i) * indentPerLevel + indentPerLevel * 0.25
                     NSBezierPath(rect: CGRect(
-                        x: barX, y: barY, width: barWidth, height: tb.height
+                        x: barX, y: barY, width: barWidth, height: barHeight
                     )).fill()
                 }
             }
         }
+    }
+
+    // MARK: - Callouts
+
+    /// Draw a callout background + left accent bar behind text. The icon/title
+    /// overlay is drawn afterward in `drawCalloutOverlays` so it renders on top
+    /// of the hidden source text.
+    private func drawCalloutBackgrounds(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard let ca = calloutAttribute(in: range, textStorage: ts) else { return }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+        NSGraphicsContext.current = nsContext
+
+        let calloutColor = ca.color
+        let containerWidth = textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
+        let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let level = calloutLevel(in: range, textStorage: ts) ?? 1
+
+        // Vertical span of the whole callout block.
+        var firstY: CGFloat?
+        var lastMaxY: CGFloat?
+        for lineFragment in textLineFragments {
+            let tb = lineFragment.typographicBounds
+            let y = point.y + tb.origin.y
+            let maxY = y + tb.height
+            if firstY == nil { firstY = y }
+            lastMaxY = max(lastMaxY ?? y, maxY)
+        }
+        guard let firstY = firstY, var lastMaxY = lastMaxY else { return }
+
+        // Background fill — plain rectangle spanning the full container width.
+        let isLast = isLastCalloutFragment(in: range, textStorage: ts)
+        if isLast { lastMaxY += Self.calloutBottomPadding }
+        let bgRect = CGRect(x: leftEdge, y: firstY, width: containerWidth, height: lastMaxY - firstY)
+        let bgPath = NSBezierPath(rect: bgRect)
+        calloutColor.withAlphaComponent(0.1).setFill()
+        bgPath.fill()
+
+        // Left accent bar, aligned with the innermost blockquote bar for this level.
+        let barX = leftEdge + CGFloat(level - 1) * Self.blockquoteIndentPerLevel + Self.blockquoteIndentPerLevel * 0.25
+        let barRect = CGRect(x: barX, y: firstY, width: Self.blockquoteBarWidth, height: lastMaxY - firstY)
+        calloutColor.setFill()
+        NSBezierPath(rect: barRect).fill()
+    }
+
+    /// Draw the SF Symbol icon and rendered title for a callout. Called after
+    /// `super.draw` so the replacement text appears on top of the hidden source.
+    private func drawCalloutOverlays(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard let ca = calloutAttribute(in: range, textStorage: ts) else { return }
+
+        // In edit mode the raw Markdown is visible, so skip the rendered icon.
+        guard !ca.isEditing else { return }
+
+        // Icon only on the first fragment of the callout block.
+        guard isFirstCalloutFragment(in: range, textStorage: ts),
+              let firstLine = textLineFragments.first else { return }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
+        NSGraphicsContext.current = nsContext
+
+        let calloutColor = ca.color
+        let calloutIcon = ca.icon
+        let leftEdge = point.x - layoutFragmentFrame.origin.x
+        let level = calloutLevel(in: range, textStorage: ts) ?? 1
+        let indent = CGFloat(level) * Self.blockquoteIndentPerLevel
+
+        let tb = firstLine.typographicBounds
+        let lineY = point.y + tb.origin.y
+
+        let textView = textLayoutManager?.textContainer?.textView
+        let baseFont = (textView as? NativeTextView)?.baseFont
+            ?? (textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+
+        let iconHeight = ceil(baseFont.ascender - baseFont.descender)
+        let iconWidth = iconHeight + 4
+        let iconX = leftEdge + indent + Self.blockquoteIndentPerLevel * 0.5
+        let firstCharPos = firstLine.locationForCharacter(at: firstLine.characterRange.location)
+        let baselineY = lineY + firstCharPos.y
+        let iconCenterY = baselineY - baseFont.capHeight / 2
+        let iconY = iconCenterY - iconHeight / 2
+
+        if let baseSymbol = NSImage(systemSymbolName: calloutIcon, accessibilityDescription: nil) {
+            let colorConfig = NSImage.SymbolConfiguration(hierarchicalColor: calloutColor)
+            let refConfig = NSImage.SymbolConfiguration(pointSize: 20, weight: .regular)
+            let refSymbol = baseSymbol.withSymbolConfiguration(refConfig.applying(colorConfig)) ?? baseSymbol
+            let refSize = refSymbol.size
+            let scale = iconHeight / refSize.height
+            let drawWidth = refSize.width * scale
+            let drawX = iconX + (iconWidth - drawWidth) / 2
+            refSymbol.draw(in: CGRect(x: drawX, y: iconY, width: drawWidth, height: iconHeight))
+        }
+    }
+
+    private func isFirstCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        let currentCallout = calloutAttribute(in: range, textStorage: textStorage)
+        guard let tlm = textLayoutManager,
+              let tcm = tlm.textContentManager as? NSTextContentStorage else { return true }
+        guard let prevLocation = tcm.location(rangeInElement.location, offsetBy: -1),
+              let prevFragment = tlm.textLayoutFragment(for: prevLocation),
+              let prevRange = Self.nsRange(for: prevFragment, in: tcm) else { return true }
+        guard let prevCallout = calloutAttribute(in: prevRange, textStorage: textStorage) else { return true }
+        return prevCallout.id != currentCallout?.id
+    }
+
+    private func isLastCalloutFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        let currentCallout = calloutAttribute(in: range, textStorage: textStorage)
+        var nextIndex = NSMaxRange(range)
+        let nsText = textStorage.string as NSString
+        while nextIndex < textStorage.length {
+            let ch = nsText.character(at: nextIndex)
+            if ch == 0x0A || ch == 0x0D {
+                nextIndex += 1
+                continue
+            }
+            break
+        }
+        guard nextIndex < textStorage.length else { return true }
+        guard let nextCallout = textStorage.attribute(.callout, at: nextIndex, effectiveRange: nil) as? CalloutAttribute
+        else { return true }
+        // Adjacent callout blocks have distinct UUIDs; same id → continuation
+        // of the same callout, different id → this is the last fragment of its own.
+        return nextCallout.id != currentCallout?.id
+    }
+
+    private func isLastBlockquoteFragment(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        guard let tlm = textLayoutManager,
+              let tcm = tlm.textContentManager as? NSTextContentStorage else { return true }
+        guard let nextLocation = tcm.location(rangeInElement.endLocation, offsetBy: 1),
+              let nextFragment = tlm.textLayoutFragment(for: nextLocation),
+              let nextRange = Self.nsRange(for: nextFragment, in: tcm) else { return true }
+        var nextHasBlockquote = false
+        var nextHasCallout = false
+        textStorage.enumerateAttribute(.blockquoteLevel, in: nextRange, options: []) { value, _, stop in
+            if value is Int { nextHasBlockquote = true; stop.pointee = true }
+        }
+        textStorage.enumerateAttribute(.callout, in: nextRange, options: []) { value, _, stop in
+            if value is CalloutAttribute { nextHasCallout = true; stop.pointee = true }
+        }
+        // A plain blockquote bar ends when the next fragment is not a blockquote,
+        // or when it becomes a callout (callouts draw their own accent bar).
+        return !nextHasBlockquote || nextHasCallout
+    }
+
+    private func calloutAttribute(in range: NSRange, textStorage: NSTextStorage) -> CalloutAttribute? {
+        var result: CalloutAttribute?
+        textStorage.enumerateAttribute(.callout, in: range, options: []) { value, _, stop in
+            if let ca = value as? CalloutAttribute {
+                result = ca
+                stop.pointee = true
+            }
+        }
+        return result
+    }
+
+    private func hasCallout(in range: NSRange, textStorage: NSTextStorage) -> Bool {
+        calloutAttribute(in: range, textStorage: textStorage) != nil
+    }
+
+    private func calloutLevel(in range: NSRange, textStorage: NSTextStorage) -> Int? {
+        var result: Int?
+        textStorage.enumerateAttribute(.blockquoteLevel, in: range, options: []) { value, _, stop in
+            if let level = value as? Int {
+                result = level
+                stop.pointee = true
+            }
+        }
+        return result
     }
 
     // MARK: - Bullet Markers

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -97,7 +97,8 @@ enum MarkdownASTStyler {
         for block in blocks {
             switch block {
             case .codeBlock(let range): ranges.append(range)
-            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines):
+            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines),
+                 .callout(_, _, _, let inlines):
                 walk(inlines)
             case .list(_, let items):
                 for item in items { walk(item.inlines) }
@@ -134,7 +135,8 @@ enum MarkdownASTStyler {
         }
         for block in blocks {
             switch block {
-            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines):
+            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines),
+                 .callout(_, _, _, let inlines):
                 walk(inlines)
             case .list(_, let items):
                 for item in items { walk(item.inlines) }
@@ -250,11 +252,16 @@ enum MarkdownASTStyler {
                         #"\[[^\]\r\n]+\]\([^)\r\n]*$"#, #"\[[^\]\r\n]+\]\(\)"#]
         let muted = ctx.theme.mutedText
         let faded = ctx.theme.incompleteLink.withAlphaComponent(ctx.config.link.incompleteLinkAlpha)
+        let calloutMarkerRanges = attrs.compactMap { entry -> NSRange? in
+            entry.attributes[.calloutMarker] != nil ? entry.range : nil
+        }
         for pattern in patterns {
             guard let re = regex(pattern, false) else { continue }
             for scan in ctx.scanRanges {
               for m in re.matches(in: ctx.text, options: [], range: scan)
-                  where !isInCode(m.range, codeRanges) && !isInCode(m.range, checkboxRanges) {
+                  where !isInCode(m.range, codeRanges)
+                    && !isInCode(m.range, checkboxRanges)
+                    && !calloutMarkerRanges.contains(where: { NSIntersectionRange($0, m.range).length > 0 }) {
                 for (i, ch) in ctx.ns.substring(with: m.range).enumerated() {
                     let r = NSRange(location: m.range.location + i, length: 1)
                     let isBracket = ch == "[" || ch == "]" || ch == "(" || ch == ")"
@@ -329,6 +336,9 @@ enum MarkdownASTStyler {
             styleBlockquote(range: range, ctx: ctx, into: &attrs)
             styleInlines(inlines, font: font, ctx: ctx, into: &attrs)
 
+        case .callout(let type, let title, let range, _):
+            styleCallout(type: type, title: title, range: range, ctx: ctx, into: &attrs)
+
         case .list(_, let items):
             for item in items {
                 styleListItem(item, ctx: ctx, into: &attrs)
@@ -400,6 +410,148 @@ enum MarkdownASTStyler {
             attrs.append((tokenRange, [.blockquoteLevel: level]))
         }
     }
+
+    // MARK: - Callout Styling
+
+    private static func styleCallout(
+        type: String, title: String, range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]
+    ) {
+        let indentPerLevel = MarkdownTextLayoutFragment.blockquoteIndentPerLevel
+        let active = ctx.isActive(range)
+        guard let style = ctx.config.callout.types[type] else { return }
+
+        let calloutAttr = CalloutAttribute(
+            type: type, title: title, color: style.color, icon: style.icon, isEditing: active
+        )
+
+        var lineStart = range.location
+        let end = NSMaxRange(range)
+        while lineStart < end {
+            let line = ctx.ns.lineRange(for: NSRange(location: lineStart, length: 0))
+            let lineEnd = NSMaxRange(line)
+            let isFirstLine = lineStart == range.location
+            var i = line.location
+            var indent = 0
+            while i < lineEnd, indent < 3, ctx.ns.character(at: i) == 0x20 || ctx.ns.character(at: i) == 0x09 {
+                i += 1; indent += 1
+            }
+            let markerStart = i
+            var level = 0
+            var j = i
+            while j < lineEnd, ctx.ns.character(at: j) == 0x3E /* > */ {
+                level += 1; j += 1
+                if j < lineEnd, ctx.ns.character(at: j) == 0x20 || ctx.ns.character(at: j) == 0x09 { j += 1 }
+            }
+            defer { lineStart = lineEnd }
+            guard level > 0 else { continue }
+
+            var contentEnd = lineEnd
+            if contentEnd > j {
+                let last = ctx.ns.character(at: contentEnd - 1)
+                if last == 0x0A || last == 0x0D { contentEnd -= 1 }
+            }
+            let markerRange = NSRange(location: markerStart, length: j - markerStart)
+            let contentRange = NSRange(location: j, length: max(0, contentEnd - j))
+            let tokenRange = NSRange(location: line.location, length: contentEnd - line.location)
+
+            let textIndent = CGFloat(level) * indentPerLevel + indentPerLevel * 0.5
+            let iconWidth = ceil(ctx.baseFont.ascender - ctx.baseFont.descender) + 4
+
+            let para = NSMutableParagraphStyle()
+            para.firstLineHeadIndent = (isFirstLine && !active) ? textIndent + iconWidth : textIndent
+            para.headIndent = textIndent
+            let lineHeight = ctx.baseLineHeight + ctx.config.blockquote.extraLineHeight
+            para.minimumLineHeight = lineHeight
+            // First line in render mode allows wrapping for long titles (no max).
+            if active || !isFirstLine { para.maximumLineHeight = lineHeight }
+            para.paragraphSpacing = (lineEnd >= end)
+                ? max(ctx.baseParagraphSpacing, bottomPadding)
+                : 0
+            para.paragraphSpacingBefore = 0
+
+            // Stamp callout attribute on every line so the renderer can find it.
+            attrs.append((tokenRange, [.callout: calloutAttr]))
+
+            let bodyFont: NSFont = {
+                let desc = ctx.baseFont.fontDescriptor.addingAttributes([
+                    .traits: [NSFontDescriptor.TraitKey.weight: NSFont.Weight.medium]
+                ])
+                return NSFont(descriptor: desc, size: ctx.baseFont.pointSize) ?? ctx.baseFont
+            }()
+            let titleFont = NSFontManager.shared.convert(ctx.baseFont, toHaveTrait: .boldFontMask)
+
+            if contentRange.length > 0 {
+                if isFirstLine {
+                    // First line has `[!TYPE] title`; hide the syntax marker, bold the title.
+                    let contentStr = ctx.ns.substring(with: contentRange)
+                    let contentNS = contentStr as NSString
+                    let bracketRange = contentNS.range(of: "[!")
+                    let closeRange = contentNS.range(of: "]", options: [], range: bracketRange.location != NSNotFound
+                        ? NSRange(location: bracketRange.location, length: contentNS.length - bracketRange.location)
+                        : NSRange(location: 0, length: contentNS.length))
+                    if bracketRange.location != NSNotFound, closeRange.location != NSNotFound {
+                        let markerLen = closeRange.location + 1 - bracketRange.location
+                        let markerDocRange = NSRange(location: contentRange.location + bracketRange.location, length: markerLen)
+                        let afterMarker = bracketRange.location + markerLen
+                        var titleStart = afterMarker
+                        while titleStart < contentNS.length,
+                              contentNS.character(at: titleStart) == 0x20 || contentNS.character(at: titleStart) == 0x09 {
+                            titleStart += 1
+                        }
+                        let titleDocRange = NSRange(location: contentRange.location + titleStart,
+                                                     length: contentNS.length - titleStart)
+                        // Title: always bold
+                        if titleDocRange.length > 0 {
+                            attrs.append((titleDocRange, [
+                                .font: titleFont,
+                                .foregroundColor: ctx.theme.bodyText,
+                            ]))
+                        }
+                        // [!TYPE] marker: hide when inactive, show muted when editing.
+                        // When the title is empty, use base font for the marker
+                        // so the line retains its height (clear color keeps it invisible).
+                        let hideFont: NSFont = (!active && titleDocRange.length == 0)
+                            ? ctx.baseFont : ctx.inlineMarkerFont
+                        if active {
+                            attrs.append((markerDocRange, [.foregroundColor: ctx.theme.mutedText]))
+                        } else {
+                            attrs.append((markerDocRange, [
+                                .foregroundColor: NSColor.clear,
+                                .font: hideFont,
+                            ]))
+                        }
+                        // Also stamp callout marker so regex passes skip it
+                        attrs.append((markerDocRange, [.calloutMarker: true]))
+                    } else {
+                        attrs.append((contentRange, [
+                            .font: bodyFont,
+                            .foregroundColor: ctx.theme.bodyText,
+                        ]))
+                    }
+                } else {
+                    attrs.append((contentRange, [
+                        .font: bodyFont,
+                        .foregroundColor: ctx.theme.bodyText,
+                    ]))
+                }
+            }
+
+            attrs.append((ctx.ns.paragraphRange(for: tokenRange), [.paragraphStyle: para]))
+
+            // `>` marker visibility.
+            if active || ctx.isActive(tokenRange) {
+                attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
+            } else {
+                attrs.append((markerRange, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
+            }
+
+            attrs.append((tokenRange, [.blockquoteLevel: level]))
+        }
+    }
+
+    // MARK: - Code Block
+
+    private static let bottomPadding: CGFloat = 15
 
     private static func styleCodeBlock(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
         let parts = codeBlockParts(range, ctx.ns)
@@ -562,7 +714,7 @@ enum MarkdownASTStyler {
             case .heading(_, let range, let markers, let inlines):
                 if !ctx.isActive(range) { shrink(markers, ctx: ctx, into: &attrs) }
                 shrinkInlineMarkers(inlines, ctx: ctx, into: &attrs)
-            case .paragraph(_, let inlines), .blockquote(_, let inlines):
+            case .paragraph(_, let inlines), .blockquote(_, let inlines), .callout(_, _, _, let inlines):
                 shrinkInlineMarkers(inlines, ctx: ctx, into: &attrs)
             case .list(_, let items):
                 // Phase A: shrink only inline markers; the list marker is hidden by the bullet/task pass.

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -243,6 +243,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.maxOverscrollPoints = configuration.overscroll.maxPoints
         textView.minOverscrollPoints = configuration.overscroll.minPoints
         context.coordinator.configuration = configuration
+        BlockParser.calloutTypes = configuration.callout.isEmpty ? nil : configuration.callout.activeTypes
         textView.insertionPointColor = configuration.theme.bodyText
         textView.isEditable = isEditable
         textView.isSelectable = true

--- a/Tests/MarkdownEngineTests/CalloutRenderTests.swift
+++ b/Tests/MarkdownEngineTests/CalloutRenderTests.swift
@@ -1,0 +1,73 @@
+//
+//  CalloutRenderTests.swift
+//  MarkdownEngineTests
+//
+//  Tests for callout attribute emission.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Callout rendering")
+struct CalloutRenderTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    private static let calloutConfig = CalloutConfiguration(types: [
+        "info": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "info.circle"),
+        "note": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "note.text"),
+        "warning": CalloutConfiguration.CalloutStyle(color: .systemOrange, icon: "exclamationmark.triangle"),
+    ])
+
+    @MainActor
+    @Test("Callout attribute is emitted for > [!info] blocks")
+    func calloutAttributeEmitted() throws {
+        _ = NSApplication.shared
+        let text = "> [!info] Important note\n> First body line\n> Another line"
+
+        var config = MarkdownEditorConfiguration.default
+        config.callout = Self.calloutConfig
+        BlockParser.calloutTypes = config.callout.activeTypes
+        defer { BlockParser.calloutTypes = nil }
+
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: -1,
+            configuration: config
+        )
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] is CalloutAttribute }
+        #expect(!calloutRanges.isEmpty, "expected callout attribute to be emitted for > [!info] block")
+
+        let calloutAttr = calloutRanges.first?.attributes[.callout] as? CalloutAttribute
+        #expect(calloutAttr?.type == "info", "expected type 'info', got '\(calloutAttr?.type ?? "nil")'")
+        #expect(calloutAttr?.title == "Important note", "expected title 'Important note', got '\(calloutAttr?.title ?? "nil")'")
+    }
+
+    @MainActor
+    @Test("Block without callout config stays as blockquote")
+    func noCalloutConfigFallsBackToBlockquote() throws {
+        _ = NSApplication.shared
+        let text = "> [!info] No config"
+
+        var config = MarkdownEditorConfiguration.default
+        config.callout = .none
+        BlockParser.calloutTypes = nil
+
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: -1,
+            configuration: config
+        )
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] is CalloutAttribute }
+        #expect(calloutRanges.isEmpty, "expected no callout attribute when config is empty")
+    }
+}

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -181,8 +181,16 @@ struct MarkdownASTStylerTests {
 
     @Test("Callout attributes are emitted per line")
     func calloutAttributes() {
+        BlockParser.calloutTypes = ["info"]
+        defer { BlockParser.calloutTypes = nil }
+        var config = MarkdownEditorConfiguration.default
+        config.callout = CalloutConfiguration(types: [
+            "info": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "info.circle")
+        ])
         let text = "> [!INFO] My Title\n> body line"
-        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: config
+        )
         let ns = text as NSString
 
         let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
@@ -194,22 +202,32 @@ struct MarkdownASTStylerTests {
             #expect(ca?.isEditing == false)
         }
 
+        // Title is always visible (bold + bodyText).
         let titleRange = ns.range(of: "My Title")
-        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
-        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.bodyText)
 
+        // [!INFO] marker is hidden (clear + tiny font) when inactive.
         let markerRange = ns.range(of: "[!INFO]")
         #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
-        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
 
+        // Body line: medium body font + bodyText.
         let bodyRange = ns.range(of: "body line")
         #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.bodyText)
     }
 
     @Test("Multi-line callout tags every line including escaped body lines")
     func multiLineCallout() {
+        BlockParser.calloutTypes = ["info"]
+        defer { BlockParser.calloutTypes = nil }
+        var config = MarkdownEditorConfiguration.default
+        config.callout = CalloutConfiguration(types: [
+            "info": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "info.circle")
+        ])
         let text = "> [!info] Important note\n> \\Escaped body line\n> Another line"
-        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: config
+        )
         let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
         #expect(calloutRanges.count == 3)
         for entry in calloutRanges {
@@ -221,8 +239,16 @@ struct MarkdownASTStylerTests {
 
     @Test("Callout attributes are emitted for a realistic multi-line example")
     func calloutAttributesForRealisticExample() {
+        BlockParser.calloutTypes = ["info"]
+        defer { BlockParser.calloutTypes = nil }
+        var config = MarkdownEditorConfiguration.default
+        config.callout = CalloutConfiguration(types: [
+            "info": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "info.circle")
+        ])
         let text = "> [!info] Important note\n> First body line\n> Another line"
-        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: config
+        )
         let ns = text as NSString
 
         let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
@@ -233,22 +259,29 @@ struct MarkdownASTStylerTests {
             #expect(ca?.title == "Important note")
         }
 
+        // Title is always visible (bold + bodyText).
         let titleRange = ns.range(of: "Important note")
-        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
-        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.bodyText)
 
+        // [!info] marker is hidden (clear + tiny font) when inactive.
         let markerRange = ns.range(of: "[!info]")
         #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
-        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
     }
 
     @Test("Callout stays in callout mode while the caret is inside")
     func calloutRevealedWhenActive() {
+        BlockParser.calloutTypes = ["info"]
+        defer { BlockParser.calloutTypes = nil }
+        var config = MarkdownEditorConfiguration.default
+        config.callout = CalloutConfiguration(types: [
+            "info": CalloutConfiguration.CalloutStyle(color: .systemBlue, icon: "info.circle")
+        ])
         let text = "> [!INFO] My Title\n> body line"
         let ns = text as NSString
         let caret = ns.range(of: "body line").location + 1
         let attrs = MarkdownASTStyler.styleAttributes(
-            text: text, fontName: fontName, fontSize: base, caretLocation: caret
+            text: text, fontName: fontName, fontSize: base, caretLocation: caret, configuration: config
         )
 
         // The whole block remains a callout in edit mode.
@@ -257,18 +290,16 @@ struct MarkdownASTStylerTests {
         let editingRanges = attrs.filter { ($0.attributes[.callout] as? CalloutAttribute)?.isEditing == true }
         #expect(editingRanges.count == 2)
 
-        // Raw title text is visible instead of hidden, styled like blockquote content.
+        // Title is always bold (visible even in edit mode).
         let titleRange = ns.range(of: "My Title")
-        #expect(!isHiddenMarkerFont(in: attrs, at: titleRange.location))
-        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) != true)
-        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.mutedText)
+        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.bodyText)
 
-        // The `[!INFO]` marker is also muted, not callout-colored.
+        // [!INFO] marker is muted when active (editing), not hidden.
         let markerRange = ns.range(of: "[!INFO]")
-        #expect(!isHiddenMarkerFont(in: attrs, at: markerRange.location))
         #expect(color(in: attrs, at: markerRange.location) == MarkdownEditorTheme.default.mutedText)
 
-        // The `>` marker is muted like a normal blockquote marker.
+        // `>` marker is muted when active.
         let gtRange = ns.range(of: "> ")
         #expect(color(in: attrs, at: gtRange.location) == MarkdownEditorTheme.default.mutedText)
 

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -178,6 +178,104 @@ struct MarkdownASTStylerTests {
             #expect(isHiddenMarkerFont(in: attrs, at: pos), "marker at \(pos) should be shrunk")
         }
     }
+
+    @Test("Callout attributes are emitted per line")
+    func calloutAttributes() {
+        let text = "> [!INFO] My Title\n> body line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let ns = text as NSString
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 2)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "My Title")
+            #expect(ca?.isEditing == false)
+        }
+
+        let titleRange = ns.range(of: "My Title")
+        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+
+        let markerRange = ns.range(of: "[!INFO]")
+        #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
+
+        let bodyRange = ns.range(of: "body line")
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.bodyText)
+    }
+
+    @Test("Multi-line callout tags every line including escaped body lines")
+    func multiLineCallout() {
+        let text = "> [!info] Important note\n> \\Escaped body line\n> Another line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 3)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "Important note")
+        }
+    }
+
+    @Test("Callout attributes are emitted for a realistic multi-line example")
+    func calloutAttributesForRealisticExample() {
+        let text = "> [!info] Important note\n> First body line\n> Another line"
+        let attrs = MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base)
+        let ns = text as NSString
+
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 3)
+        for entry in calloutRanges {
+            let ca = entry.attributes[.callout] as? CalloutAttribute
+            #expect(ca?.type == "info")
+            #expect(ca?.title == "Important note")
+        }
+
+        let titleRange = ns.range(of: "Important note")
+        #expect(color(in: attrs, at: titleRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: titleRange.location))
+
+        let markerRange = ns.range(of: "[!info]")
+        #expect(color(in: attrs, at: markerRange.location) == NSColor.clear)
+        #expect(isHiddenMarkerFont(in: attrs, at: markerRange.location))
+    }
+
+    @Test("Callout stays in callout mode while the caret is inside")
+    func calloutRevealedWhenActive() {
+        let text = "> [!INFO] My Title\n> body line"
+        let ns = text as NSString
+        let caret = ns.range(of: "body line").location + 1
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: caret
+        )
+
+        // The whole block remains a callout in edit mode.
+        let calloutRanges = attrs.filter { $0.attributes[.callout] != nil }
+        #expect(calloutRanges.count == 2)
+        let editingRanges = attrs.filter { ($0.attributes[.callout] as? CalloutAttribute)?.isEditing == true }
+        #expect(editingRanges.count == 2)
+
+        // Raw title text is visible instead of hidden, styled like blockquote content.
+        let titleRange = ns.range(of: "My Title")
+        #expect(!isHiddenMarkerFont(in: attrs, at: titleRange.location))
+        #expect(font(in: attrs, at: titleRange.location)?.fontDescriptor.symbolicTraits.contains(.bold) != true)
+        #expect(color(in: attrs, at: titleRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // The `[!INFO]` marker is also muted, not callout-colored.
+        let markerRange = ns.range(of: "[!INFO]")
+        #expect(!isHiddenMarkerFont(in: attrs, at: markerRange.location))
+        #expect(color(in: attrs, at: markerRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // The `>` marker is muted like a normal blockquote marker.
+        let gtRange = ns.range(of: "> ")
+        #expect(color(in: attrs, at: gtRange.location) == MarkdownEditorTheme.default.mutedText)
+
+        // Body line uses semibold with bodyText color in callout blocks.
+        let bodyRange = ns.range(of: "body line")
+        #expect(color(in: attrs, at: bodyRange.location) == MarkdownEditorTheme.default.bodyText)
+    }
 }
 
 /// Canonical, order-independent string of styled ranges so two style runs can be


### PR DESCRIPTION
## Summary

Adds config-driven callout block support as a standalone pipeline, entirely
separate from blockquotes. Embedders supply type-to-color+icon mappings via
`CalloutConfiguration`, and the engine renders GFM-style callouts with
background fill, colored accent bar, and SF Symbol icons.

## Problem

The previous callout implementation on `local` was tied to blockquote styling
— detection happened inside `styleBlockquote()` via regex, making the feature
hard to isolate, test, and review independently.

## Solution

A dedicated `BlockKind.callout` in `BlockParser`, activated by a single static
injection point (`BlockParser.calloutTypes`). No method signatures change
anywhere in the parser/styler/tokenizer pipeline.

- **Parser**: `calloutInfo()` hand-scanner classifies `> [!TYPE]` lines before
  `isBlockquote()` in `computeBlocks`
- **Token**: single token per block (like `codeBlock`), so incremental editing
  naturally expands to the full callout range via `tokenRestyleParagraphs`
- **Styler**: `styleCallout()` independent of `styleBlockquote()`; title always
  visible, `[!TYPE]` marker hidden in render mode
- **Renderer**: plain rectangle background + left accent bar + SF Symbol icon
  (no rounded corners, no overlay title)
- **Config**: `CalloutConfiguration` with `CalloutStyle(color:icon:)` per type;
  `.none` default preserves backward compatibility
