### PR TITLE
Pair ``` fences only when a closing fence exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- An unclosed ``` fence no longer swallows the rest of the document: typing an
+  opening fence above existing content left every block below it (tables,
+  block LaTeX, thematic breaks, links) unrendered until the closing fence was
+  typed. A fence now forms a code block only once its closing fence exists.
+
 ## [0.10.0] - 2026-07-15
 
 ### Added

--- a/Sources/MarkdownEngine/Extensions/ContainerExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/ContainerExtension.swift
@@ -18,7 +18,8 @@
 //  The fence lines hide while the caret is outside the block and reveal
 //  muted while editing (mirroring code fences); the body keeps full inline
 //  styling plus the container background. An unclosed container runs to the end
-//  of the document, exactly like an unclosed code fence.
+//  of the document (unlike an unclosed ``` fence, which stays literal text
+//  until its closing fence exists).
 //
 
 import AppKit

--- a/Sources/MarkdownEngine/Parser/BlockParser.swift
+++ b/Sources/MarkdownEngine/Parser/BlockParser.swift
@@ -274,6 +274,16 @@ enum BlockParser {
 
         func lineText(_ i: Int) -> String { nsText.substring(with: lines[i]) }
 
+        /// Line index of the fence closing a code block opened at `start`; nil when unclosed.
+        func fenceCloseIndex(from start: Int) -> Int? {
+            var scan = start + 1
+            while scan < lines.count {
+                if isFence(lineText(scan)) { return scan }
+                scan += 1
+            }
+            return nil
+        }
+
         /// Line index of the `$$` closing a block-LaTeX run opened at `start`; nil if none.
         func blockLatexCloseIndex(from start: Int) -> Int? {
             let open = lineText(start).trimmingCharacters(in: .whitespacesAndNewlines)
@@ -295,14 +305,7 @@ enum BlockParser {
                 blocks.append(Block(kind: .blank, range: union(lines[i...end])))
                 i = end + 1
 
-            } else if isFence(line) {
-                // Opaque: consume through the closing fence (or to EOF if none).
-                var end = lines.count - 1
-                var scan = i + 1
-                while scan < lines.count {
-                    if isFence(lineText(scan)) { end = scan; break }
-                    scan += 1
-                }
+            } else if isFence(line), let end = fenceCloseIndex(from: i) {
                 blocks.append(Block(kind: .fencedCode, range: union(lines[i...end])))
                 i = end + 1
 
@@ -358,10 +361,12 @@ enum BlockParser {
                 var end = i
                 while end + 1 < lines.count {
                     let next = lineText(end + 1)
-                    if isBlank(next) || isFence(next) || isThematicBreak(next)
+                    if isBlank(next) || isThematicBreak(next)
                         || isHeading(next) || isBlockquote(next) || isListItem(next) { break }
-                    // A table (row + separator), a block-LaTeX run, or an
-                    // extension fence interrupts it.
+                    // A table (row + separator), a CLOSED code fence, a
+                    // block-LaTeX run, or an extension fence interrupts it —
+                    // an unclosed opener stays part of the paragraph.
+                    if isFence(next), fenceCloseIndex(from: end + 1) != nil { break }
                     if isTableRow(next), end + 2 < lines.count, isTableSeparator(lineText(end + 2)) { break }
                     if isBlockLatexOpen(next), blockLatexCloseIndex(from: end + 1) != nil { break }
                     if registry.blockEntry(opening: next) != nil { break }

--- a/Sources/MarkdownEngine/Parser/MarkdownAST.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownAST.swift
@@ -25,7 +25,7 @@ struct ListItem: Equatable {
 }
 
 /// An extension-supplied fenced block. `closeFence` is nil when the block is
-/// unclosed (it then runs to the end of the document, like an open ``` fence).
+/// unclosed (it then runs to the end of the document).
 struct ExtensionBlockNode: Equatable {
     let extensionID: String
     let range: NSRange

--- a/Tests/MarkdownEngineTests/BlockParserTests.swift
+++ b/Tests/MarkdownEngineTests/BlockParserTests.swift
@@ -68,6 +68,34 @@ struct BlockParserTests {
         #expect(BlockParser.parse("```\ncode\n```\n") == [b(.fencedCode, 0, 13)])
     }
 
+    @Test("an unclosed fence stays literal text — blocks below are not swallowed")
+    func unclosedFenceDoesNotSwallow() {
+        // ```\n then a table, a thematic break, block LaTeX, and a link
+        // paragraph — none of them may end up inside a code block.
+        let text = "```\n\n|a|b|\n|-|-|\n|1|2|\n\n---\n\n$$x$$\n\n[l](u)"
+        let blocks = BlockParser.parse(text)
+        #expect(!blocks.contains { $0.kind == .fencedCode })
+        #expect(blocks.contains { $0.kind == .table })
+        #expect(blocks.contains { $0.kind == .thematicBreak })
+        #expect(blocks.contains { $0.kind == .blockLatex })
+        assertTiles(text)
+    }
+
+    @Test("an unclosed fence merges into the paragraph it starts")
+    func unclosedFenceIsParagraph() {
+        #expect(BlockParser.parse("```\n[l](u)") == [b(.paragraph, 0, 10)])
+        #expect(BlockParser.parse("a\n```swift") == [b(.paragraph, 0, 10)])
+    }
+
+    @Test("a closed fence below an unclosed opener pairs with it")
+    func fencePairing() {
+        // The first ``` pairs with the next fence line — CommonMark pairing —
+        // so this is one code block followed by a paragraph.
+        let text = "```\ncode\n```\ntail"
+        #expect(BlockParser.parse(text) == [b(.fencedCode, 0, 13), b(.paragraph, 13, 4)])
+        assertTiles(text)
+    }
+
     @Test("consecutive blockquote lines form one block, ended by a non-quote line")
     func blockquote() {
         let text = "> a\n> b\nc"


### PR DESCRIPTION
## Problem

Typing an opening ``` fence above existing content — the normal way you wrap
something in a code block — made everything below it stop rendering. Tables,
`---` thematic breaks, `$$…$$` blocks, and links all went flat until the
closing fence was typed.

`BlockParser.computeBlocks` treated an unclosed fence as opening a code block
that runs to the end of the document. The swallowed content didn't even render
*as code*: `BlockLevelTokenizer.codeBlock` returns no token when there's no
closing fence, so the range lost its own styling without gaining code styling.

Minimal reproducer — every block below the fence is swallowed:

```
```

| a | b |
|---|---|
| 1 | 2 |

---

$$x + y$$

[link](https://example.com)
```

## Fix

A fence line opens a code block only when a closing fence line actually follows
it; until then it stays literal paragraph text and everything below keeps
rendering normally. Once the closing fence is typed, the code block forms
exactly as before.

Paragraph continuation now mirrors the rule `$$` blocks already used (break only
on a *closed* fence), which preserves the "no adjacent paragraphs" invariant
`BlockParser.incrementalParse` relies on when splicing.

Unclosed **extension** fences (`::: … :::`) still run to EOF — documented and
test-pinned behavior, unrelated to this bug. Two comments that described code
fences as sharing that behavior were corrected.

## Testing

Three tests added to `BlockParserTests`:

- an unclosed fence above a table / HR / block-LaTeX / link swallows none of them
- an unclosed opener merges into its own paragraph
- a closed fence still pairs greedily with the next fence line

I also verified end-to-end through `DocumentParseState` with real per-keystroke
edit descriptors (simulating typing `` ` ``, ``` `` ```, ``` ``` ``` above a
table and a formula) that the incremental path agrees with the full parse — that
check was scratch and isn't part of the diff.

`swift build` and `swift test` green: 253 tests, 45 suites.

## Note on scope

Fence pairing stays CommonMark-greedy, so typing ``` above an *existing* code
block still pairs with that block's opening fence and re-flows it until you type
your own closer. That's inherent to greedy pairing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)