### PR TITLE
feat(toc): add headings extraction, scroll-to-range, and per-editor TOC integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Table-of-contents integration for embedder outline panels:
+  - `DocumentHeading` — public heading entry (`level`, `title`, source-coordinate `range`).
+  - `HeadingExtractor` — walks the engine AST to collect ATX headings (skips headings
+    inside fenced code blocks; title text strips inline markup).
+  - `NativeTextViewWrapper.onHeadingsDidChange` — closure called with the current
+    `[DocumentHeading]` list whenever heading structure changes.
+  - `NativeTextViewWrapper.scrollHandler` — per-editor `ScrollHandler` object
+    through which the embedder requests scroll-to-range; the engine fills in the
+    handler during `makeNSView` for direct coordinator invocation.
+  - `scrollRangeIntoView(_:in:)` — shared reading-column scroll helper (also used by
+    find-match reveal).
 - `MarkdownEditorConfiguration.rawSourceMode`: present the document as raw
   Markdown source — no syntax hiding, no markdown styling, and no wiki-link
   display transform (`[[Name|UUID]]` shows verbatim). The editor keeps base

--- a/Sources/MarkdownEngine/Parser/HeadingExtractor.swift
+++ b/Sources/MarkdownEngine/Parser/HeadingExtractor.swift
@@ -1,0 +1,62 @@
+//
+//  HeadingExtractor.swift
+//  MarkdownEngine
+//
+//  Extracts table-of-contents entries from the document AST.
+//
+
+import Foundation
+
+enum HeadingExtractor {
+
+    static func extract(from text: String) -> [DocumentHeading] {
+        let ns = text as NSString
+        return DocumentAST.parse(text).compactMap { block in
+            guard case .heading(let level, let range, _, let inlines) = block else { return nil }
+            let title = plainText(from: inlines, in: ns).trimmingCharacters(in: .whitespacesAndNewlines)
+            return DocumentHeading(
+                level: level,
+                title: title,
+                rangeLocation: range.location,
+                rangeLength: range.length
+            )
+        }
+    }
+
+    private static func plainText(from nodes: [InlineNode], in ns: NSString) -> String {
+        var parts: [String] = []
+        for node in nodes {
+            appendPlainText(node, to: &parts, in: ns)
+        }
+        return parts.joined()
+    }
+
+    private static func appendPlainText(_ node: InlineNode, to parts: inout [String], in ns: NSString) {
+        switch node {
+        case .text(let range):
+            parts.append(ns.substring(with: range))
+        case .code(_, let content):
+            parts.append(ns.substring(with: content))
+        case .emphasis(_, _, _, let children),
+             .strikethrough(_, _, let children),
+             .highlight(_, _, let children):
+            for child in children { appendPlainText(child, to: &parts, in: ns) }
+        case .link(_, let textRange, _, _, let children):
+            if children.isEmpty {
+                parts.append(ns.substring(with: textRange))
+            } else {
+                for child in children { appendPlainText(child, to: &parts, in: ns) }
+            }
+        case .image(_, let alt, _, _):
+            parts.append(ns.substring(with: alt))
+        case .wikiLink(_, let name, _, _):
+            parts.append(ns.substring(with: name))
+        case .imageEmbed(_, let target, _):
+            parts.append(ns.substring(with: target))
+        case .inlineLatex(_, let content, _):
+            parts.append(ns.substring(with: content))
+        case .escape(_, let character, _):
+            parts.append(ns.substring(with: character))
+        }
+    }
+}

--- a/Sources/MarkdownEngine/Services/DocumentHeading.swift
+++ b/Sources/MarkdownEngine/Services/DocumentHeading.swift
@@ -1,0 +1,27 @@
+//
+//  DocumentHeading.swift
+//  MarkdownEngine
+//
+//  Public heading entry for embedder table-of-contents UIs.
+//
+
+import Foundation
+
+/// One ATX heading in the document, extracted from the engine's AST parse.
+public struct DocumentHeading: Sendable, Equatable {
+    public let level: Int
+    public let title: String
+    public let rangeLocation: Int
+    public let rangeLength: Int
+
+    public init(level: Int, title: String, rangeLocation: Int, rangeLength: Int) {
+        self.level = level
+        self.title = title
+        self.rangeLocation = rangeLocation
+        self.rangeLength = rangeLength
+    }
+
+    public var range: NSRange {
+        NSRange(location: rangeLocation, length: rangeLength)
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -85,33 +85,7 @@ extension NativeTextViewCoordinator {
         guard allRanges.indices.contains(currentIndex) else { return }
         let range = allRanges[currentIndex]
         guard range.location + range.length <= fullRange.length else { return }
-        // Default (text view IS documentView): native reveal — unchanged for non-readingWidth embedders.
-        guard configuration.readingWidth != nil,
-              let tlm = tv.textLayoutManager,
-              let scrollView = tv.enclosingScrollView,
-              let matchStart = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: range.location) else {
-            tv.scrollRangeToVisible(range)
-            return
-        }
-        // Reading column: text view is a centered subview of the container — scroll the clip explicitly.
-        tlm.enumerateTextLayoutFragments(from: matchStart, options: [.ensuresLayout]) { fragment in
-            let cv = scrollView.contentView
-            let insetsTop = scrollView.contentInsets.top
-            // Fragment frames are text-view-local; the scroll offset is in
-            // document-view space — lift by the text view's offset inside the
-            // container (the header band).
-            let frame = fragment.layoutFragmentFrame.offsetBy(dx: 0, dy: tv.frame.origin.y)
-            let visibleTop = cv.bounds.origin.y + insetsTop
-            let visibleBottom = cv.bounds.origin.y + cv.bounds.height
-            // Only scroll when the match is off-screen; reveal it a little below the top.
-            if frame.minY < visibleTop || frame.maxY > visibleBottom {
-                let targetY = frame.minY - insetsTop - cv.bounds.height * 0.2
-                cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
-                scrollView.reflectScrolledClipView(cv)
-                (scrollView as? ClampedScrollView)?.clampToInsets()
-            }
-            return false
-        }
+        scrollRangeIntoView(range, in: tv)
     }
 
     @objc func handleFindClearHighlights(_ notification: Notification) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Headings.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Headings.swift
@@ -1,0 +1,51 @@
+//
+//  NativeTextViewCoordinator+Headings.swift
+//  MarkdownEngine
+//
+//  Sidebar TOC integration: extracts headings from the document and
+//  scrolls to a caller-supplied source-coordinate range on demand.
+//
+
+import AppKit
+import Foundation
+
+extension NativeTextViewCoordinator {
+
+    func postHeadingsDidChange(for text: String) {
+        let headings = HeadingExtractor.extract(from: text)
+        guard headings != lastPostedHeadings else { return }
+        lastPostedHeadings = headings
+        onHeadingsDidChange?(headings)
+    }
+
+    /// Scrolls `range` into view without changing selection or adding find highlights.
+    func scrollRangeIntoView(_ range: NSRange, in tv: NSTextView) {
+        let fullLength = (tv.string as NSString).length
+        guard range.location < fullLength else { return }
+
+        guard let tlm = tv.textLayoutManager,
+              let scrollView = tv.enclosingScrollView,
+              let matchStart = tlm.textContentManager?.location(
+                tlm.documentRange.location, offsetBy: range.location)
+        else {
+            tv.scrollRangeToVisible(range)
+            return
+        }
+
+        tlm.ensureLayout(for: tlm.documentRange)
+        tlm.enumerateTextLayoutFragments(from: matchStart, options: [.ensuresLayout]) { fragment in
+            let cv = scrollView.contentView
+            let insetsTop = scrollView.contentInsets.top
+            let frame = fragment.layoutFragmentFrame.offsetBy(dx: 0, dy: tv.frame.origin.y)
+            let visibleTop = cv.bounds.origin.y + insetsTop
+            let visibleBottom = cv.bounds.origin.y + cv.bounds.height
+            if frame.minY < visibleTop || frame.maxY > visibleBottom {
+                let targetY = frame.minY - insetsTop - cv.bounds.height * 0.2
+                cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
+                scrollView.reflectScrolledClipView(cv)
+                (scrollView as? ClampedScrollView)?.clampToInsets()
+            }
+            return false
+        }
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -87,6 +87,7 @@ extension NativeTextViewCoordinator {
                 bottomTextView.recalcOverscroll(for: scrollView, debugTag: "textDidChange")
                 (scrollView as? ClampedScrollView)?.clampToInsets()
             }
+            postHeadingsDidChange(for: tv.string)
             return
         }
         let wtActive = isWritingToolsActive
@@ -198,6 +199,7 @@ extension NativeTextViewCoordinator {
         updateCodeBlockSelection(textView: tv, tokens: tokens)
         if wtActive {
             previousActiveTokenIndices = activeTokenIndices
+            postHeadingsDidChange(for: tv.string)
             return
         }
         if let bottomTextView = tv as? NativeTextView,
@@ -206,6 +208,7 @@ extension NativeTextViewCoordinator {
             (scrollView as? ClampedScrollView)?.clampToInsets()
         }
         previousActiveTokenIndices = activeTokenIndices
+        postHeadingsDidChange(for: tv.string)
     }
 
     public func textViewDidChangeSelection(_ notification: Notification) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -51,6 +51,8 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var lastImageFingerprint: AnyHashable?
     var lastWikiFingerprint: AnyHashable?
     private var busObservers: [NSObjectProtocol] = []
+    /// Closure called when the document's ATX headings change.
+    var onHeadingsDidChange: (([DocumentHeading]) -> Void)?
     private var registeredAppearanceObserverName: Notification.Name?
     weak var textView: NSTextView?
     /// Owns the scroll-away header (build, content refresh, collapse/expand,
@@ -96,6 +98,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var cachedCodeBlockTokens: [(index: Int, token: MarkdownToken)] = []
     var cachedParsedText: String?
     var cachedParsedDocument: ParsedDocument?
+    var lastPostedHeadings: [DocumentHeading]?
     // Skip spellcheck property setters when the state wouldn't change.
     var cachedSpellingDisabled: Bool?
 
@@ -299,6 +302,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
 
     // Find-in-document highlight handlers live in
     // `NativeTextViewCoordinator+Find.swift`.
+    // Table-of-contents integration lives in `NativeTextViewCoordinator+Headings.swift`.
 
     func wikiLinkID(for range: NSRange) -> String? {
         wikiLinkMetadata[WikiLinkService.RangeKey(range)]?.id

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -127,6 +127,12 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// Called on mouse-move with the event location in window coordinates.
     /// Return `true` to show the arrow cursor instead of the I-beam.
     public var isCursorExcluded: ((CGPoint) -> Bool)?
+    /// Called with the current ATX headings whenever the document's heading
+    /// structure changes, so embedders can populate a TOC outline.
+    public var onHeadingsDidChange: (([DocumentHeading]) -> Void)?
+    /// Object through which the embedder requests scroll-to-range.
+    /// The engine fills in the handler during `makeNSView`.
+    public var scrollHandler: ScrollHandler
 
     public init(
         text: Binding<String>,
@@ -145,6 +151,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         onInlinePreviewKey: ((InlinePreviewKey) -> Bool)? = nil,
         onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)? = nil,
         onSpellCheckingPolicyChanged: ((SpellCheckingPolicy) -> Void)? = nil,
+        onHeadingsDidChange: (([DocumentHeading]) -> Void)? = nil,
+        scrollHandler: ScrollHandler = ScrollHandler(),
         placeholder: NSAttributedString? = nil,
         header: AnyView? = nil,
         headerCollapsedHeight: CGFloat = 0,
@@ -168,6 +176,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.onInlinePreviewKey = onInlinePreviewKey
         self.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         self.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
+        self.onHeadingsDidChange = onHeadingsDidChange
+        self.scrollHandler = scrollHandler
         self.placeholder = placeholder
         self.header = header
         self.headerCollapsedHeight = headerCollapsedHeight
@@ -367,6 +377,12 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             context.coordinator.updateCodeBlockSelection(textView: textView)
         }
         reconcileHeader(textView: textView, context: context)
+        context.coordinator.postHeadingsDidChange(for: textView.string)
+        let ctx = context
+        scrollHandler.scroll = { [weak tv = textView] (range: NSRange) in
+            guard let tv else { return }
+            ctx.coordinator.scrollRangeIntoView(range, in: tv)
+        }
         return scrollView
     }
 
@@ -590,7 +606,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
         context.coordinator.onInlinePreviewKey = onInlinePreviewKey
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
+        context.coordinator.onHeadingsDidChange = onHeadingsDidChange
         context.coordinator.didInitialFormatting = true
+        context.coordinator.postHeadingsDidChange(for: textView.string)
     }
 
     public func makeCoordinator() -> Coordinator {
@@ -612,6 +630,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.userPrefersGrammarChecking = configuration.spellChecking.grammarChecking
         coordinator.userPrefersAutomaticSpellingCorrection = configuration.spellChecking.automaticSpellingCorrection
         coordinator.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
+        coordinator.onHeadingsDidChange = onHeadingsDidChange
         return coordinator
     }
 }

--- a/Sources/MarkdownEngine/TextView/ScrollHandler.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollHandler.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Per-editor object that bridges scroll-to-range requests from the embedder
+/// to the engine coordinator without NotificationCenter or SwiftUI bindings.
+/// The embedder creates one instance and passes it to the wrapper; the
+/// wrapper fills in the handler during `makeNSView`.
+public final class ScrollHandler: NSObject {
+    public var scroll: ((NSRange) -> Void)?
+}

--- a/Tests/MarkdownEngineTests/HeadingsBusTests.swift
+++ b/Tests/MarkdownEngineTests/HeadingsBusTests.swift
@@ -1,0 +1,46 @@
+//
+//  HeadingsBusTests.swift
+//  MarkdownEngineTests
+//
+
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Heading extraction")
+struct HeadingsBusTests {
+
+    @Test func extractsNestedHeadings() {
+        let text = "# One\n\n## Two\n\n### Three\n"
+        let headings = HeadingExtractor.extract(from: text)
+        #expect(headings.count == 3)
+        #expect(headings[0].level == 1)
+        #expect(headings[0].title == "One")
+        #expect(headings[1].level == 2)
+        #expect(headings[1].title == "Two")
+        #expect(headings[2].level == 3)
+        #expect(headings[2].title == "Three")
+    }
+
+    @Test func extractsBoldTitleText() {
+        let text = "# **Bold** title\n"
+        let headings = HeadingExtractor.extract(from: text)
+        #expect(headings.count == 1)
+        #expect(headings[0].title == "Bold title")
+    }
+
+    @Test func ignoresHeadingInsideCodeBlock() {
+        let text = "```\n# Not a heading\n```\n\n# Real\n"
+        let headings = HeadingExtractor.extract(from: text)
+        #expect(headings.count == 1)
+        #expect(headings[0].title == "Real")
+    }
+
+    @Test func headingRangeCoversLine() {
+        let text = "## Hello\n"
+        let headings = HeadingExtractor.extract(from: text)
+        #expect(headings.count == 1)
+        let ns = text as NSString
+        #expect(ns.substring(with: headings[0].range).hasPrefix("##"))
+    }
+}


### PR DESCRIPTION
## Summary

Adds public heading-extraction and scroll-to-heading APIs so an embedder can build an outline / TOC panel alongside the editor.

## Problem

The engine rendered headings, but there was no public way to:

1. Enumerate the headings in a document with level, title, and source range.
2. Receive updates when headings changed after edits.
3. Programmatically scroll the editor to a heading's source range.

This made it impossible to build a navigation / TOC sidebar without re-parsing the Markdown outside the engine.

## Solution

- `DocumentHeading` — public struct describing one heading (`level`, `title`, `range` in source coordinates).
- `HeadingExtractor` — AST-based collector for ATX headings; excludes headings inside code blocks and strips inline markup from the title text.
- `NativeTextViewWrapper.onHeadingsDidChange` — closure callback that fires after text changes with the current heading list (deduplicated).
- `ScrollHandler` — per-editor `NSObject` bridge that the embedder owns and the engine fills in `makeNSView`, so the embedder can request scrolls directly.
- `scrollRangeIntoView(_:in:)` — shared TextKit 2 layout-fragment scroll helper used by both TOC reveal and existing find-match reveal.
- `HeadingsBusTests` — unit tests covering heading extraction, code-block exclusion, and title-stripping.
