### PR TITLE
Custom task-checkbox symbols and demo upgrade

### DIFF
--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -27,6 +27,9 @@ struct ContentView: View {
     @State private var showRawSource = false
     @State private var useReadingColumn = false
 
+    // Base font size; all relative sizing (headings, code, math) tracks it.
+    @State private var fontSize: CGFloat = 16
+
     // Scroll-away header demo.
     @State private var showHeader = false
     @State private var headerExpanded = true
@@ -35,11 +38,12 @@ struct ContentView: View {
         NativeTextViewWrapper(
             text: $text,
             configuration: configuration,
+            fontSize: fontSize,
             isEditable: !isReadOnly,
             placeholder: NSAttributedString(
                 string: "Empty document — start typing, markdown styles live…",
                 attributes: [
-                    .font: NSFont.systemFont(ofSize: 16),
+                    .font: NSFont.systemFont(ofSize: fontSize),
                     .foregroundColor: NSColor.secondaryLabelColor,
                 ]
             ),
@@ -67,6 +71,23 @@ struct ContentView: View {
                     Label("Reading column", systemImage: "arrow.right.and.line.vertical.and.arrow.left")
                 }
                 .help("Centered fixed-width reading column — wide tables still break out to full width")
+
+                ControlGroup {
+                    Button {
+                        fontSize = max(10, fontSize - 2)
+                    } label: {
+                        Label("Smaller text", systemImage: "textformat.size.smaller")
+                    }
+                    .disabled(fontSize <= 10)
+
+                    Button {
+                        fontSize = min(28, fontSize + 2)
+                    } label: {
+                        Label("Larger text", systemImage: "textformat.size.larger")
+                    }
+                    .disabled(fontSize >= 28)
+                }
+                .help("Base font size — headings, code, and math scale relative to it")
 
                 Menu {
                     Toggle("Show header", isOn: $showHeader)

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -96,6 +96,13 @@ struct ContentView: View {
         // Unregistered syntax stays literal text.
         config.extensions = [HighlightExtension(), StrikethroughExtension(),]
 
+        // Custom task-checkbox symbols: any SF Symbol pair works; unresolvable
+        // names fall back to the stock square / checkmark.square.fill.
+        config.taskCheckbox = .init(
+            uncheckedSymbolName: "square",
+            checkedSymbolName: "square.fill"
+        )
+
         return config
     }
 }
@@ -113,6 +120,7 @@ private var sampleMarkdown: String {
     [
         markdownHeader,
         inlineFormattingSection,
+        taskListSection,
         extensionSection,
         tableSection,
         latexSection,
@@ -120,6 +128,17 @@ private var sampleMarkdown: String {
         markdownFooter,
     ].joined(separator: "\n\n")
 }
+
+/// Task-list demo: the checkbox glyphs are SF Symbols configured via
+/// `TaskCheckboxStyle` — this demo swaps the default checkmark for a
+/// filled square. Click a box to toggle it.
+private let taskListSection = """
+## Task lists
+
+- [x] Configure custom checkbox symbols
+- [ ] Click a box to toggle it
+- [ ] Ship it
+"""
 
 /// Extension seam demo: `==highlight==` and `~~strikethrough~~` are NOT part
 /// of the core grammar anymore — they're supplied by the opt-in

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -21,6 +21,13 @@ import MarkdownEngineLatex
 
 struct ContentView: View {
     @State private var text: String = sampleMarkdown
+
+    // Engine modes, flipped live from the toolbar.
+    @State private var isReadOnly = false
+    @State private var showRawSource = false
+    @State private var useReadingColumn = false
+
+    // Scroll-away header demo.
     @State private var showHeader = false
     @State private var headerExpanded = true
 
@@ -28,19 +35,47 @@ struct ContentView: View {
         NativeTextViewWrapper(
             text: $text,
             configuration: configuration,
+            isEditable: !isReadOnly,
+            placeholder: NSAttributedString(
+                string: "Empty document — start typing, markdown styles live…",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: 16),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+            ),
             header: showHeader ? AnyView(demoHeader) : nil,
             headerCollapsedHeight: 40,
             headerExpanded: headerExpanded
         )
+        // `readingWidth` is applied when the underlying NSView is built, so
+        // flipping the reading column recreates the editor via `.id`. The
+        // `text` binding survives; scroll position resets — fine for a demo.
+        .id(useReadingColumn)
         .toolbar {
             ToolbarItemGroup {
-                // Scroll-away header: an embedder-supplied SwiftUI view hosted
-                // above the body that scrolls with it. "Expanded" animates
-                // between the full content height and `headerCollapsedHeight`
-                // (the top row stays visible; the rows below clip away).
-                Toggle("Header", isOn: $showHeader)
-                Toggle("Expanded", isOn: $headerExpanded)
-                    .disabled(!showHeader)
+                Toggle(isOn: $isReadOnly) {
+                    Label("Read-only", systemImage: isReadOnly ? "lock" : "lock.open")
+                }
+                .help("Read-only: the styled document stays scrollable and selectable, editing is off")
+
+                Toggle(isOn: $showRawSource) {
+                    Label("Raw source", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+                .help("Raw markdown source: no styling, no syntax hiding")
+
+                Toggle(isOn: $useReadingColumn) {
+                    Label("Reading column", systemImage: "arrow.right.and.line.vertical.and.arrow.left")
+                }
+                .help("Centered fixed-width reading column — wide tables still break out to full width")
+
+                Menu {
+                    Toggle("Show header", isOn: $showHeader)
+                    Toggle("Expanded", isOn: $headerExpanded)
+                        .disabled(!showHeader)
+                } label: {
+                    Label("Header", systemImage: "rectangle.topthird.inset.filled")
+                }
+                .help("Scroll-away header: an embedder-supplied SwiftUI view hosted above the document")
             }
         }
     }
@@ -92,8 +127,7 @@ struct ContentView: View {
 
         // Opt-in constructs beyond pure markdown. The core engine no longer
         // knows `==highlight==` or `~~strikethrough~~` — they are extensions
-        // you register; `::: … :::` containers are a fenced BLOCK extension.
-        // Unregistered syntax stays literal text.
+        // you register. Unregistered syntax stays literal text.
         config.extensions = [HighlightExtension(), StrikethroughExtension(),]
 
         // Custom task-checkbox symbols: any SF Symbol pair works; unresolvable
@@ -102,6 +136,10 @@ struct ContentView: View {
             uncheckedSymbolName: "square",
             checkedSymbolName: "square.fill"
         )
+
+        // Toolbar-driven modes.
+        config.rawSourceMode = showRawSource
+        config.readingWidth = useReadingColumn ? 620 : nil
 
         return config
     }
@@ -180,7 +218,7 @@ private let markdownHeader = """
 
 A native macOS Markdown editor built on **TextKit 2**, bridged to SwiftUI — brought to you by [nodes-web.com](https://nodes-web.com).
 
-Edit this text live. Formatting updates as you type.
+Edit this text live. Formatting updates as you type — and the toolbar flips engine modes at runtime: read-only, raw markdown source, and a centered reading column.
 
 ---
 """

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -225,11 +225,11 @@ Cells wrap to the available width:
 
 Too many columns → horizontal scroll instead of crushed cells:
 
-| Movement | Landmark novel | Narrative signature | Characteristic preoccupations | Philosophical undercurrents | Contemporaneous reception | Posthumous reputation |
-|---|---|---|---|---|---|---|
-| Modernism | Der Zauberberg | Essayistic time-dilation | Sanatorium cosmopolitanism | Schopenhauer-inflected pessimism | Immediate bestseller | Cornerstone of literary modernism |
-| Menippean satire | The Master and Margarita | Novel-within-a-novel | Cowardice and censorship | Faustian epigraph | Suppressed, samizdat-circulated | Perennial Russian favorite |
-| Aestheticism | The Picture of Dorian Gray | Epigrammatic wit | Portrait-as-conscience | Paterian hedonism | Scandalized reviewers | Perpetually adapted |
+| Movement | Landmark novel | Narrative signature | Characteristic preoccupations | Philosophical undercurrents | Contemporaneous reception | Posthumous reputation | Author | Structural device | Central symbol | Typical setting | Enduring influence |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Modernism | Der Zauberberg | Essayistic time-dilation | Sanatorium cosmopolitanism | Schopenhauer-inflected pessimism | Immediate bestseller | Cornerstone of literary modernism | Thomas Mann | Bildungsroman inversion | The mountain as timeless enclosure | Alpine sanatorium | Shaped the European novel of ideas |
+| Menippean satire | The Master and Margarita | Novel-within-a-novel | Cowardice and censorship | Faustian epigraph | Suppressed, samizdat-circulated | Perennial Russian favorite | Mikhail Bulgakov | Interleaved dual narratives | The devil as satirical mirror | Soviet Moscow and biblical Jerusalem | Model for satire under censorship |
+| Aestheticism | The Picture of Dorian Gray | Epigrammatic wit | Portrait-as-conscience | Paterian hedonism | Scandalized reviewers | Perpetually adapted | Oscar Wilde | Portrait as moral ledger | The aging portrait | Fin de siècle London | Touchstone for art for art’s sake |
 """
 
 private let markdownHeader = """

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -130,13 +130,6 @@ struct ContentView: View {
         // you register. Unregistered syntax stays literal text.
         config.extensions = [HighlightExtension(), StrikethroughExtension()]
 
-        // Custom task-checkbox symbols: any SF Symbol pair works; unresolvable
-        // names fall back to the stock square / checkmark.square.fill.
-        config.taskCheckbox = .init(
-            uncheckedSymbolName: "square",
-            checkedSymbolName: "square.fill"
-        )
-
         // Toolbar-driven modes.
         config.rawSourceMode = showRawSource
         config.readingWidth = useReadingColumn ? 620 : nil
@@ -185,13 +178,12 @@ Lists auto-continue on Return; Tab and Shift-Tab move the nesting level:
 2. and auto-continue too
 """
 
-/// Task-list demo: the checkbox glyphs are SF Symbols configured via
-/// `TaskCheckboxStyle` — this demo swaps the default checkmark for a
-/// filled square. Click a box to toggle it.
+/// Task-list demo: click a checkbox to toggle it. The glyphs are SF Symbols;
+/// embedders can swap them via `TaskCheckboxStyle` (`config.taskCheckbox`).
 private let taskListSection = """
 ## Task lists
 
-- [x] Configure custom checkbox symbols
+- [x] Draw checkboxes as SF Symbols
 - [ ] Click a box to toggle it
 - [ ] Ship it
 """

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -128,7 +128,7 @@ struct ContentView: View {
         // Opt-in constructs beyond pure markdown. The core engine no longer
         // knows `==highlight==` or `~~strikethrough~~` — they are extensions
         // you register. Unregistered syntax stays literal text.
-        config.extensions = [HighlightExtension(), StrikethroughExtension(),]
+        config.extensions = [HighlightExtension(), StrikethroughExtension()]
 
         // Custom task-checkbox symbols: any SF Symbol pair works; unresolvable
         // names fall back to the stock square / checkmark.square.fill.
@@ -147,8 +147,8 @@ struct ContentView: View {
 
 /// Builds the demo markdown shown when the editor first loads.
 ///
-/// The text is composed from a fixed header/footer plus three feature
-/// sections — inline formatting, block math, and code — that swap between
+/// The text is composed from a fixed header/footer plus feature sections.
+/// Three of them — inline formatting, block math, and code — swap between
 /// a full showcase and a short "feature unavailable" note depending on
 /// which optional bridge products are linked.
 ///
@@ -158,6 +158,7 @@ private var sampleMarkdown: String {
     [
         markdownHeader,
         inlineFormattingSection,
+        blocksSection,
         taskListSection,
         extensionSection,
         tableSection,
@@ -166,6 +167,23 @@ private var sampleMarkdown: String {
         markdownFooter,
     ].joined(separator: "\n\n")
 }
+
+/// Blockquote + list demo: quotes keep inline styling; lists auto-continue
+/// on Return, renumber, and change nesting with Tab / Shift-Tab.
+private let blocksSection = """
+## Blockquotes & lists
+
+> Blockquotes keep full **inline** styling — and quote markers hide like every other marker.
+
+Lists auto-continue on Return; Tab and Shift-Tab move the nesting level:
+
+- Unordered lists
+  - nest two spaces per level
+    - up to three levels deep
+
+1. Ordered lists renumber as you edit
+2. and auto-continue too
+"""
 
 /// Task-list demo: the checkbox glyphs are SF Symbols configured via
 /// `TaskCheckboxStyle` — this demo swaps the default checkmark for a
@@ -189,7 +207,6 @@ This ==highlighted text== comes from `HighlightExtension`, and this \
 ~~struck-through text~~ from `StrikethroughExtension`. Unregistered, the exact \
 same characters would stay literal markdown. Nesting works too: \
 ==with *italic* inside== and ~~also *nested*~~.
-
 """
 
 /// Table layout demo: the first table's cells WRAP to the available width
@@ -200,17 +217,19 @@ private let tableSection = """
 
 Cells wrap to the available width:
 
-| Rechtsform | Gründungskosten | Laufende Kosten/Jahr |
-|---|---|---|
-| Einzelunternehmen (Kleingewerbe) | 20–60€ (Gewerbeanmeldung) | ~0€ (nur Steuerberater optional, 300–800€) |
-| GbR (mit zwei Gesellschaftern) | 20–60€ x Anzahl Gesellschafter (jeder meldet einzeln an) | Gesellschaftervertrag empfohlen (Anwalt: 500–1.500€ einmalig) |
-| UG (haftungsbeschränkt) | Notar + Handelsregister: ~300–500€ (Musterprotokoll) bis 1.000€+ | IHK-Beitrag (~150–400€), Steuerberater fast Pflicht |
+| Novel | Opening line |
+|---|---|
+| Der Zauberberg (1924) | "Ein einfacher junger Mensch reiste im Hochsommer von Hamburg, seiner Vaterstadt, nach Davos-Platz im Graubündischen." |
+| The Master and Margarita (1966–67) | "At the sunset hour of one warm spring day two men were to be seen at Patriarch's Ponds." (trans. Michael Glenny) |
+| The Picture of Dorian Gray (1890) | "The studio was filled with the rich odour of roses, and when the light summer wind stirred amidst the trees of the garden, there came through the open door the heavy scent of the lilac, or the more delicate perfume of the pink-flowering thorn." |
 
 Too many columns → horizontal scroll instead of crushed cells:
 
-| Rechtsformvergleich | Gründungskostenaufstellung | Haftungsbeschränkung | Steuerberaterkosten | Handelsregistereintrag | Stammkapitalanforderung |
-|---|---|---|---|---|---|
-| Einzelunternehmen | Gewerbeanmeldung | unbeschränkt | optional | nein | keines |
+| Movement | Landmark novel | Narrative signature | Characteristic preoccupations | Philosophical undercurrents | Contemporaneous reception | Posthumous reputation |
+|---|---|---|---|---|---|---|
+| Modernism | Der Zauberberg | Essayistic time-dilation | Sanatorium cosmopolitanism | Schopenhauer-inflected pessimism | Immediate bestseller | Cornerstone of literary modernism |
+| Menippean satire | The Master and Margarita | Novel-within-a-novel | Cowardice and censorship | Faustian epigraph | Suppressed, samizdat-circulated | Perennial Russian favorite |
+| Aestheticism | The Picture of Dorian Gray | Epigrammatic wit | Portrait-as-conscience | Paterian hedonism | Scandalized reviewers | Perpetually adapted |
 """
 
 private let markdownHeader = """

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -32,6 +32,7 @@ public struct MarkdownEditorConfiguration: Sendable {
     public var codeBlock: CodeBlockStyle
     public var inlineCode: InlineCodeStyle
     public var lists: ListStyle
+    public var taskCheckbox: TaskCheckboxStyle
     public var headings: HeadingStyle
     public var imageEmbed: ImageEmbedStyle
     public var blockLatex: BlockLatexStyle
@@ -81,6 +82,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         codeBlock: CodeBlockStyle = .default,
         inlineCode: InlineCodeStyle = .default,
         lists: ListStyle = .default,
+        taskCheckbox: TaskCheckboxStyle = .default,
         headings: HeadingStyle = .default,
         imageEmbed: ImageEmbedStyle = .default,
         blockLatex: BlockLatexStyle = .default,
@@ -105,6 +107,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.codeBlock = codeBlock
         self.inlineCode = inlineCode
         self.lists = lists
+        self.taskCheckbox = taskCheckbox
         self.headings = headings
         self.imageEmbed = imageEmbed
         self.blockLatex = blockLatex
@@ -300,6 +303,33 @@ public struct ListStyle: Sendable {
     }
 
     public static let `default` = ListStyle()
+}
+
+// MARK: - Task checkboxes
+
+/// SF Symbol names used to draw task-list checkboxes (`- [ ]` / `- [x]`).
+///
+/// Any SF Symbol available on the deployment target can be substituted, for
+/// example `"circle"` / `"checkmark.circle.fill"`. A name that doesn't
+/// resolve falls back to the corresponding default symbol at draw time, so a
+/// typo degrades to the stock look instead of drawing nothing. Tint colors
+/// stay theme-driven (`MarkdownEditorTheme/mutedText` unchecked,
+/// `MarkdownEditorTheme/bodyText` checked).
+public struct TaskCheckboxStyle: Sendable {
+    /// SF Symbol drawn for an unchecked task item (`[ ]`).
+    public var uncheckedSymbolName: String
+    /// SF Symbol drawn for a checked task item (`[x]`).
+    public var checkedSymbolName: String
+
+    public init(
+        uncheckedSymbolName: String = "square",
+        checkedSymbolName: String = "checkmark.square.fill"
+    ) {
+        self.uncheckedSymbolName = uncheckedSymbolName
+        self.checkedSymbolName = checkedSymbolName
+    }
+
+    public static let `default` = TaskCheckboxStyle()
 }
 
 // MARK: - Headings

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -593,11 +593,17 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
             let iconInset = max(0.0, size * 0.01)
             let iconRect = boxRect.insetBy(dx: iconInset, dy: iconInset)
-            let symbolName = isChecked ? "checkmark.square.fill" : "square"
-            if let baseSymbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) {
+            let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
+                ?? .default
+            let style = configuration.taskCheckbox
+            let symbolName = isChecked ? style.checkedSymbolName : style.uncheckedSymbolName
+            let fallbackName = isChecked
+                ? TaskCheckboxStyle.default.checkedSymbolName
+                : TaskCheckboxStyle.default.uncheckedSymbolName
+            if let baseSymbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+                ?? NSImage(systemSymbolName: fallbackName, accessibilityDescription: nil) {
                 let sizeConfig = NSImage.SymbolConfiguration(pointSize: iconRect.height, weight: .regular)
-                let theme = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration.theme ?? .default
-                let tint = isChecked ? theme.bodyText : theme.mutedText
+                let tint = isChecked ? configuration.theme.bodyText : configuration.theme.mutedText
                 let colorConfig = NSImage.SymbolConfiguration(hierarchicalColor: tint)
                 let symbolConfig = sizeConfig.applying(colorConfig)
                 let symbol = baseSymbol.withSymbolConfiguration(symbolConfig) ?? baseSymbol


### PR DESCRIPTION
## Summary

**Engine**
- `TaskCheckboxStyle`: task checkboxes accept any SF Symbol pair via `uncheckedSymbolName` / `checkedSymbolName`; names that don't resolve fall back to the defaults (`square` / `checkmark.square.fill`)

**Demo**
- Toolbar controls for engine modes: read-only, raw markdown source, centered reading column, and base font size (A−/A+); the scroll-away-header toggles move into a Header menu
- Empty documents show a placeholder
- New "Blockquotes & lists" sample section; the sample tables compare Der Zauberberg, The Master and Margarita, and The Picture of Dorian Gray to show cell wrapping and the horizontal-scroll breakout for wide tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)
