### PR TITLE
feat: make prose typography configurable

### DIFF
--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -31,6 +31,7 @@ public struct MarkdownEditorConfiguration: Sendable {
     public var markers: MarkerStyle
     public var codeBlock: CodeBlockStyle
     public var inlineCode: InlineCodeStyle
+    public var strong: StrongStyle
     public var lists: ListStyle
     public var taskCheckbox: TaskCheckboxStyle
     public var headings: HeadingStyle
@@ -81,6 +82,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         markers: MarkerStyle = .default,
         codeBlock: CodeBlockStyle = .default,
         inlineCode: InlineCodeStyle = .default,
+        strong: StrongStyle = .default,
         lists: ListStyle = .default,
         taskCheckbox: TaskCheckboxStyle = .default,
         headings: HeadingStyle = .default,
@@ -106,6 +108,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.markers = markers
         self.codeBlock = codeBlock
         self.inlineCode = inlineCode
+        self.strong = strong
         self.lists = lists
         self.taskCheckbox = taskCheckbox
         self.headings = headings
@@ -271,6 +274,20 @@ public struct InlineCodeStyle: Sendable {
     public static let `default` = InlineCodeStyle()
 }
 
+// MARK: - Strong emphasis
+
+/// Styling for strong-emphasis (`**bold**`) spans.
+public struct StrongStyle: Sendable {
+    /// Font weight used for strong-emphasis content.
+    public var fontWeight: NSFont.Weight
+
+    public init(fontWeight: NSFont.Weight = .bold) {
+        self.fontWeight = fontWeight
+    }
+
+    public static let `default` = StrongStyle()
+}
+
 // MARK: - Lists
 
 /// Behavior toggles and metrics for ordered / unordered list editing.
@@ -341,13 +358,17 @@ public struct HeadingStyle: Sendable {
     public var fontMultipliers: [CGFloat]
     /// Top spacing in `em` units per heading level (1...6).
     public var topSpacingEm: [CGFloat]
+    /// Font weight shared by all heading levels.
+    public var fontWeight: NSFont.Weight
 
     public init(
         fontMultipliers: [CGFloat] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67],
-        topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10]
+        topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10],
+        fontWeight: NSFont.Weight = .bold
     ) {
         self.fontMultipliers = fontMultipliers
         self.topSpacingEm = topSpacingEm
+        self.fontWeight = fontWeight
     }
 
     public func fontMultiplier(for level: Int) -> CGFloat {
@@ -476,10 +497,17 @@ public struct ParagraphStyle: Sendable {
     public var spacingFactor: CGFloat
     /// Extra height (points) added to the default paragraph line height.
     public var lineHeightExtraSpacing: CGFloat
+    /// Height of an empty Markdown line relative to the normal body line height.
+    public var blankLineHeightScale: CGFloat
 
-    public init(spacingFactor: CGFloat = 0.3, lineHeightExtraSpacing: CGFloat = 2) {
+    public init(
+        spacingFactor: CGFloat = 0.3,
+        lineHeightExtraSpacing: CGFloat = 2,
+        blankLineHeightScale: CGFloat = 1
+    ) {
         self.spacingFactor = spacingFactor
         self.lineHeightExtraSpacing = lineHeightExtraSpacing
+        self.blankLineHeightScale = blankLineHeightScale
     }
 
     public static let `default` = ParagraphStyle()

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -366,7 +366,7 @@ enum MarkdownASTStyler {
             let multiplier = ctx.config.headings.fontMultiplier(for: level)
             let headingBase = NSFont(name: ctx.fontName, size: ctx.baseFont.pointSize * multiplier)
                 ?? .systemFont(ofSize: ctx.baseFont.pointSize * multiplier)
-            let headingFont = adding(.bold, to: headingBase)
+            let headingFont = applying(weight: ctx.config.headings.fontWeight, to: headingBase)
             let lineHeight = ceil(headingFont.ascender - headingFont.descender + headingFont.leading) + 1
             let headingPara = NSMutableParagraphStyle()
             headingPara.minimumLineHeight = lineHeight
@@ -396,9 +396,26 @@ enum MarkdownASTStyler {
             styleThematicBreak(range: range, ctx: ctx, into: &attrs)
         case .ext(let node):
             styleExtensionBlock(node, font: font, ctx: ctx, into: &attrs)
-        case .blockLatex, .table, .blank:
+        case .blank(let range):
+            styleBlankLine(range: range, ctx: ctx, into: &attrs)
+        case .blockLatex, .table:
             break   // NSImage rendering ported next
         }
+    }
+
+    private static func styleBlankLine(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
+        let scale = ctx.config.paragraph.blankLineHeightScale
+        guard scale != 1 else { return }
+        let lineHeight = max(
+            1,
+            (ctx.baseLineHeight + ctx.config.paragraph.lineHeightExtraSpacing) * scale
+        )
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.minimumLineHeight = lineHeight
+        paragraph.maximumLineHeight = lineHeight
+        paragraph.paragraphSpacing = 0
+        paragraph.paragraphSpacingBefore = 0
+        attrs.append((range, [.paragraphStyle: paragraph]))
     }
 
     /// Extension fenced block: the extension supplies content ATTRIBUTES only;
@@ -545,7 +562,11 @@ enum MarkdownASTStyler {
                 break
 
             case .emphasis(let kind, let range, let markers, let children):
-                let composed = adding(traits(for: kind), to: font)
+                let composed = applying(
+                    emphasis: kind,
+                    weight: ctx.config.strong.fontWeight,
+                    to: font
+                )
                 attrs.append((content(of: markers), [.font: composed]))
                 if ctx.isActive(range) {
                     for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
@@ -697,12 +718,33 @@ enum MarkdownASTStyler {
 
     // MARK: - Helpers
 
-    private static func traits(for kind: EmphasisKind) -> NSFontDescriptor.SymbolicTraits {
-        switch kind {
-        case .italic: return .italic
-        case .bold: return .bold
-        case .boldItalic: return [.bold, .italic]
+    private static func applying(
+        emphasis: EmphasisKind,
+        weight: NSFont.Weight,
+        to font: NSFont
+    ) -> NSFont {
+        switch emphasis {
+        case .italic:
+            return adding(.italic, to: font)
+        case .bold:
+            return applying(weight: weight, to: font)
+        case .boldItalic:
+            return adding(.italic, to: applying(weight: weight, to: font))
         }
+    }
+
+    private static func applying(weight: NSFont.Weight, to font: NSFont) -> NSFont {
+        guard weight != .bold, let familyName = font.familyName else {
+            return adding(.bold, to: font)
+        }
+        let descriptor = NSFontDescriptor(fontAttributes: [
+            .family: familyName,
+            .traits: [
+                NSFontDescriptor.TraitKey.weight: weight.rawValue,
+                NSFontDescriptor.TraitKey.symbolic: font.fontDescriptor.symbolicTraits.rawValue,
+            ],
+        ])
+        return NSFont(descriptor: descriptor, size: font.pointSize) ?? font
     }
 
     private static func adding(_ extra: NSFontDescriptor.SymbolicTraits, to font: NSFont) -> NSFont {

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -65,6 +65,75 @@ struct MarkdownASTStylerTests {
         #expect(o?.fontDescriptor.symbolicTraits.contains([.bold, .italic]) == true)
     }
 
+    @Test("heading weight is configurable")
+    func configurableHeadingWeight() {
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.headings.fontWeight = .semibold
+
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "# Heading",
+            fontName: fontName,
+            fontSize: base,
+            configuration: configuration
+        )
+        let heading = font(in: attrs, at: 2)
+        let traits = heading?.fontDescriptor.object(forKey: .traits)
+            as? [NSFontDescriptor.TraitKey: Any]
+        let weight = traits?[.weight] as? NSNumber
+
+        #expect(abs((weight?.doubleValue ?? 0) - Double(NSFont.Weight.semibold.rawValue)) < 0.001)
+        #expect(heading?.pointSize == base * configuration.headings.fontMultiplier(for: 1))
+    }
+
+    @Test("strong-emphasis weight is configurable")
+    func configurableStrongWeight() {
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.strong.fontWeight = .semibold
+
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "**Strong**",
+            fontName: fontName,
+            fontSize: base,
+            configuration: configuration
+        )
+        let strong = font(in: attrs, at: 2)
+        let traits = strong?.fontDescriptor.object(forKey: .traits)
+            as? [NSFontDescriptor.TraitKey: Any]
+        let weight = traits?[.weight] as? NSNumber
+
+        #expect(abs((weight?.doubleValue ?? 0) - Double(NSFont.Weight.semibold.rawValue)) < 0.001)
+
+        let nestedAttrs = MarkdownASTStyler.styleAttributes(
+            text: "*outer **inner** outer*",
+            fontName: fontName,
+            fontSize: base,
+            configuration: configuration
+        )
+        let nestedStrong = font(in: nestedAttrs, at: 9)
+        #expect(nestedStrong?.fontDescriptor.symbolicTraits.contains([.bold, .italic]) == true)
+    }
+
+    @Test("blank line height is configurable")
+    func configurableBlankLineHeight() {
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.paragraph.blankLineHeightScale = 0.5
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "first\n\nsecond",
+            fontName: fontName,
+            fontSize: base,
+            configuration: configuration
+        )
+        let blankLineStyle = attrs.reversed().first { entry in
+            NSLocationInRange(6, entry.range) && entry.attributes[.paragraphStyle] != nil
+        }?.attributes[.paragraphStyle] as? NSParagraphStyle
+        let bodyFont = NSFont(name: fontName, size: base) ?? .systemFont(ofSize: base)
+        let bodyLineHeight = ceil(bodyFont.ascender - bodyFont.descender + bodyFont.leading)
+            + configuration.paragraph.lineHeightExtraSpacing
+
+        #expect(blankLineStyle?.minimumLineHeight == bodyLineHeight * 0.5)
+        #expect(blankLineStyle?.paragraphSpacing == 0)
+    }
+
     @Test("nested emphasis in a paragraph composes bold+italic")
     func paragraphNestedEmphasis() {
         let attrs = MarkdownASTStyler.styleAttributes(text: "**a *b* c**", fontName: fontName, fontSize: base)


### PR DESCRIPTION
## Summary
- add configurable font weights for headings and strong emphasis
- add an opt-in `blankLineHeightScale` to `ParagraphStyle`
- preserve the existing bold and full-height defaults
- resolve non-default weights through the base font family

## Testing
- `swift test` (256 tests)