### PR TITLE
feat: add fenced code block layout provider

### DIFF
--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -152,6 +152,44 @@ public struct PlainTextSyntaxHighlighter: SyntaxHighlighter {
     public var appearanceDidChangeNotification: Notification.Name? { nil }
 }
 
+// MARK: - Fenced Code Block Layout
+
+/// Reserves additional line height for an individual triple-backtick code block.
+///
+/// This seam intentionally follows the legacy parser's supported subset:
+/// closed, column-zero fences made from exactly three backticks. The engine
+/// applies the provider's multiplier to that block's TextKit paragraph metrics
+/// without changing its source. Values are constrained to `1...20`, so this
+/// service can enlarge a block but cannot collapse editable source lines.
+public protocol FencedCodeBlockLayoutProvider: Sendable {
+    /// Returns the requested line-height multiplier for this block.
+    func lineHeightMultiplier(for request: FencedCodeBlockLayoutRequest) -> CGFloat
+
+    /// Coarse fingerprint of the provider's current layout decisions.
+    /// A different value invalidates layout and restyles the document.
+    func fingerprint() -> AnyHashable
+}
+
+/// Source content for a legacy exact-three-backtick, column-zero code block.
+public struct FencedCodeBlockLayoutRequest: Sendable, Equatable {
+    /// The complete trimmed text after the opening three backticks, or `nil` when absent.
+    public let infoString: String?
+    /// The code between the opening and closing triple-backtick fence lines.
+    public let code: String
+
+    public init(infoString: String?, code: String) {
+        self.infoString = infoString
+        self.code = code
+    }
+}
+
+/// Default provider that preserves the configured code line height.
+public struct NoOpFencedCodeBlockLayoutProvider: FencedCodeBlockLayoutProvider {
+    public init() {}
+    public func lineHeightMultiplier(for request: FencedCodeBlockLayoutRequest) -> CGFloat { 1 }
+    public func fingerprint() -> AnyHashable { 0 }
+}
+
 // MARK: - LaTeX
 
 /// Renders LaTeX formulas to images for inline display.
@@ -318,6 +356,7 @@ public struct MarkdownEditorServices: Sendable {
     public var wikiLinks: any WikiLinkResolver
     public var images: any EmbeddedImageProvider
     public var syntaxHighlighter: any SyntaxHighlighter
+    public var fencedCodeBlockLayout: any FencedCodeBlockLayoutProvider
     public var latex: any LatexRenderer
     public var bus: MarkdownEditorBus
 
@@ -325,12 +364,14 @@ public struct MarkdownEditorServices: Sendable {
         wikiLinks: any WikiLinkResolver = NoOpWikiLinkResolver(),
         images: any EmbeddedImageProvider = NoOpEmbeddedImageProvider(),
         syntaxHighlighter: any SyntaxHighlighter = PlainTextSyntaxHighlighter(),
+        fencedCodeBlockLayout: any FencedCodeBlockLayoutProvider = NoOpFencedCodeBlockLayoutProvider(),
         latex: any LatexRenderer = NoOpLatexRenderer(),
         bus: MarkdownEditorBus = .default
     ) {
         self.wikiLinks = wikiLinks
         self.images = images
         self.syntaxHighlighter = syntaxHighlighter
+        self.fencedCodeBlockLayout = fencedCodeBlockLayout
         self.latex = latex
         self.bus = bus
     }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -22,6 +22,8 @@ import Foundation
 
 enum MarkdownASTStyler {
 
+    private static let maximumCodeBlockLineHeightMultiplier: CGFloat = 20
+
     static func styleAttributes(
         text: String,
         fontName: String,
@@ -489,14 +491,24 @@ enum MarkdownASTStyler {
 
     private static func styleCodeBlock(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
         let parts = codeBlockParts(range, ctx.ns)
+        let codeContent = ctx.ns.substring(with: parts.content)
+        let requestedMultiplier = ctx.config.services.fencedCodeBlockLayout.lineHeightMultiplier(
+            for: FencedCodeBlockLayoutRequest(infoString: parts.infoString, code: codeContent)
+        )
+        let multiplier = requestedMultiplier.isFinite
+            ? min(max(requestedMultiplier, 1), maximumCodeBlockLineHeightMultiplier)
+            : 1
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.setParagraphStyle(ctx.codeParagraphStyle)
+        paragraphStyle.minimumLineHeight *= multiplier
+        paragraphStyle.maximumLineHeight *= multiplier
         attrs.append((parts.codeRange, [
-            .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: ctx.codeParagraphStyle,
+            .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: paragraphStyle,
         ]))
         // Suppress spell-check underlines on the whole fenced block — code is not prose.
         attrs.append((parts.codeRange, [.spellingState: 0]))
-        let codeContent = ctx.ns.substring(with: parts.content)
         if !codeContent.isEmpty,
-           let highlighted = ctx.config.services.syntaxHighlighter.highlight(code: codeContent, language: parts.language) {
+           let highlighted = ctx.config.services.syntaxHighlighter.highlight(code: codeContent, language: parts.infoString) {
             highlighted.enumerateAttributes(in: NSRange(location: 0, length: highlighted.length)) { a, r, _ in
                 guard let fg = a[.foregroundColor] else { return }
                 attrs.append((NSRange(location: parts.content.location + r.location, length: r.length), [.foregroundColor: fg]))
@@ -510,9 +522,9 @@ enum MarkdownASTStyler {
         attrs.append((parts.closeFence, markerAttrs))
     }
 
-    /// Split a fenced-code range into open fence (+language), content, close fence, and language.
+    /// Split a fenced-code range into open fence (+info string), content, close fence, and info string.
     private static func codeBlockParts(_ range: NSRange, _ ns: NSString)
-        -> (codeRange: NSRange, openFence: NSRange, content: NSRange, closeFence: NSRange, language: String?) {
+        -> (codeRange: NSRange, openFence: NSRange, content: NSRange, closeFence: NSRange, infoString: String?) {
         let start = range.location
         let end = NSMaxRange(range)
         var openEnd = start
@@ -527,13 +539,13 @@ enum MarkdownASTStyler {
         let codeRange = NSRange(location: start, length: NSMaxRange(closeFence) - start)
         let content = NSRange(location: openEnd, length: max(0, lastLine.location - openEnd))
 
-        var language: String?
+        var infoString: String?
         if openFence.length > 3 {
             let raw = ns.substring(with: NSRange(location: start + 3, length: openFence.length - 3))
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            language = raw.isEmpty ? nil : raw
+            infoString = raw.isEmpty ? nil : raw
         }
-        return (codeRange, openFence, content, closeFence, language)
+        return (codeRange, openFence, content, closeFence, infoString)
     }
 
     // MARK: - Inlines (composing)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -56,6 +56,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     /// returns the current value, regardless of when state changed.
     var lastImageFingerprint: AnyHashable?
     var lastWikiFingerprint: AnyHashable?
+    var lastFencedCodeBlockLayoutFingerprint: AnyHashable?
     private var busObservers: [NSObjectProtocol] = []
     private var registeredAppearanceObserverName: Notification.Name?
     weak var textView: NSTextView?
@@ -264,6 +265,23 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
         super.init()
         // Init + didSet share this helper so the observer tracks whichever service is current.
         subscribeToAppearanceNotification()
+    }
+
+    /// Compare and record service fingerprints from a SwiftUI configuration update.
+    func updateServiceFingerprints(for services: MarkdownEditorServices)
+        -> (images: Bool, wikiLinks: Bool, fencedCodeBlockLayout: Bool) {
+        let imageFingerprint = services.images.fingerprint()
+        let wikiFingerprint = services.wikiLinks.fingerprint()
+        let fencedCodeBlockLayoutFingerprint = services.fencedCodeBlockLayout.fingerprint()
+        let changes = (
+            images: imageFingerprint != lastImageFingerprint,
+            wikiLinks: wikiFingerprint != lastWikiFingerprint,
+            fencedCodeBlockLayout: fencedCodeBlockLayoutFingerprint != lastFencedCodeBlockLayoutFingerprint
+        )
+        lastImageFingerprint = imageFingerprint
+        lastWikiFingerprint = wikiFingerprint
+        lastFencedCodeBlockLayoutFingerprint = fencedCodeBlockLayoutFingerprint
+        return changes
     }
 
     /// (Re)register the syntax-highlighter appearance observer; idempotent and unsubscribes on nil.

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -498,17 +498,14 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         // (e.g. when the available wiki-link targets change). Cheap pointer-/
         // value-based comparison; full equality isn't required because the
         // embedder is the source of truth.
-        let newImageFingerprint = configuration.services.images.fingerprint()
-        let newWikiFingerprint = configuration.services.wikiLinks.fingerprint()
-        let imageChanged = newImageFingerprint != context.coordinator.lastImageFingerprint
-        let wikiChanged = newWikiFingerprint != context.coordinator.lastWikiFingerprint
-        if imageChanged || wikiChanged {
-            context.coordinator.lastImageFingerprint = newImageFingerprint
-            context.coordinator.lastWikiFingerprint = newWikiFingerprint
+        let serviceChanges = context.coordinator.updateServiceFingerprints(for: configuration.services)
+        if serviceChanges.images || serviceChanges.wikiLinks || serviceChanges.fencedCodeBlockLayout {
             context.coordinator.configuration.services = configuration.services
             textView.configuration.services = configuration.services
-            // Only an image change needs a layout re-measure; a wiki-link rename is style-only.
-            if imageChanged, let tlm = textView.textLayoutManager {
+            // Image and fenced-code reservation changes affect paragraph geometry;
+            // a wiki-link rename is style-only.
+            if serviceChanges.images || serviceChanges.fencedCodeBlockLayout,
+               let tlm = textView.textLayoutManager {
                 tlm.invalidateLayout(for: tlm.documentRange)
             }
             // Restyle live tv content — full rebuild would clobber paste-fresh embeds when `text` binding hasn't caught up.
@@ -625,8 +622,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         )
         coordinator.documentId = documentId
         coordinator.configuration = configuration
-        coordinator.lastImageFingerprint = configuration.services.images.fingerprint()
-        coordinator.lastWikiFingerprint = configuration.services.wikiLinks.fingerprint()
+        _ = coordinator.updateServiceFingerprints(for: configuration.services)
         coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         coordinator.onInlinePreviewKey = onInlinePreviewKey
         coordinator.userPrefersContinuousSpellChecking = configuration.spellChecking.continuousSpellChecking

--- a/Tests/MarkdownEngineTests/FencedCodeBlockLayoutProviderTests.swift
+++ b/Tests/MarkdownEngineTests/FencedCodeBlockLayoutProviderTests.swift
@@ -1,0 +1,147 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Fenced code block layout provider")
+struct FencedCodeBlockLayoutProviderTests {
+    private let fontSize: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: fontSize).fontName }
+
+    private struct FixedProvider: FencedCodeBlockLayoutProvider {
+        let multiplier: CGFloat
+
+        func lineHeightMultiplier(for request: FencedCodeBlockLayoutRequest) -> CGFloat {
+            multiplier
+        }
+
+        func fingerprint() -> AnyHashable { multiplier }
+    }
+
+    private struct MermaidProvider: FencedCodeBlockLayoutProvider {
+        func lineHeightMultiplier(for request: FencedCodeBlockLayoutRequest) -> CGFloat {
+            request.infoString == "mermaid theme=dark" && request.code == "graph TD\n" ? 3 : 1
+        }
+
+        func fingerprint() -> AnyHashable { "mermaid-layout-v1" }
+    }
+
+    private func styles(
+        for text: String,
+        provider: any FencedCodeBlockLayoutProvider = NoOpFencedCodeBlockLayoutProvider()
+    ) -> [StyledRange] {
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.services.fencedCodeBlockLayout = provider
+        return MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: fontSize,
+            configuration: configuration
+        )
+    }
+
+    private func paragraphStyle(in styles: [StyledRange], at location: Int) -> NSParagraphStyle? {
+        styles.last { NSLocationInRange(location, $0.range) && $0.attributes[.paragraphStyle] != nil }?
+            .attributes[.paragraphStyle] as? NSParagraphStyle
+    }
+
+    private var defaultCodeLineHeight: CGFloat {
+        let configuration = MarkdownEditorConfiguration.default
+        let codeFont = configuration.services.syntaxHighlighter.codeFont(
+            size: round(fontSize * configuration.codeBlock.fontSizeScale)
+        )
+        return ceil(codeFont.ascender - codeFont.descender + codeFont.leading)
+    }
+
+    @Test("default provider preserves code paragraph metrics")
+    func defaultMetricsAreUnchanged() {
+        let text = "```swift\nlet x = 1\n```\nafter"
+        let style = paragraphStyle(in: styles(for: text), at: 0)
+
+        #expect(style?.minimumLineHeight == defaultCodeLineHeight)
+        #expect(style?.maximumLineHeight == defaultCodeLineHeight)
+    }
+
+    @Test("matching info string enlarges only its fenced block")
+    func languageSpecificMultiplierDoesNotAffectSecondBlock() {
+        let text = "```mermaid theme=dark\ngraph TD\n```\n\n```swift\nlet x = 1\n```\nafter"
+        let styled = styles(for: text, provider: MermaidProvider())
+        let ns = text as NSString
+        let mermaid = paragraphStyle(in: styled, at: ns.range(of: "graph TD").location)
+        let swift = paragraphStyle(in: styled, at: ns.range(of: "let x = 1").location)
+
+        #expect(mermaid?.minimumLineHeight == defaultCodeLineHeight * 3)
+        #expect(mermaid?.maximumLineHeight == defaultCodeLineHeight * 3)
+        #expect(swift?.minimumLineHeight == defaultCodeLineHeight)
+        #expect(swift?.maximumLineHeight == defaultCodeLineHeight)
+    }
+
+    @MainActor
+    @Test("multiplied paragraph metrics push following content without changing source")
+    func multiplierChangesTextLayout() {
+        let text = "```mermaid\ngraph TD\n```\nafter"
+
+        func followingLineY(provider: any FencedCodeBlockLayoutProvider) -> CGFloat {
+            let storage = NSTextStorage(string: text, attributes: [.font: NSFont.systemFont(ofSize: fontSize)])
+            for (range, attributes) in styles(for: text, provider: provider) {
+                storage.addAttributes(attributes, range: range)
+            }
+            #expect(storage.string == text)
+            let layoutManager = NSLayoutManager()
+            let container = NSTextContainer(size: NSSize(width: 400, height: CGFloat.greatestFiniteMagnitude))
+            storage.addLayoutManager(layoutManager)
+            layoutManager.addTextContainer(container)
+            layoutManager.ensureLayout(for: container)
+            let glyph = layoutManager.glyphIndexForCharacter(at: (text as NSString).range(of: "after").location)
+            return layoutManager.lineFragmentRect(forGlyphAt: glyph, effectiveRange: nil).minY
+        }
+
+        let defaultY = followingLineY(provider: NoOpFencedCodeBlockLayoutProvider())
+        let enlargedY = followingLineY(provider: FixedProvider(multiplier: 3))
+
+        #expect(enlargedY > defaultY)
+    }
+
+    @Test("multipliers below one and non-finite values preserve default metrics")
+    func shrinkingAndInvalidMultipliersFallBack() {
+        let text = "```\ncode\n```"
+        for value in [CGFloat.nan, .infinity, -.infinity, -1, 0, 0.01, 0.5] {
+            let style = paragraphStyle(in: styles(for: text, provider: FixedProvider(multiplier: value)), at: 0)
+            #expect(style?.minimumLineHeight == defaultCodeLineHeight)
+            #expect(style?.maximumLineHeight == defaultCodeLineHeight)
+        }
+    }
+
+    @MainActor
+    @Test("changing only the fenced-code provider fingerprint is detected")
+    func fencedCodeFingerprintTriggersServiceRefresh() {
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(""),
+            fontName: fontName,
+            fontSize: fontSize,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        var services = MarkdownEditorServices.default
+        services.fencedCodeBlockLayout = FixedProvider(multiplier: 1)
+        _ = coordinator.updateServiceFingerprints(for: services)
+
+        services.fencedCodeBlockLayout = FixedProvider(multiplier: 2)
+        let changes = coordinator.updateServiceFingerprints(for: services)
+
+        #expect(changes.images == false)
+        #expect(changes.wikiLinks == false)
+        #expect(changes.fencedCodeBlockLayout == true)
+        #expect(coordinator.lastFencedCodeBlockLayoutFingerprint == AnyHashable(CGFloat(2)))
+    }
+
+    @Test("finite multipliers have an upper sanity bound")
+    func multiplierIsBounded() {
+        let text = "```\ncode\n```"
+        let style = paragraphStyle(in: styles(for: text, provider: FixedProvider(multiplier: 1_000)), at: 0)
+
+        #expect(style?.minimumLineHeight == defaultCodeLineHeight * 20)
+        #expect(style?.maximumLineHeight == defaultCodeLineHeight * 20)
+    }
+}


### PR DESCRIPTION
## Summary
- add a public Sendable per-triple-backtick-code-block layout provider and request
- reserve TextKit paragraph line height with a safe `1...20` enlargement-only multiplier
- fingerprint layout providers so runtime replacements sync services, invalidate layout, and restyle
- preserve default metrics and source content while pushing following content

## Supported fence subset
This seam intentionally follows the legacy parser subset used by Arkush: closed, exact-three-backtick fences at column zero. Long fences and alternate line separators remain pre-existing parser limitations and are not changed here.

## Validation
- focused provider suite: `swift test --filter FencedCodeBlockLayoutProviderTests` (6 tests)
- full suite: `swift test` (259 tests in 46 suites)
- `git diff --check`