### PR TITLE
Add find & replace (replaceCurrent / replaceAll bus handlers)

### DIFF
--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -244,6 +244,17 @@ public struct MarkdownEditorBus: Sendable {
     /// Posted by the engine in response to `findQuery` with `userInfo["count"] as? Int`
     /// (number of matches in the displayed text), so the host can show "x of y".
     public var findResults: Notification.Name?
+    /// Posted by the host UI to replace the current find match. Expected
+    /// `userInfo["query"] as? String`, `userInfo["replacement"] as? String`,
+    /// optional `userInfo["currentIndex"] as? Int`. The engine edits its own
+    /// displayed text (with undo), re-highlights the remaining matches, and
+    /// posts `findResults` with the new count.
+    public var replaceCurrent: Notification.Name?
+    /// Posted by the host UI to replace every find match in one undo step.
+    /// Expected `userInfo["query"] as? String`, `userInfo["replacement"] as? String`.
+    /// The engine posts `findResults` with the count still matching afterward
+    /// (non-zero only if the replacement itself contains the query).
+    public var replaceAll: Notification.Name?
 
     public init(
         applyBoldRequest: Notification.Name? = nil,
@@ -265,7 +276,9 @@ public struct MarkdownEditorBus: Sendable {
         findScrollToRange: Notification.Name? = nil,
         findClearHighlights: Notification.Name? = nil,
         findQuery: Notification.Name? = nil,
-        findResults: Notification.Name? = nil
+        findResults: Notification.Name? = nil,
+        replaceCurrent: Notification.Name? = nil,
+        replaceAll: Notification.Name? = nil
     ) {
         self.applyBoldRequest = applyBoldRequest
         self.applyItalicRequest = applyItalicRequest
@@ -287,6 +300,8 @@ public struct MarkdownEditorBus: Sendable {
         self.findClearHighlights = findClearHighlights
         self.findQuery = findQuery
         self.findResults = findResults
+        self.replaceCurrent = replaceCurrent
+        self.replaceAll = replaceAll
     }
 
     public static let `default` = MarkdownEditorBus()

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -34,26 +34,98 @@ extension NativeTextViewCoordinator {
               let query = info["query"] as? String else { return }
         let requestedIndex = info["currentIndex"] as? Int ?? 0
 
-        var allRanges: [NSRange] = []
-        if !query.isEmpty {
-            let haystack = tv.string as NSString
-            let opts: NSString.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
-            var searchStart = 0
-            while searchStart < haystack.length {
-                let scope = NSRange(location: searchStart, length: haystack.length - searchStart)
-                let found = haystack.range(of: query, options: opts, range: scope)
-                if found.location == NSNotFound { break }
-                allRanges.append(found)
-                searchStart = found.location + max(found.length, 1)
-            }
-        }
-
+        let allRanges = findMatches(of: query, in: tv.string as NSString)
         let currentIndex = allRanges.isEmpty ? 0 : min(max(requestedIndex, 0), allRanges.count - 1)
         renderFindMatches(allRanges, currentIndex: currentIndex)
+        postFindResults(count: allRanges.count)
+    }
 
-        if let resultsName = configuration.services.bus.findResults {
-            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: ["count": allRanges.count])
+    /// All ranges of `query` in `haystack` (display coordinates), case- and
+    /// diacritic-insensitive. Shared by find and replace.
+    func findMatches(of query: String, in haystack: NSString) -> [NSRange] {
+        guard !query.isEmpty else { return [] }
+        var ranges: [NSRange] = []
+        let opts: NSString.CompareOptions = [.caseInsensitive, .diacriticInsensitive]
+        var searchStart = 0
+        while searchStart < haystack.length {
+            let scope = NSRange(location: searchStart, length: haystack.length - searchStart)
+            let found = haystack.range(of: query, options: opts, range: scope)
+            if found.location == NSNotFound { break }
+            ranges.append(found)
+            searchStart = found.location + max(found.length, 1)
         }
+        return ranges
+    }
+
+    private func postFindResults(count: Int) {
+        if let resultsName = configuration.services.bus.findResults {
+            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: ["count": count])
+        }
+    }
+
+    /// Replace the current find match with the replacement string (one undo
+    /// step), then re-highlight and report the remaining match count.
+    @objc func handleReplaceCurrent(_ notification: Notification) {
+        guard let tv = textView, tv.isEditable,
+              let info = notification.userInfo,
+              let query = info["query"] as? String, !query.isEmpty,
+              let replacement = info["replacement"] as? String else { return }
+        let requestedIndex = info["currentIndex"] as? Int ?? 0
+
+        let matches = findMatches(of: query, in: tv.string as NSString)
+        guard !matches.isEmpty else { postFindResults(count: 0); return }
+        let idx = min(max(requestedIndex, 0), matches.count - 1)
+        let target = matches[idx]
+        guard NSMaxRange(target) <= (tv.string as NSString).length else { return }
+
+        tv.breakUndoCoalescing()
+        isProgrammaticEdit = true
+        defer { isProgrammaticEdit = false }
+        guard tv.shouldChangeText(in: target, replacementString: replacement) else { return }
+        tv.textStorage?.replaceCharacters(in: target, with: replacement)
+        tv.didChangeText()
+        tv.undoManager?.setActionName("Replace")
+        tv.breakUndoCoalescing()
+
+        // Re-find on the edited text; keep the index so focus lands on the next
+        // occurrence (or clamps to the last remaining one).
+        let updated = findMatches(of: query, in: tv.string as NSString)
+        let nextIndex = updated.isEmpty ? 0 : min(idx, updated.count - 1)
+        renderFindMatches(updated, currentIndex: nextIndex)
+        postFindResults(count: updated.count)
+    }
+
+    /// Replace every find match in a single undo step, then re-highlight.
+    @objc func handleReplaceAll(_ notification: Notification) {
+        guard let tv = textView, tv.isEditable,
+              let info = notification.userInfo,
+              let query = info["query"] as? String, !query.isEmpty,
+              let replacement = info["replacement"] as? String else { return }
+
+        let matches = findMatches(of: query, in: tv.string as NSString)
+        guard !matches.isEmpty else { postFindResults(count: 0); return }
+
+        // Group as one undo; edit back-to-front so earlier ranges stay valid.
+        let orderedRanges = matches.reversed().map { NSValue(range: $0) }
+        let replacements = Array(repeating: replacement, count: matches.count)
+
+        tv.breakUndoCoalescing()
+        isProgrammaticEdit = true
+        defer { isProgrammaticEdit = false }
+        guard tv.shouldChangeText(inRanges: orderedRanges, replacementStrings: replacements) else { return }
+        tv.textStorage?.beginEditing()
+        for match in matches.reversed() {
+            tv.textStorage?.replaceCharacters(in: match, with: replacement)
+        }
+        tv.textStorage?.endEditing()
+        tv.didChangeText()
+        tv.undoManager?.setActionName("Replace All")
+        tv.breakUndoCoalescing()
+
+        // Usually zero remain; non-zero only if the replacement contains the query.
+        let remaining = findMatches(of: query, in: tv.string as NSString)
+        renderFindMatches(remaining, currentIndex: 0)
+        postFindResults(count: remaining.count)
     }
 
     /// Highlight all matches (current one stronger) and scroll the current match into view.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -295,6 +295,16 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
                 self?.handleFindQuery(notification)
             })
         }
+        if let name = bus.replaceCurrent {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleReplaceCurrent(notification)
+            })
+        }
+        if let name = bus.replaceAll {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleReplaceAll(notification)
+            })
+        }
     }
 
     // Find-in-document highlight handlers live in


### PR DESCRIPTION
### What

Extends the existing display-coordinate find with two bus notifications:

- `replaceCurrent` — replace the focused match, re-highlight, and keep the index on the next occurrence.
- `replaceAll` — replace every match in one undo step, back-to-front so ranges stay valid.

Both edit the engine's own displayed text with proper `shouldChangeText`/`didChangeText` undo registration and report the remaining count via `findResults`. A shared `findMatches` helper is extracted from `handleFindQuery`.

Purely additive (new optional bus names); embedders that don't set them are unaffected.

*Context: extracted from the [ChristineTham/swift-markdown-engine](https://github.com/ChristineTham/swift-markdown-engine) fork used by HelloNotes, which ships a ⌘F find/replace bar on top of this.*