### PR TITLE
Ordered lists numbered by position; cursors that survive an inverted span

### DIFF
--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -74,6 +74,16 @@ public struct MarkdownEditorConfiguration: Sendable {
     /// default: unregistered syntax stays literal text. Order defines match
     /// precedence among extensions; built-in constructs always win first.
     public var extensions: [any MarkdownExtension]
+    /// Let the caret and the I-beam take the ink of the extension span they sit
+    /// in, instead of `theme.bodyText` and the plain system pointer.
+    ///
+    /// Off by default. It only matters for an extension that INVERTS its
+    /// content (dark ink on a light block), where both cursors would otherwise
+    /// be drawn in the block's own color and disappear inside it. An extension
+    /// whose `contentAttributes` set no foreground is unaffected either way —
+    /// so this stays the embedder's explicit decision rather than something the
+    /// engine infers from a color it happens to see.
+    public var cursorFollowsSpanInk: Bool
 
     public init(
         theme: MarkdownEditorTheme = .default,
@@ -99,7 +109,8 @@ public struct MarkdownEditorConfiguration: Sendable {
         spellChecking: SpellCheckingPolicy = .default,
         heightBehavior: HeightBehavior = .scrolls,
         rawSourceMode: Bool = false,
-        extensions: [any MarkdownExtension] = []
+        extensions: [any MarkdownExtension] = [],
+        cursorFollowsSpanInk: Bool = false
     ) {
         self.theme = theme
         self.services = services
@@ -125,6 +136,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.heightBehavior = heightBehavior
         self.rawSourceMode = rawSourceMode
         self.extensions = extensions
+        self.cursorFollowsSpanInk = cursorFollowsSpanInk
     }
 
     public static let `default` = MarkdownEditorConfiguration()

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -24,6 +24,7 @@ extension NSAttributedString.Key {
     /// Marks a bullet-list marker char (`-`/`*`/`+`) whose glyph is hidden so
     /// the fragment can paint a `•` in its place. Set to `true`.
     static let bulletMarker = NSAttributedString.Key("BulletListMarker")
+    static let orderedMarker = NSAttributedString.Key("OrderedListMarker")
     /// CGFloat — natural image width; presence flags block as overlay-rendered.
     static let scrollableBlockNaturalWidth = NSAttributedString.Key("ScrollableBlockNaturalWidth")
     /// Int — hash of source text; key for overlay reconcile + offset persistence.
@@ -89,6 +90,7 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
         // 4b. Bullet glyphs (on top of hidden -/*/+ markers)
         drawBulletMarkers(at: point, in: context)
+        drawOrderedMarkers(at: point, in: context)
 
         // 5. Thematic breaks (full-width line, painted last so it doesn't
         //    fight with anything that already drew at the line's center)
@@ -554,6 +556,42 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             // ascent below — so top = baseline − ascent aligns the glyph.
             let topY = pos.baselineY - font.ascender
             glyph.draw(at: CGPoint(x: pos.x + xOffset, y: topY), withAttributes: glyphAttrs)
+        }
+    }
+
+    // MARK: - Ordered List Markers
+
+    /// Paint the whole display marker "N." (`.orderedMarker` value) over the
+    /// hidden source marker (digits + dot, cleared by the styler as one unit and
+    /// kerned to the display width so any digit count aligns and content/wrapped
+    /// lines hang at that width). Draws the raw source marker instead while the
+    /// line is selected, so selection reveals the literal digits.
+    private func drawOrderedMarkers(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        let selectionRanges: [NSRange] = {
+            guard let tv = textLayoutManager?.textContainer?.textView else { return [] }
+            return tv.selectedRanges.map { $0.rangeValue }.filter { $0.length > 0 }
+        }()
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+
+        let theme = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
+            .configuration.theme ?? .default
+        let storageString = ts.string as NSString
+
+        ts.enumerateAttribute(.orderedMarker, in: range, options: []) { [weak self] value, attrRange, _ in
+            guard let self, let number = value as? String else { return }
+            guard let pos = self.drawPosition(forDocumentCharAt: attrRange.location, point: point) else { return }
+            let font = (ts.attribute(.font, at: attrRange.location, effectiveRange: nil) as? NSFont)
+                ?? (self.textLayoutManager?.textContainer?.textView?.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize))
+            let isSelected = selectionRanges.contains(where: { NSIntersectionRange($0, attrRange).length > 0 })
+            let raw = storageString.substring(with: attrRange)
+            let glyph = (isSelected ? raw : number) as NSString
+            let glyphAttrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.bodyText]
+            let topY = pos.baselineY - font.ascender
+            glyph.draw(at: CGPoint(x: pos.x, y: topY), withAttributes: glyphAttrs)
         }
     }
 

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -51,6 +51,8 @@ enum MarkdownASTStyler {
         codePara.tailIndent = -configuration.codeBlock.horizontalIndent
         codePara.minimumLineHeight = codeLineHeight
         codePara.maximumLineHeight = codeLineHeight
+        let blocks = DocumentAST.parse(text, scopedRanges: scopedRanges, precomputedBlocks: precomputedBlocks,
+                                       registry: configuration.extensionRegistry)
         let ctx = Ctx(
             ns: ns,
             fontName: fontName,
@@ -66,10 +68,9 @@ enum MarkdownASTStyler {
             config: configuration,
             extensionsByID: configuration.extensionsByID,
             wikiLinkID: wikiLinkIDProvider,
-            scopedRanges: scopedRanges
+            scopedRanges: scopedRanges,
+            orderedDisplayNumbers: computeOrderedDisplayNumbers(blocks: blocks, ns: ns)
         )
-        let blocks = DocumentAST.parse(text, scopedRanges: scopedRanges, precomputedBlocks: precomputedBlocks,
-                                       registry: configuration.extensionRegistry)
         var attrs: [StyledRange] = []
         for block in blocks where ctx.inScope(block.range) {
             styleBlock(block, font: baseFont, ctx: ctx, into: &attrs)
@@ -184,8 +185,104 @@ enum MarkdownASTStyler {
         attrs.append((hr, [.paragraphStyle: NSMutableParagraphStyle()]))
     }
 
+    /// Ordered-list display numbers computed across the WHOLE document, keyed by
+    /// each ordered item's marker location. Positional, not the literal digit, so
+    /// any edit renumbers correctly; the count carries across a blank line (a
+    /// loose-list separator) so `1.`/`2.`⏎blank⏎`2.` shows 1,2,3 — real content
+    /// between lists resets it. First item of a run keeps its own start value.
+    /// Like MarkdownLists.listRegex but also accepts `)` ordered markers (`5)`),
+    /// matching the AST — used by the backward seed scan (group 2 = digits).
+    private static let seedOrderedLineRegex = try! NSRegularExpression(
+        pattern: #"^\s*((?:(\d+)[.)]|[-•*+])(?:\s+\[[ xX]\])?\s+)"#
+    )
+
+    /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
+    /// in the full source: same-indent items counted, blank lines skipped, real
+    /// content stops it) and returns the next number per indent. Lets a scoped
+    /// restyle that only sees a local window continue the document's numbering.
+    private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
+        guard loc > 0, loc <= ns.length else { return [:] }
+        var runLines: [(indent: Int, number: Int?)] = []   // bottom-to-top; nil = bullet/other list
+        var scan = loc
+        while scan > 0 {
+            let lineRange = ns.lineRange(for: NSRange(location: scan - 1, length: 0))
+            let line = ns.substring(with: lineRange) as NSString
+            let full = NSRange(location: 0, length: line.length)
+            if (line as String).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                scan = lineRange.location                    // blank line: loose-list spacing
+                continue
+            }
+            guard let m = seedOrderedLineRegex.firstMatch(in: line as String, range: full) else { break }
+            let ws = MarkdownLists.leadingWhitespaceRegex.firstMatch(in: line as String, range: full)
+                .map { line.substring(with: $0.range) } ?? ""
+            let number = m.range(at: 2).location != NSNotFound ? Int(line.substring(with: m.range(at: 2))) : nil
+            // Key by the raw leading-whitespace char count to match the parser's
+            // `item.indent` used by computeOrderedDisplayNumbers — otherwise a
+            // nested item's seed counter wouldn't line up and it'd fall back to
+            // the literal digit.
+            runLines.append(((ws as NSString).length, number))
+            scan = lineRange.location
+        }
+        var counters: [Int: Int] = [:]
+        for item in runLines.reversed() {                    // replay top-to-bottom
+            if let number = item.number {
+                counters[item.indent] = (counters[item.indent] ?? number) + 1
+            } else {
+                counters[item.indent] = nil
+            }
+            for key in counters.keys where key > item.indent { counters[key] = nil }
+        }
+        return counters
+    }
+
+    private static func computeOrderedDisplayNumbers(blocks: [BlockNode], ns: NSString) -> [Int: Int] {
+        var result: [Int: Int] = [:]
+        var counters: [Int: Int] = [:]
+        // `blocks` is NOT the document: a scoped restyle keeps only the blocks that
+        // intersect the scope, and a multi-region scope (caret paragraph + previous
+        // caret paragraph, built on every click) drops everything between them —
+        // including the prose whose `default:` below is what ends a run. So treat
+        // every discontinuity like a fresh start and re-seed from the SOURCE, the
+        // only thing that can still see the skipped text. Lazily, at the first
+        // ordered item after the gap, so prose/bullet restyles never pay the scan.
+        var needsSeed = true
+        var contiguousEnd: Int?
+        for block in blocks {
+            if let contiguousEnd, block.range.location > contiguousEnd {
+                counters = [:]
+                needsSeed = true
+            }
+            contiguousEnd = NSMaxRange(block.range)
+            switch block {
+            case .list(_, let items):
+                for item in items {
+                    if item.ordered, let literal = item.number {
+                        if needsSeed {
+                            counters = seedOrderedCounters(above: item.marker.location, in: ns)
+                            needsSeed = false
+                        }
+                        let n = counters[item.indent] ?? literal
+                        result[item.marker.location] = n
+                        counters[item.indent] = n + 1
+                    } else {
+                        counters[item.indent] = nil
+                    }
+                    for key in counters.keys where key > item.indent { counters[key] = nil }
+                }
+            case .blank:
+                break                     // blank lines keep the count (spacing, not a reset)
+            case .paragraph(_, let inlines) where inlines.isEmpty:
+                break                     // an empty paragraph line is spacing too
+            default:
+                counters = [:]            // real text/content ends the run
+                needsSeed = false         // a seed scan would stop on this line anyway
+            }
+        }
+        return result
+    }
+
     /// AST list-item decoration: indent paragraph, `•` bullet, checkbox + strikethrough, all caret-aware.
-    private static func styleListItem(_ item: ListItem, ctx: Ctx, into attrs: inout [StyledRange]) {
+    private static func styleListItem(_ item: ListItem, displayNumber: Int?, ctx: Ctx, into attrs: inout [StyledRange]) {
         guard ctx.config.lists.helpersEnabled else { return }
 
         // Line content (item line minus its trailing newline).
@@ -220,8 +317,31 @@ enum MarkdownASTStyler {
             markerGroup = NSRange(location: item.marker.location,
                                   length: item.contentRange.location - item.marker.location)
         }
-        let markerWidth = (ctx.ns.substring(with: markerGroup) as NSString)
-            .size(withAttributes: [.font: ctx.baseFont]).width
+        // An ordered item whose displayed number differs from its source digit
+        // gets its WHOLE marker overlaid (below); the hanging indent must then
+        // measure the DISPLAY marker so wrapped lines align at any digit count.
+        // False while the caret reveals the marker (edit at raw width) and for
+        // tasks (the checkbox branch owns those).
+        let orderedSyntax = NSRange(location: item.marker.location,
+                                    length: item.contentRange.location - item.marker.location)
+        // Also off while the marker is inside a selection: the painter reveals the
+        // raw source digits there, so the slot must revert to raw width (else a
+        // kerned slot leaves a gap/overlap over the raw digits).
+        let orderedOverlayActive = item.ordered && item.checkbox == nil && item.number != nil
+            && displayNumber != nil && displayNumber != item.number
+            && !MarkdownStyler.caretRevealsOrderedMarker(caret: ctx.caret, syntax: orderedSyntax)
+            && !ctx.selectionIntersects(orderedSyntax)
+        // Keep the source punctuation (`.` or `)`) when overlaying, so a paren list stays a paren list.
+        let orderedPunct = orderedOverlayActive && item.marker.length > 0
+            ? ctx.ns.substring(with: NSRange(location: NSMaxRange(item.marker) - 1, length: 1)) : "."
+        let markerWidth: CGFloat = {
+            if orderedOverlayActive, let displayNumber {
+                let gap = ctx.ns.substring(with: NSRange(location: NSMaxRange(item.marker),
+                                                         length: item.contentRange.location - NSMaxRange(item.marker)))
+                return (("\(displayNumber)\(orderedPunct)" + gap) as NSString).size(withAttributes: [.font: ctx.baseFont]).width
+            }
+            return (ctx.ns.substring(with: markerGroup) as NSString).size(withAttributes: [.font: ctx.baseFont]).width
+        }()
         let depthIndent = CGFloat(MarkdownLists.indentLevel(from: ws)) * ctx.config.lists.indentPerLevel
         let ps = NSMutableParagraphStyle()
         let lineHeight = ctx.baseLineHeight + ctx.config.lists.extraLineHeight
@@ -268,6 +388,25 @@ enum MarkdownASTStyler {
                                  length: item.contentRange.location - item.marker.location)
             if NSLocationInRange(ctx.caret, syntax) { return }
             attrs.append((item.marker, [.bulletMarker: true, .foregroundColor: NSColor.clear]))
+        } else if orderedOverlayActive, let displayNumber {
+            // Hide the ENTIRE source marker (digits + dot) as one unit and paint
+            // the whole display marker "N." over it, so the dot travels with the
+            // digits. Kern the slot to the display marker's width (horizontal
+            // only — a scaled font would inflate the marker ascent and push the
+            // content baseline down under the pinned line height); spread across
+            // all marker chars so every glyph advance stays positive even when
+            // the number shrinks (10 → 9).
+            let sourceW = (ctx.ns.substring(with: item.marker) as NSString)
+                .size(withAttributes: [.font: ctx.baseFont]).width
+            let displayW = ("\(displayNumber)\(orderedPunct)" as NSString)
+                .size(withAttributes: [.font: ctx.baseFont]).width
+            var markerAttrs: [NSAttributedString.Key: Any] = [
+                .orderedMarker: "\(displayNumber)\(orderedPunct)", .foregroundColor: NSColor.clear,
+            ]
+            if abs(displayW - sourceW) > 0.01 {
+                markerAttrs[.kern] = (displayW - sourceW) / CGFloat(max(1, item.marker.length))
+            }
+            attrs.append((item.marker, markerAttrs))
         }
     }
 
@@ -328,6 +467,7 @@ enum MarkdownASTStyler {
         let extensionsByID: [String: any MarkdownExtension]
         let wikiLinkID: (NSRange) -> String?
         let scopedRanges: [NSRange]?
+        let orderedDisplayNumbers: [Int: Int]
 
         /// True when a non-empty selection overlaps `range` — the selection
         /// counterpart of `isActive` for elements that reveal on select.
@@ -386,7 +526,8 @@ enum MarkdownASTStyler {
 
         case .list(_, let items):
             for item in items {
-                styleListItem(item, ctx: ctx, into: &attrs)
+                styleListItem(item, displayNumber: ctx.orderedDisplayNumbers[item.marker.location],
+                              ctx: ctx, into: &attrs)
                 styleInlines(item.inlines, font: font, ctx: ctx, into: &attrs)
             }
 

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -196,6 +196,10 @@ enum MarkdownASTStyler {
         pattern: #"^\s*((?:(\d+)[.)]|[-•*+])(?:\s+\[[ xX]\])?\s+)"#
     )
 
+    /// First non-blank character in a range answers "was there content in the
+    /// hole between two scoped blocks" without materializing the substring.
+    private static let nonWhitespace = CharacterSet.whitespacesAndNewlines.inverted
+
     /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
     /// in the full source: same-indent items counted, blank lines skipped, real
     /// content stops it) and returns the next number per indent. Lets a scoped
@@ -203,7 +207,11 @@ enum MarkdownASTStyler {
     private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
         guard loc > 0, loc <= ns.length else { return [:] }
         var runLines: [(indent: Int, number: Int?)] = []   // bottom-to-top; nil = bullet/other list
-        var scan = loc
+        // From the START of loc's line: callers pass a MARKER offset, which for
+        // an indented item still sits inside its own line — scanning up from
+        // there counted the item itself, so every nested list rendered one too
+        // high ("  1. a" showing 2.).
+        var scan = ns.lineRange(for: NSRange(location: min(loc, ns.length), length: 0)).location
         while scan > 0 {
             let lineRange = ns.lineRange(for: NSRange(location: scan - 1, length: 0))
             let line = ns.substring(with: lineRange) as NSString
@@ -248,7 +256,15 @@ enum MarkdownASTStyler {
         var needsSeed = true
         var contiguousEnd: Int?
         for block in blocks {
-            if let contiguousEnd, block.range.location > contiguousEnd {
+            if let contiguousEnd, block.range.location > contiguousEnd,
+               ns.rangeOfCharacter(from: Self.nonWhitespace, options: [],
+                                   range: NSRange(location: contiguousEnd,
+                                                  length: block.range.location - contiguousEnd)).location != NSNotFound {
+                // Only CONTENT in the hole ends the run. A hole of pure blank
+                // lines is loose-list spacing — and it is the shape the
+                // coordinator's forward walk hands us (list, list, list, blanks
+                // skipped), where re-seeding meant one full backward scan per
+                // item: 639 ms for a single Return in an 800-item loose list.
                 counters = [:]
                 needsSeed = true
             }

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+OrderedMarkers.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+OrderedMarkers.swift
@@ -1,0 +1,60 @@
+//
+//  MarkdownStyler+OrderedMarkers.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  Caret-crossing helper for `1.` / `1)` ordered markers. The number the editor
+//  SHOWS is positional (`MarkdownASTStyler`), and the raw source digits are
+//  revealed while the caret edits them — so the coordinator needs to know when
+//  the caret crosses that boundary, exactly like it already does for bullets,
+//  task checkboxes and thematic breaks. Rendering itself lives in the AST
+//  styler; this file only answers membership.
+//
+
+import AppKit
+import Foundation
+
+extension MarkdownStyler {
+
+    /// Indented ordered marker at line start, excluding task items — the AST
+    /// styler never overlays those, so their digits are always literal.
+    static let orderedListRegex: NSRegularExpression = try! NSRegularExpression(
+        pattern: #"^([ \t]*)(\d+[.)])([ \t]+)(?!\[[ xX]\])"#,
+        options: [.anchorsMatchLines]
+    )
+
+    // MARK: Ordered Marker Membership
+
+    /// True while the caret sits ON the digits — inside `syntax`, but never at
+    /// its first offset. That one offset is excluded on purpose: every
+    /// whole-line delete and line-join parks the caret exactly there, and
+    /// counting it as "editing the digits" left the surviving item showing its
+    /// stale literal (a 1./2./3. list read 1./1. after deleting item 2).
+    static func caretRevealsOrderedMarker(caret: Int, syntax: NSRange) -> Bool {
+        caret > syntax.location && caret < NSMaxRange(syntax)
+    }
+
+    /// `<digits><.|)><spaces>` range on `location`'s line while the caret
+    /// reveals it, else `nil`. Paired with ``caretRevealsOrderedMarker`` so the
+    /// coordinator's crossing signal and the styler's reveal cannot disagree.
+    static func orderedSyntaxRange(at location: Int, in text: String) -> NSRange? {
+        let nsText = text as NSString
+        let safeLoc = max(0, min(location, nsText.length))
+        let lineRange = nsText.lineRange(for: NSRange(location: safeLoc, length: 0))
+        let line = nsText.substring(with: lineRange)
+        guard let match = orderedListRegex.firstMatch(
+            in: line,
+            options: [],
+            range: NSRange(location: 0, length: line.utf16.count)
+        ) else { return nil }
+        let markerLineRange = match.range(at: 2)
+        let spacerLineRange = match.range(at: 3)
+        guard markerLineRange.location != NSNotFound,
+              spacerLineRange.location != NSNotFound else { return nil }
+        let syntaxStart = lineRange.location + markerLineRange.location
+        let syntaxEnd = lineRange.location + spacerLineRange.location + spacerLineRange.length
+        let syntaxRange = NSRange(location: syntaxStart, length: syntaxEnd - syntaxStart)
+        return caretRevealsOrderedMarker(caret: safeLoc, syntax: syntaxRange) ? syntaxRange : nil
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
@@ -1,0 +1,49 @@
+//
+//  NativeTextViewCoordinator+CaretColor.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  The caret takes the ink of the span it sits in. An extension paints its
+//  content with its own attributes, and one that inverts — dark ink on a light
+//  block, e.g. an inverted `==highlight==` — leaves a `theme.bodyText` caret
+//  drawn in the block's own color, i.e. invisible. Generic on purpose: any
+//  extension whose `contentAttributes` carry a foreground gets this for free.
+//
+
+import AppKit
+import Foundation
+
+extension NativeTextViewCoordinator {
+
+    /// Foreground an extension paints at `location`, or `theme.bodyText`.
+    /// Only the CONTENT counts — on the `==` markers the background is the page
+    /// again, so the caret belongs back at the body color. Takes the tokens the
+    /// caller already parsed: this runs on every caret move and must not add a
+    /// parse (a `parsedDocument` call without the edit descriptor would drop the
+    /// keystroke's O(edit) splice onto an O(doc) verify).
+    func caretColor(at location: Int, tokens: [MarkdownToken]) -> NSColor {
+        let theme = configuration.theme
+        // Which extensions repaint their ink at all — for a registry where none
+        // does (the engine's own highlight/strikethrough paint background and
+        // decoration only) this is where the work stops, before the token scan.
+        var inkByID: [String: NSColor] = [:]
+        for ext in configuration.extensions {
+            if let color = ext.contentAttributes(theme: theme)[.foregroundColor] as? NSColor {
+                inkByID[ext.id] = color
+            }
+        }
+        guard !inkByID.isEmpty else { return theme.bodyText }
+        var innermost: (length: Int, color: NSColor)?
+        for token in tokens {
+            guard case .extensionSpan(let id) = token.kind, let color = inkByID[id],
+                  location >= token.contentRange.location,
+                  location <= NSMaxRange(token.contentRange)
+            else { continue }
+            if innermost == nil || token.contentRange.length < innermost!.length {
+                innermost = (token.contentRange.length, color)   // nested spans: the tightest one wins
+            }
+        }
+        return innermost?.color ?? theme.bodyText
+    }
+}

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
@@ -24,6 +24,7 @@ extension NativeTextViewCoordinator {
     /// keystroke's O(edit) splice onto an O(doc) verify).
     func caretColor(at location: Int, tokens: [MarkdownToken]) -> NSColor {
         let theme = configuration.theme
+        guard configuration.cursorFollowsSpanInk else { return theme.bodyText }
         // Which extensions repaint their ink at all — for a registry where none
         // does (the engine's own highlight/strikethrough paint background and
         // decoration only) this is where the work stops, before the token scan.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
@@ -18,11 +18,15 @@ extension NativeTextViewCoordinator {
 
     /// Foreground an extension paints at `location`, or `theme.bodyText`.
     /// Only the CONTENT counts — on the `==` markers the background is the page
-    /// again, so the caret belongs back at the body color. Takes the tokens the
-    /// caller already parsed: this runs on every caret move and must not add a
-    /// parse (a `parsedDocument` call without the edit descriptor would drop the
-    /// keystroke's O(edit) splice onto an O(doc) verify).
-    func caretColor(at location: Int, tokens: [MarkdownToken]) -> NSColor {
+    /// again, so the caret belongs back at the body color.
+    ///
+    /// Runs on every keystroke, so it borrows both of the caller's results: the
+    /// already-parsed `tokens` (a `parsedDocument` call without the edit
+    /// descriptor would drop the keystroke's O(edit) splice onto an O(doc)
+    /// verify) and `active`, the memoized set of tokens the caret is inside —
+    /// which turns this from a pass over every token in the document into a
+    /// look at the two or three under the caret.
+    func caretColor(at location: Int, tokens: [MarkdownToken], active: Set<Int>) -> NSColor {
         let theme = configuration.theme
         guard configuration.cursorFollowsSpanInk else { return theme.bodyText }
         // Which extensions repaint their ink at all — for a registry where none
@@ -36,7 +40,9 @@ extension NativeTextViewCoordinator {
         }
         guard !inkByID.isEmpty else { return theme.bodyText }
         var innermost: (length: Int, color: NSColor)?
-        for token in tokens {
+        for index in active {
+            guard index >= 0, index < tokens.count else { continue }
+            let token = tokens[index]
             guard case .extensionSpan(let id) = token.kind, let color = inkByID[id],
                   location >= token.contentRange.location,
                   location <= NSMaxRange(token.contentRange)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -13,6 +13,13 @@
 
 import AppKit
 
+extension NSAttributedString.Key {
+    /// Marks a background this file painted. `.backgroundColor` has other owners
+    /// (extension spans, code fences, table cells), so find has to recognize its
+    /// own highlights before removing any.
+    static let findHighlight = NSAttributedString.Key("FindHighlight")
+}
+
 extension NativeTextViewCoordinator {
     /// Legacy path: the host computes match ranges and posts them. Kept for compatibility, but
     /// it trusts SOURCE-coordinate ranges, which misalign wherever the displayed text is shorter
@@ -128,14 +135,42 @@ extension NativeTextViewCoordinator {
         postFindResults(count: remaining.count)
     }
 
+    /// Drop find's own backgrounds and restyle the paragraphs they sat in.
+    ///
+    /// Removing `.backgroundColor` takes the styling background with it - one
+    /// attribute, several owners - and nothing repaints it on its own, so an
+    /// `==` block stayed blank until the next restyle happened to run (a click).
+    /// Scoped to the marked ranges: paragraphs find never touched keep theirs.
+    private func clearFindHighlights(in textView: NSTextView) {
+        guard let storage = textView.textStorage else { return }
+        let text = textView.string as NSString
+        guard text.length > 0 else { return }
+
+        var highlighted: [NSRange] = []
+        storage.enumerateAttribute(
+            .findHighlight,
+            in: NSRange(location: 0, length: text.length),
+            options: []
+        ) { value, range, _ in
+            if value != nil { highlighted.append(range) }
+        }
+        guard !highlighted.isEmpty else { return }
+
+        for range in highlighted {
+            storage.removeAttribute(.backgroundColor, range: range)
+            storage.removeAttribute(.findHighlight, range: range)
+        }
+        // Raw source mode has no styling to restore; restyleParagraphs no-ops there.
+        restyleParagraphs(highlighted.map { text.paragraphRange(for: $0) }, in: textView)
+    }
+
     /// Highlight all matches (current one stronger) and scroll the current match into view.
     private func renderFindMatches(_ allRanges: [NSRange], currentIndex: Int) {
         guard let tv = textView else { return }
         let storage = tv.textStorage
         let fullRange = NSRange(location: 0, length: (tv.string as NSString).length)
 
-        // Clear previous highlights
-        storage?.removeAttribute(.backgroundColor, range: fullRange)
+        clearFindHighlights(in: tv)
 
         // Highlight all matches; the focused match gets a stronger color.
         let theme = configuration.theme
@@ -147,6 +182,7 @@ extension NativeTextViewCoordinator {
             guard matchRange.location + matchRange.length <= fullRange.length else { continue }
             let color = (i == currentIndex) ? currentHighlightColor : highlightColor
             storage?.addAttribute(.backgroundColor, value: color, range: matchRange)
+            storage?.addAttribute(.findHighlight, value: true, range: matchRange)
         }
 
         if let tlm = tv.textLayoutManager {
@@ -211,8 +247,7 @@ extension NativeTextViewCoordinator {
             }
         }
 
-        let fullRange = NSRange(location: 0, length: (tv.string as NSString).length)
-        tv.textStorage?.removeAttribute(.backgroundColor, range: fullRange)
+        clearFindHighlights(in: tv)
         if let tlm = tv.textLayoutManager {
             tlm.ensureLayout(for: tlm.documentRange)
         }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -19,6 +19,9 @@ extension NativeTextViewCoordinator {
         from text: String,
         invalidateLayout: Bool = false
     ) {
+        // A rebuild means a different document (or a mode flip): drop the caret
+        // ink resolved for the old one instead of carrying it into this text.
+        resolvedCaretColor = nil
         // Storage is raw Markdown; only wiki links transform on display.
         // In raw source mode display IS storage — no transform, no metadata.
         let services = configuration.services

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -349,6 +349,14 @@ extension NativeTextViewCoordinator {
         let latexTokens = parsed.latexTokens
         let blockLatexTokens = parsed.blockLatexTokens
 
+        // The caret takes the ink of the span it sits in — an inverted highlight
+        // paints dark ink on a light block, where a bodyText caret is drawn in
+        // the block's own color and disappears. Cached for updateNSView, which
+        // has no tokens to hand.
+        let caretInk = caretColor(at: selRange.location, tokens: tokens)
+        resolvedCaretColor = caretInk
+        if tv.isEditable { tv.insertionPointColor = caretInk }
+
         let prevActive = activeTokenIndices
         PerfTrace.measure("selActive") {
             activeTokenIndices = activeTokenIndices(parsed: parsed, selection: selRange, in: nsText, suppressed: !tv.isEditable)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -397,18 +397,22 @@ extension NativeTextViewCoordinator {
         let latexTokens = parsed.latexTokens
         let blockLatexTokens = parsed.blockLatexTokens
 
-        // The caret takes the ink of the span it sits in — an inverted highlight
-        // paints dark ink on a light block, where a bodyText caret is drawn in
-        // the block's own color and disappears. Cached for updateNSView, which
-        // has no tokens to hand.
-        let caretInk = caretColor(at: selRange.location, tokens: tokens)
-        resolvedCaretColor = caretInk
-        if tv.isEditable { tv.insertionPointColor = caretInk }
-
         let prevActive = activeTokenIndices
         PerfTrace.measure("selActive") {
             activeTokenIndices = activeTokenIndices(parsed: parsed, selection: selRange, in: nsText, suppressed: !tv.isEditable)
             filterImageEmbedActiveTokens(parsed: parsed, text: nsText, selectionLocation: selRange.location)
+        }
+
+        // The caret takes the ink of the span it sits in — an inverted highlight
+        // paints dark ink on a light block, where a bodyText caret is drawn in
+        // the block's own color and disappears. Placed after the active-token
+        // pass so it can reuse it instead of walking the document's tokens
+        // again, and assigned only on a CHANGE (this fires on every keystroke).
+        // Cached for updateNSView, which has no tokens to hand.
+        let caretInk = caretColor(at: selRange.location, tokens: tokens, active: activeTokenIndices)
+        if caretInk != resolvedCaretColor {
+            resolvedCaretColor = caretInk
+            if tv.isEditable { tv.insertionPointColor = caretInk }
         }
 
         // Snap-back: when the caret LEFT a wiki/image token, re-sync its displayed name to the live target name.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -285,38 +285,52 @@ extension NativeTextViewCoordinator {
             currentActiveTokenIndices: activeTokenIndices,
             previousActiveTokenIndices: preEditActiveTokenIndices
         ))
-        // An ordered list numbers each item by its POSITION. A plain content edit
-        // never shifts numbers, so restyle only the containing list block (like
-        // tables). But adding/removing an item (a line-break edit) shifts every
-        // following number through the run end, so restyle the WHOLE forward run —
+        // An ordered list numbers each item by its POSITION, so adding or
+        // removing an item (a line-break or indent edit) shifts every following
+        // number through the end of the run: restyle the whole forward run —
         // list blocks joined by blank separators, stopping at the first content
-        // block. Numbers above are unchanged and the styler's backward seed feeds
-        // the count in, so forward-only from the edit is sufficient.
+        // block. Numbers ABOVE are unchanged and the styler's backward seed
+        // feeds the count in, so forward-only from the edit is enough. A plain
+        // content edit shifts no number and keeps the default paragraph scope.
         let listStructureChanged = pendingListStructureEdit
         pendingListStructureEdit = false
-        let editBlocks = parsed.blocks
-        var bi = 0
-        while bi < editBlocks.count {
-            let b = editBlocks[bi]
-            guard b.kind == .list,
-                  NSIntersectionRange(b.range, safeEditedRange).length > 0
-                    || NSIntersectionRange(b.range, paragraphRange).length > 0
-                    || NSIntersectionRange(b.range, previousParagraph).length > 0
-                    || NSIntersectionRange(b.range, nextParagraph).length > 0
-            else { bi += 1; continue }
-            if listStructureChanged {
-                var j = bi
+        if listStructureChanged {
+            let editBlocks = parsed.blocks
+            // The parser groups consecutive `-` lines into ONE block, so widening
+            // on `.kind == .list` alone made a bullet list pay for numbers it does
+            // not have. `firstMatch` returns on the first ordered line, so a
+            // numbered list answers at once; only a bullet block is scanned whole.
+            let hasOrderedItem: (NSRange) -> Bool = { range in
+                MarkdownStyler.orderedListRegex.firstMatch(in: docString, options: [], range: range) != nil
+            }
+            if let start = editBlocks.firstIndex(where: { b in
+                b.kind == .list
+                    && (NSIntersectionRange(b.range, safeEditedRange).length > 0
+                        || NSIntersectionRange(b.range, paragraphRange).length > 0
+                        || NSIntersectionRange(b.range, previousParagraph).length > 0
+                        || NSIntersectionRange(b.range, nextParagraph).length > 0)
+                    && hasOrderedItem(b.range)
+            }) {
+                var runEnd = NSMaxRange(editBlocks[start].range)
+                var j = start
                 walk: while j < editBlocks.count {
-                    switch editBlocks[j].kind {
-                    case .list:  effectiveParagraphCandidates.append(editBlocks[j].range); j += 1
+                    let next = editBlocks[j]
+                    switch next.kind {
+                    case .list:
+                        guard hasOrderedItem(next.range) else { break walk }   // a bullet block ends the run
+                        runEnd = NSMaxRange(next.range)
+                        j += 1
                     case .blank: j += 1
                     default:     break walk
                     }
                 }
-                bi = j
-            } else {
-                effectiveParagraphCandidates.append(b.range)
-                bi += 1
+                // ONE range for the whole run, not one per block: a loose list is
+                // one block PER ITEM and the styler matches every block against
+                // every scoped range, so n ranges made a single Return quadratic
+                // (944 ms at 800 items, Debug; 67 ms merged).
+                effectiveParagraphCandidates.append(
+                    NSRange(location: editBlocks[start].range.location,
+                            length: runEnd - editBlocks[start].range.location))
             }
         }
 

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -285,6 +285,40 @@ extension NativeTextViewCoordinator {
             currentActiveTokenIndices: activeTokenIndices,
             previousActiveTokenIndices: preEditActiveTokenIndices
         ))
+        // An ordered list numbers each item by its POSITION. A plain content edit
+        // never shifts numbers, so restyle only the containing list block (like
+        // tables). But adding/removing an item (a line-break edit) shifts every
+        // following number through the run end, so restyle the WHOLE forward run —
+        // list blocks joined by blank separators, stopping at the first content
+        // block. Numbers above are unchanged and the styler's backward seed feeds
+        // the count in, so forward-only from the edit is sufficient.
+        let listStructureChanged = pendingListStructureEdit
+        pendingListStructureEdit = false
+        let editBlocks = parsed.blocks
+        var bi = 0
+        while bi < editBlocks.count {
+            let b = editBlocks[bi]
+            guard b.kind == .list,
+                  NSIntersectionRange(b.range, safeEditedRange).length > 0
+                    || NSIntersectionRange(b.range, paragraphRange).length > 0
+                    || NSIntersectionRange(b.range, previousParagraph).length > 0
+                    || NSIntersectionRange(b.range, nextParagraph).length > 0
+            else { bi += 1; continue }
+            if listStructureChanged {
+                var j = bi
+                walk: while j < editBlocks.count {
+                    switch editBlocks[j].kind {
+                    case .list:  effectiveParagraphCandidates.append(editBlocks[j].range); j += 1
+                    case .blank: j += 1
+                    default:     break walk
+                    }
+                }
+                bi = j
+            } else {
+                effectiveParagraphCandidates.append(b.range)
+                bi += 1
+            }
+        }
 
         PerfTrace.measure("restyle") { restyleTextView(tv, paragraphCandidates: effectiveParagraphCandidates, tokens: tokens, classified: parsed.classified, blocks: parsed.blocks) }
         PerfTrace.measure("codeSel") { updateCodeBlockSelection(textView: tv, parsed: parsed) }
@@ -435,23 +469,38 @@ extension NativeTextViewCoordinator {
         let currentBulletSyntax = MarkdownStyler.bulletSyntaxRange(at: selLoc, in: docText)
         let bulletSyntaxChanged = prevBulletSyntax?.location != currentBulletSyntax?.location
             || prevBulletSyntax?.length != currentBulletSyntax?.length
+        // Ordered markers: the styler paints a POSITIONAL number over the source
+        // digits and reveals the raw digits while the caret edits them. Nothing
+        // else notices that crossing — markers aren't tokens and
+        // `bulletListRegex` carries no digits — so without this the line keeps
+        // whatever was painted last (raw `10.` stuck after editing a digit, or
+        // an overlay still asserting a number the run no longer has).
+        let prevOrderedSyntax = previousCaretLocation.flatMap {
+            MarkdownStyler.orderedSyntaxRange(at: $0, in: docText)
+        }
+        let currentOrderedSyntax = MarkdownStyler.orderedSyntaxRange(at: selLoc, in: docText)
+        let orderedSyntaxChanged = prevOrderedSyntax?.location != currentOrderedSyntax?.location
+            || prevOrderedSyntax?.length != currentOrderedSyntax?.length
         // Task syntax also reveals while a SELECTION sweeps it (styler is
         // selection-aware), but none of the caret-based signals above fire
         // when only the selection SPAN changes (shift-extend keeps the
         // anchor put). Cheap gate: only spans whose paragraphs contain a
         // task-marker prefix matter — plain selections never trigger.
-        let paragraphsTouchTaskSyntax: (NSRange?) -> Bool = { range in
+        let paragraphsTouchRevealSyntax: (NSRange?) -> Bool = { range in
             guard let range, range.length > 0 else { return false }
             let clamped = NSIntersectionRange(range, NSRange(location: 0, length: nsText.length))
             guard clamped.length > 0 else { return false }
             let span = nsText.paragraphRange(for: clamped)
             for needle in ["- [", "* [", "+ ["]
             where nsText.range(of: needle, options: [], range: span).location != NSNotFound { return true }
-            return false
+            // An ordered marker reveals its raw digits under a selection too, and
+            // its slot is kerned to the DISPLAY width — without a restyle the raw
+            // digits would draw into a slot sized for a different number.
+            return MarkdownStyler.orderedListRegex.firstMatch(in: docText, options: [], range: span) != nil
         }
         let selectionSpanChanged = previousSelectedRange != selRange
             && ((previousSelectedRange?.length ?? 0) > 0 || selRange.length > 0)
-            && (paragraphsTouchTaskSyntax(previousSelectedRange) || paragraphsTouchTaskSyntax(selRange))
+            && (paragraphsTouchRevealSyntax(previousSelectedRange) || paragraphsTouchRevealSyntax(selRange))
         // Mid-drag restyle is suppressed (revealing markers shifts the layout → drag hit-test lands short, dropping trailing chars) and replayed on release.
         let isDragSelecting = currentEventType == .leftMouseDragged || currentEventType == .periodic
         if shouldSkipSelectionRestyle {
@@ -459,7 +508,7 @@ extension NativeTextViewCoordinator {
         } else if isDragSelecting {
             needsRestyleAfterDrag = true
         } else if tokensChanged || taskSyntaxChanged || hrLineChanged || bulletSyntaxChanged
-                    || selectionSpanChanged || needsRestyleAfterDrag {
+                    || orderedSyntaxChanged || selectionSpanChanged || needsRestyleAfterDrag {
             needsRestyleAfterDrag = false
             // Candidates are built ONLY when a restyle actually runs — this
             // used to happen unconditionally on every selection change,
@@ -472,12 +521,12 @@ extension NativeTextViewCoordinator {
                 let safePrev = min(prevLoc, nsText.length)
                 paragraphCandidates.append(nsText.paragraphRange(for: NSRange(location: safePrev, length: 0)))
             }
-            // Selection-revealed task syntax lives anywhere in the selected
-            // span (old and new) — scope the restyle over both so extends
-            // reveal newly covered task lines and deselects re-hide the old
-            // ones. Gated on the task probe so plain selections never widen
-            // the scope beyond the caret paragraphs.
-            for span in [previousSelectedRange, selRange] where paragraphsTouchTaskSyntax(span) {
+            // Selection-revealed task/ordered syntax lives anywhere in the
+            // selected span (old and new) — scope the restyle over both so
+            // extends reveal newly covered lines and deselects re-hide the old
+            // ones. Gated on the probe so plain selections never widen the
+            // scope beyond the caret paragraphs.
+            for span in [previousSelectedRange, selRange] where paragraphsTouchRevealSyntax(span) {
                 guard let span else { continue }
                 let clamped = NSIntersectionRange(span, NSRange(location: 0, length: nsText.length))
                 if clamped.length > 0 { paragraphCandidates.append(nsText.paragraphRange(for: clamped)) }
@@ -695,9 +744,24 @@ extension NativeTextViewCoordinator {
             pendingBacktickWindow = (affectedCharRange.location, affectedCharRange.length,
                 MarkdownDetection.backtickWindowCount(in: preNS, around: affectedCharRange))
             pendingExtFenceTouched = editWindowTouchesExtensionFence(in: preNS, around: affectedCharRange)
+            // An ordered item is added/removed only when the edit inserts or
+            // deletes a line break → every following number shifts. A programmatic
+            // sub-edit (e.g. the list-continuation re-insert) only OR-adds, so it
+            // can't clear the user keystroke's signal.
+            let addsBreak = replacementString?.utf16.contains { $0 == 0x0A || $0 == 0x0D } ?? false
+            let removesBreak = affectedCharRange.length > 0
+                && preNS.rangeOfCharacter(from: .newlines, options: [], range: affectedCharRange).location != NSNotFound
+            // A tab insert/delete is an indent/outdent: it shifts a nested item's
+            // level and so the run's numbering, without touching a line break.
+            let addsTab = replacementString?.utf16.contains { $0 == 0x09 } ?? false
+            let removesTab = affectedCharRange.length > 0
+                && preNS.rangeOfCharacter(from: CharacterSet(charactersIn: "\t"), options: [], range: affectedCharRange).location != NSNotFound
+            let structural = addsBreak || removesBreak || addsTab || removesTab
+            pendingListStructureEdit = isProgrammaticEdit ? (pendingListStructureEdit || structural) : structural
         } else {
             pendingBacktickWindow = nil
             pendingExtFenceTouched = false
+            pendingListStructureEdit = true
         }
         if isProgrammaticEdit { return true }
         if isWritingToolsActive { return true }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -100,6 +100,10 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     /// extension block fence — captured in shouldChangeTextIn so a DELETED
     /// fence still forces the full restyle in textDidChange.
     var pendingExtFenceTouched = false
+    /// Set in shouldChangeTextIn when an edit adds/removes a line break (an
+    /// ordered-list item was inserted/removed → every following number shifts);
+    /// consumed once in textDidChange to restyle the whole ordered run.
+    var pendingListStructureEdit = false
     /// Set when the storage mutated without the census bookkeeping seeing it
     /// (IME composition) — forces the next census back to a full scan.
     var backtickCensusNeedsRescan = false

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -143,6 +143,11 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var previousSelectedRange: NSRange? = nil
     /// Drag-select suppressed a restyle; replayed on the next non-drag selection change.
     var needsRestyleAfterDrag = false
+    /// Caret color resolved at the last selection change (an extension span can
+    /// invert the ink under the caret). `updateNSView` re-applies it instead of
+    /// resetting to `theme.bodyText`, which would stomp it on any SwiftUI pass;
+    /// nil = no span, use the theme.
+    var resolvedCaretColor: NSColor?
 
     var cachedCodeBlockTokens: [(index: Int, token: MarkdownToken)] = []
     /// Dedupe key of the last emitted code-block selections — identical

--- a/Sources/MarkdownEngine/TextView/NativeTextView/InvertedIBeamCursor.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/InvertedIBeamCursor.swift
@@ -1,0 +1,98 @@
+//
+//  InvertedIBeamCursor.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  The system I-beam is one appearance-independent glyph — a dark core inside a
+//  light halo — and macOS inverts it against the EDITOR's backdrop, not against
+//  the run under the pointer. Over a span that inverts (dark ink on a light
+//  block) both of the glyph's colors are then wrong: in a dark editor the
+//  inverted core is the block's own color and the pointer vanishes inside it.
+//
+//  So recolor, don't redraw: the live `NSCursor.iBeam` image is re-tinted core →
+//  the span's ink, halo → the span's block. Deriving from the live image keeps
+//  the system's shape and the user's pointer size (Accessibility ▸ Pointer)
+//  instead of hand-drawing a cursor that ignores both.
+//
+
+import AppKit
+
+enum InvertedIBeamCursor {
+
+    private static var cache: [Key: NSCursor] = [:]
+
+    private struct Key: Hashable {
+        let ink: String
+        let halo: String
+    }
+
+    /// I-beam whose core is `ink` and whose halo is `block`. Cached: recoloring
+    /// walks every representation's pixels (~65k across 1x–10x), which is fine
+    /// once per color pair and far too slow per mouse-move.
+    static func cursor(ink: NSColor, block: NSColor) -> NSCursor? {
+        let key = Key(ink: descriptor(ink), halo: descriptor(block))
+        if let cached = cache[key] { return cached }
+        let system = NSCursor.iBeam
+        guard let recolored = recolor(system.image, ink: ink, block: block) else { return nil }
+        let cursor = NSCursor(image: recolored, hotSpot: system.hotSpot)
+        cache[key] = cursor
+        return cursor
+    }
+
+    /// Identity for the cache key — two dynamic colors that resolve the same
+    /// today must share an entry, so key on the resolved components.
+    private static func descriptor(_ color: NSColor) -> String {
+        guard let rgb = color.usingColorSpace(.deviceRGB) else { return color.description }
+        return "\(rgb.redComponent),\(rgb.greenComponent),\(rgb.blueComponent),\(rgb.alphaComponent)"
+    }
+
+    private static func recolor(_ image: NSImage, ink: NSColor, block: NSColor) -> NSImage? {
+        guard let inkRGB = ink.usingColorSpace(.deviceRGB),
+              let blockRGB = block.usingColorSpace(.deviceRGB) else { return nil }
+        let inkBytes = bytes(of: inkRGB), blockBytes = bytes(of: blockRGB)
+        let out = NSImage(size: image.size)
+        var added = false
+        for case let source as NSBitmapImageRep in image.representations {
+            let width = source.pixelsWide, height = source.pixelsHigh
+            // Redraw into a known format first (straight alpha, 8-bit RGBA) —
+            // the system reps' own layout is not guaranteed, and per-pixel
+            // NSColor round-trips cost 1.3 s across the 1x–10x reps.
+            guard let target = NSBitmapImageRep(
+                bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+                bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+                colorSpaceName: .deviceRGB, bytesPerRow: width * 4, bitsPerPixel: 32
+            ), let context = NSGraphicsContext(bitmapImageRep: target) else { continue }
+            target.size = source.size
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.current = context
+            source.draw(in: NSRect(x: 0, y: 0, width: width, height: height))
+            NSGraphicsContext.restoreGraphicsState()
+            guard let data = target.bitmapData else { continue }
+            for pixel in stride(from: 0, to: width * height * 4, by: 4) {
+                // CoreGraphics only fills a PREMULTIPLIED buffer, so undo that
+                // before judging the color and redo it when writing back.
+                let alpha = Double(data[pixel + 3]) / 255
+                guard alpha > 0 else { continue }                        // transparent: leave it
+                // Split on the glyph's own luminance: the dark core carries the
+                // shape, the light halo carries it against a dark page.
+                let luminance = (0.299 * Double(data[pixel])
+                    + 0.587 * Double(data[pixel + 1])
+                    + 0.114 * Double(data[pixel + 2])) / (255 * alpha)
+                let replacement = luminance < 0.5 ? inkBytes : blockBytes
+                data[pixel] = UInt8(clamping: Int(Double(replacement.0) * alpha))
+                data[pixel + 1] = UInt8(clamping: Int(Double(replacement.1) * alpha))
+                data[pixel + 2] = UInt8(clamping: Int(Double(replacement.2) * alpha))
+            }
+            out.addRepresentation(target)
+            added = true
+        }
+        return added ? out : nil
+    }
+
+    private static func bytes(of color: NSColor) -> (UInt8, UInt8, UInt8) {
+        (UInt8(clamping: Int(color.redComponent * 255)),
+         UInt8(clamping: Int(color.greenComponent * 255)),
+         UInt8(clamping: Int(color.blueComponent * 255)))
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -143,6 +143,7 @@ extension NativeTextView {
     /// paint a background but keep the body ink, and the system I-beam is
     /// already right on those.
     func invertedRunColors(at event: NSEvent) -> (ink: NSColor, block: NSColor)? {
+        guard configuration.cursorFollowsSpanInk else { return nil }
         let attrs = attributes(at: convert(event.locationInWindow, from: nil))
         guard let attrs,
               let block = attrs[.backgroundColor] as? NSColor,

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -32,6 +32,7 @@ extension NativeTextView {
         } else {
             super.mouseMoved(with: event)
             applyReadOnlyCursor(for: event)
+            applyInvertedIBeamIfNeeded(for: event)
         }
     }
 
@@ -45,6 +46,7 @@ extension NativeTextView {
         } else {
             super.mouseEntered(with: event)
             applyReadOnlyCursor(for: event)
+            applyInvertedIBeamIfNeeded(for: event)
         }
     }
 
@@ -107,25 +109,70 @@ extension NativeTextView {
     /// (view coordinates). `.link` is what drives `clickedOnLink`, so this
     /// matches exactly what is clickable.
     private func isOverLink(at viewPoint: CGPoint) -> Bool {
+        attributes(at: viewPoint)?[.link] != nil
+    }
+
+    /// Attributes of the character under `viewPoint`, or nil when the point is
+    /// past the end of a line / outside any fragment.
+    private func attributes(at viewPoint: CGPoint) -> [NSAttributedString.Key: Any]? {
         guard let tlm = textLayoutManager,
-              let textStorage = textStorage, textStorage.length > 0 else { return false }
+              let textStorage = textStorage, textStorage.length > 0 else { return nil }
 
         let containerPoint = CGPoint(x: viewPoint.x - textContainerOrigin.x,
                                      y: viewPoint.y - textContainerOrigin.y)
-        guard let fragment = tlm.textLayoutFragment(for: containerPoint) else { return false }
+        guard let fragment = tlm.textLayoutFragment(for: containerPoint) else { return nil }
 
         let fragFrame = fragment.layoutFragmentFrame
         let pInFrag = CGPoint(x: containerPoint.x - fragFrame.minX,
                               y: containerPoint.y - fragFrame.minY)
         // Only accept a line fragment that actually contains the point — guards
         // against clicks in trailing padding / past the end of a line.
-        guard let line = fragment.textLineFragments.first(where: { $0.typographicBounds.contains(pInFrag) }) else { return false }
+        guard let line = fragment.textLineFragments.first(where: { $0.typographicBounds.contains(pInFrag) }) else { return nil }
 
         let pInLine = CGPoint(x: pInFrag.x - line.typographicBounds.minX,
                               y: pInFrag.y - line.typographicBounds.minY)
         let idx = line.characterIndex(for: pInLine)
         let lineString = line.attributedString
-        guard idx >= 0, idx < lineString.length else { return false }
-        return lineString.attribute(.link, at: idx, effectiveRange: nil) != nil
+        guard idx >= 0, idx < lineString.length else { return nil }
+        return lineString.attributes(at: idx, effectiveRange: nil)
+    }
+
+    /// Ink + block of a span that repaints its foreground under `event`, or nil.
+    /// Same rule as the caret color: only a run that carries BOTH a background
+    /// and a foreground of its own is inverted — inline code and find matches
+    /// paint a background but keep the body ink, and the system I-beam is
+    /// already right on those.
+    func invertedRunColors(at event: NSEvent) -> (ink: NSColor, block: NSColor)? {
+        let attrs = attributes(at: convert(event.locationInWindow, from: nil))
+        guard let attrs,
+              let block = attrs[.backgroundColor] as? NSColor,
+              let ink = attrs[.foregroundColor] as? NSColor else { return nil }
+        // Resolve inside the view's appearance: these are dynamic colors, and
+        // `NSAppearance.current` during a mouse event is not necessarily ours —
+        // a dark editor would otherwise get the light-mode pair.
+        var resolved: (ink: NSColor, block: NSColor, body: NSColor)?
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            guard let ink = ink.usingColorSpace(.deviceRGB),
+                  let block = block.usingColorSpace(.deviceRGB),
+                  let body = configuration.theme.bodyText.usingColorSpace(.deviceRGB) else { return }
+            resolved = (ink, block, body)
+        }
+        guard let resolved else { return nil }
+        // Body ink on a background is inline code or a find match — the system
+        // I-beam is already right there; only a run that repaints its ink needs us.
+        guard resolved.ink != resolved.body else { return nil }
+        return (resolved.ink, resolved.block)
+    }
+
+    /// Over an inverted span the system I-beam is drawn in the block's own
+    /// color (macOS inverts it against the editor's backdrop, not against the
+    /// run under it), so it disappears. Swap in the same glyph recolored to the
+    /// span's own ink; anywhere else `super` keeps the system cursor.
+    func applyInvertedIBeamIfNeeded(for event: NSEvent) {
+        guard isEditable,
+              let colors = invertedRunColors(at: event),
+              let cursor = InvertedIBeamCursor.cursor(ink: colors.ink, block: colors.block)
+        else { return }
+        cursor.set()
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -519,7 +519,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
         textView.isEditable = isEditable
         textView.isSelectable = true
-        textView.insertionPointColor = isEditable ? context.coordinator.configuration.theme.bodyText : .clear
+        // Keep the caret ink the selection handler resolved (an extension span
+        // can invert it); a plain bodyText reset here stomps it on every pass.
+        textView.insertionPointColor = isEditable
+            ? (context.coordinator.resolvedCaretColor ?? context.coordinator.configuration.theme.bodyText)
+            : .clear
         let fontChanged = (context.coordinator.fontName != fontName) || (context.coordinator.fontSize != fontSize)
         if let pendingInlineReplacement {
             if pendingInlineReplacement.documentId == documentId,

--- a/Tests/MarkdownEngineTests/CaretColorTests.swift
+++ b/Tests/MarkdownEngineTests/CaretColorTests.swift
@@ -1,0 +1,100 @@
+//
+//  CaretColorTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  The caret takes the ink of the extension span it sits in — otherwise a span
+//  that inverts (dark ink on a light block) draws the caret in the block's own
+//  color and it disappears.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+/// `==text==` painted as an inverted block, like the Nodes app registers.
+private struct InvertingHighlight: MarkdownExtension {
+    var id: String { HighlightExtension.identifier }
+    var inline: InlineSyntax? { InlineSyntax(open: "==", close: "==") }
+    func contentAttributes(theme: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] {
+        [.backgroundColor: NSColor.white, .foregroundColor: NSColor.black]
+    }
+    func html(childrenHTML: String) -> String { "<mark>\(childrenHTML)</mark>" }
+}
+
+@MainActor
+@Suite("Caret color follows the span's ink")
+struct CaretColorTests {
+
+    private func makeEditor(_ text: String, extensions: [any MarkdownExtension]) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
+        )
+        coordinator.configuration.extensions = extensions
+        let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.isEditable = true
+        tv.delegate = coordinator
+        coordinator.textView = tv
+        coordinator.rebuildTextStorageAndStyle(tv, from: text)
+        coordinator.lastSyncedText = text
+        coordinator.lastComputedStorage = text
+        coordinator.previousDisplayLength = (text as NSString).length
+        return (coordinator, tv)
+    }
+
+    // "plain ==marked== tail": content `marked` is {8, 6}, markers {6,2} and {14,2}.
+    private static let text = "plain ==marked== tail"
+
+    @Test("caret inside the span takes the span's ink, and gives it back on the way out")
+    func caretInsideSpanInvertsAndRestores() {
+        let (coordinator, tv) = makeEditor(Self.text, extensions: [InvertingHighlight()])
+        let body = coordinator.configuration.theme.bodyText
+
+        tv.setSelectedRange(NSRange(location: 11, length: 0))   // middle of `marked`
+        #expect(tv.insertionPointColor == NSColor.black)
+
+        tv.setSelectedRange(NSRange(location: 2, length: 0))    // back in plain text
+        #expect(tv.insertionPointColor == body)
+    }
+
+    @Test("the markers themselves keep the body ink — the block starts at the content")
+    func caretOnMarkersKeepsBodyInk() {
+        let (coordinator, tv) = makeEditor(Self.text, extensions: [InvertingHighlight()])
+        let body = coordinator.configuration.theme.bodyText
+
+        tv.setSelectedRange(NSRange(location: 7, length: 0))    // between the two `=`
+        #expect(tv.insertionPointColor == body)
+
+        tv.setSelectedRange(NSRange(location: 19, length: 0))   // in `tail`
+        #expect(tv.insertionPointColor == body)
+    }
+
+    /// The engine's own highlight paints a background only, so nothing changes
+    /// for embedders that didn't ask for inverted ink.
+    @Test("an extension that paints no foreground leaves the caret alone")
+    func plainHighlightLeavesCaretAtBodyInk() {
+        let (coordinator, tv) = makeEditor(Self.text, extensions: [HighlightExtension()])
+
+        tv.setSelectedRange(NSRange(location: 11, length: 0))
+
+        #expect(tv.insertionPointColor == coordinator.configuration.theme.bodyText)
+    }
+
+    /// `updateNSView` used to reset the caret to `theme.bodyText` on every
+    /// SwiftUI pass, which stomped the inverted ink a moment after it was set.
+    @Test("the resolved ink survives a view update")
+    func resolvedInkSurvivesViewUpdate() {
+        let (coordinator, tv) = makeEditor(Self.text, extensions: [InvertingHighlight()])
+
+        tv.setSelectedRange(NSRange(location: 11, length: 0))
+        #expect(coordinator.resolvedCaretColor == NSColor.black)
+
+        // What updateNSView re-applies (see NativeTextViewWrapper).
+        tv.insertionPointColor = coordinator.resolvedCaretColor ?? coordinator.configuration.theme.bodyText
+        #expect(tv.insertionPointColor == NSColor.black)
+    }
+}

--- a/Tests/MarkdownEngineTests/CaretColorTests.swift
+++ b/Tests/MarkdownEngineTests/CaretColorTests.swift
@@ -28,13 +28,18 @@ private struct InvertingHighlight: MarkdownExtension {
 @Suite("Caret color follows the span's ink")
 struct CaretColorTests {
 
-    private func makeEditor(_ text: String, extensions: [any MarkdownExtension]) -> (NativeTextViewCoordinator, NativeTextView) {
+    private func makeEditor(
+        _ text: String,
+        extensions: [any MarkdownExtension],
+        followsInk: Bool = true
+    ) -> (NativeTextViewCoordinator, NativeTextView) {
         _ = NSApplication.shared
         let coordinator = NativeTextViewCoordinator(
             text: .constant(text), fontName: "SF Pro", fontSize: 16,
             isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
         )
         coordinator.configuration.extensions = extensions
+        coordinator.configuration.cursorFollowsSpanInk = followsInk
         let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
         tv.isEditable = true
         tv.delegate = coordinator
@@ -71,6 +76,18 @@ struct CaretColorTests {
 
         tv.setSelectedRange(NSRange(location: 19, length: 0))   // in `tail`
         #expect(tv.insertionPointColor == body)
+    }
+
+    /// The whole behavior is off unless the embedder asks for it — an inverting
+    /// extension alone must not change any other app's caret.
+    @Test("off by default, even with an inverting extension registered")
+    func doesNothingWithoutTheOptIn() {
+        let (coordinator, tv) = makeEditor(Self.text, extensions: [InvertingHighlight()], followsInk: false)
+
+        tv.setSelectedRange(NSRange(location: 11, length: 0))
+
+        #expect(tv.insertionPointColor == coordinator.configuration.theme.bodyText)
+        #expect(coordinator.resolvedCaretColor == coordinator.configuration.theme.bodyText)
     }
 
     /// The engine's own highlight paints a background only, so nothing changes

--- a/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
+++ b/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
@@ -1,0 +1,111 @@
+//
+//  FindHighlightRestoreTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 31.07.26.
+//
+//  Find paints with `.backgroundColor`, and so do extension spans, code fences
+//  and table cells. Clearing find's highlights used to remove the attribute
+//  document-wide, which erased their block until something else restyled.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+/// `==text==` painted as an inverted block, like the Nodes app registers.
+private struct InvertingHighlight: MarkdownExtension {
+    var id: String { HighlightExtension.identifier }
+    var inline: InlineSyntax? { InlineSyntax(open: "==", close: "==") }
+    func contentAttributes(theme: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] {
+        [.backgroundColor: NSColor.white, .foregroundColor: NSColor.black]
+    }
+    func html(childrenHTML: String) -> String { "<mark>\(childrenHTML)</mark>" }
+}
+
+@MainActor
+@Suite("Find highlights give the block back when they clear")
+struct FindHighlightRestoreTests {
+
+    // "plain ==marked== tail": content `marked` is {8, 6}, `tail` is {17, 4}.
+    private static let text = "plain ==marked== tail"
+    private static let blockContent = NSRange(location: 8, length: 6)
+
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
+        )
+        coordinator.configuration.extensions = [InvertingHighlight()]
+        let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.isEditable = true
+        tv.delegate = coordinator
+        // The find path scrolls the current match into view; give it a real
+        // scroll view so it takes the TextKit 2 route instead of the TextKit 1
+        // fallback, which has no layout manager to route through here.
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        scrollView.documentView = tv
+        coordinator.textView = tv
+        coordinator.rebuildTextStorageAndStyle(tv, from: text)
+        coordinator.lastSyncedText = text
+        coordinator.lastComputedStorage = text
+        coordinator.previousDisplayLength = (text as NSString).length
+        return (coordinator, tv)
+    }
+
+    private func background(_ tv: NativeTextView, at location: Int) -> NSColor? {
+        tv.textStorage?.attribute(.backgroundColor, at: location, effectiveRange: nil) as? NSColor
+    }
+
+    private func find(_ query: String, _ coordinator: NativeTextViewCoordinator) {
+        coordinator.handleFindQuery(Notification(
+            name: Notification.Name("findQuery"),
+            object: nil,
+            userInfo: ["query": query, "currentIndex": 0]
+        ))
+    }
+
+    private func done(_ coordinator: NativeTextViewCoordinator) {
+        coordinator.handleFindClearHighlights(
+            Notification(name: Notification.Name("findClearHighlights"), object: nil)
+        )
+    }
+
+    @Test("searching the highlighted word and dismissing leaves the block painted")
+    func blockReturnsAfterClearingItsOwnMatch() {
+        let (coordinator, tv) = makeEditor(Self.text)
+        #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
+
+        find("marked", coordinator)
+        #expect(background(tv, at: Self.blockContent.location) != NSColor.white)
+
+        done(coordinator)
+        // No click, no selection change: the block is back on its own.
+        #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
+    }
+
+    @Test("a match somewhere else never touches the block")
+    func blockSurvivesAMatchElsewhere() {
+        let (coordinator, tv) = makeEditor(Self.text)
+
+        find("tail", coordinator)
+        #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
+
+        done(coordinator)
+        #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
+        #expect(background(tv, at: 17) == nil)
+    }
+
+    @Test("re-running the query drops the previous highlight instead of stacking")
+    func repeatedQueriesLeaveNoResidue() {
+        let (coordinator, tv) = makeEditor(Self.text)
+
+        find("marked", coordinator)
+        find("tail", coordinator)
+
+        #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
+        #expect(background(tv, at: 17) != nil)
+    }
+}

--- a/Tests/MarkdownEngineTests/InvertedIBeamCursorTests.swift
+++ b/Tests/MarkdownEngineTests/InvertedIBeamCursorTests.swift
@@ -1,0 +1,62 @@
+//
+//  InvertedIBeamCursorTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  The system I-beam is recolored — core → the span's ink, halo → its block —
+//  so the pointer stays visible inside an inverted highlight.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Inverted I-beam cursor")
+struct InvertedIBeamCursorTests {
+
+    init() { _ = NSApplication.shared }
+
+    /// Every opaque pixel of the largest representation, bucketed by hue.
+    private func pixelCounts(_ image: NSImage) -> (ink: Int, block: Int, other: Int) {
+        guard let rep = image.representations.compactMap({ $0 as? NSBitmapImageRep })
+            .max(by: { $0.pixelsWide < $1.pixelsWide }) else { return (0, 0, 0) }
+        var ink = 0, block = 0, other = 0
+        for x in 0..<rep.pixelsWide {
+            for y in 0..<rep.pixelsHigh {
+                guard let px = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB),
+                      px.alphaComponent > 0.5 else { continue }
+                if px.redComponent > 0.8, px.greenComponent < 0.2 { ink += 1 }
+                else if px.greenComponent > 0.8, px.redComponent < 0.2 { block += 1 }
+                else { other += 1 }
+            }
+        }
+        return (ink, block, other)
+    }
+
+    @Test("the glyph is repainted in exactly the two given colors")
+    func recolorsCoreAndHalo() throws {
+        let cursor = try #require(InvertedIBeamCursor.cursor(ink: .red, block: .green))
+
+        let counts = pixelCounts(cursor.image)
+
+        #expect(counts.ink > 0)                       // the core carries the shape
+        #expect(counts.block > counts.ink)            // the halo is the wider ring
+        #expect(counts.other == 0)                    // nothing of the system's own colors left
+        #expect(cursor.hotSpot == NSCursor.iBeam.hotSpot)
+        #expect(cursor.image.size == NSCursor.iBeam.image.size)
+    }
+
+    /// Recoloring walks ~65k pixels across the 1x–10x representations, which is
+    /// once per color pair and must never land on the mouse-move path.
+    @Test("same colors reuse the built cursor")
+    func cachesPerColorPair() throws {
+        let first = try #require(InvertedIBeamCursor.cursor(ink: .black, block: .white))
+        let second = try #require(InvertedIBeamCursor.cursor(ink: .black, block: .white))
+        let different = try #require(InvertedIBeamCursor.cursor(ink: .white, block: .black))
+
+        #expect(first === second)
+        #expect(first !== different)
+    }
+}

--- a/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
+++ b/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
@@ -1,0 +1,156 @@
+//
+//  OrderedListDisplayNumberingTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 30.07.26.
+//
+//  Ordered items are numbered by POSITION and painted over the source digits.
+//  Two things the styler alone cannot get right, and that a styler-only test
+//  would happily hide:
+//  * the block array a SCOPED restyle sees is not the document — the text
+//    between two scoped regions is missing, so a run can look continuous when
+//    prose actually ended it;
+//  * the overlay is caret-aware, so the coordinator has to restyle when the
+//    caret crosses a marker — no other signal covers ordered markers.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Ordered list display numbering")
+struct OrderedListDisplayNumberingTests {
+
+    private let fontSize: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// `(markerLocation, paintedMarker)` for every overlaid ordered marker.
+    /// Absent = the item paints its own literal digits (styler emits the
+    /// overlay only when the display number differs from the source).
+    private func overlays(_ attrs: [StyledRange]) -> [(loc: Int, text: String)] {
+        attrs.compactMap { entry in
+            (entry.1[.orderedMarker] as? String).map { (entry.0.location, $0) }
+        }
+        .sorted { $0.0 < $1.0 }
+    }
+
+    private func overlays(in tv: NSTextView) -> [(loc: Int, text: String)] {
+        guard let storage = tv.textStorage else { return [] }
+        var out: [(Int, String)] = []
+        storage.enumerateAttribute(.orderedMarker, in: NSRange(location: 0, length: storage.length)) { value, range, _ in
+            if let text = value as? String { out.append((range.location, text)) }
+        }
+        return out.sorted { $0.0 < $1.0 }
+    }
+
+    private func style(_ text: String, caret: Int = -1, scoped: [NSRange]? = nil) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: fontSize,
+            caretLocation: caret, scopedRanges: scoped
+        )
+    }
+
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
+        )
+        let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.isEditable = true
+        tv.delegate = coordinator
+        coordinator.textView = tv
+        coordinator.rebuildTextStorageAndStyle(tv, from: text)
+        coordinator.lastSyncedText = text
+        coordinator.lastComputedStorage = text
+        coordinator.previousDisplayLength = (text as NSString).length
+        return (coordinator, tv)
+    }
+
+    // MARK: Scope
+
+    /// A two-region scope (caret paragraph + previous-caret paragraph — what
+    /// every click builds) drops the prose between the lists from the block
+    /// array. The count must not flow across that hole.
+    @Test("prose between two lists still ends the run when the scope skips it")
+    func disjointScopeDoesNotCarryTheCountIntoTheNextList() {
+        let text = "1. one\n2. two\n\nProse paragraph here.\n\n1. alpha\n2. beta\n"
+        let ns = text as NSString
+        let alpha = ns.range(of: "1. alpha")
+        let scoped = [ns.paragraphRange(for: NSRange(location: 0, length: 0)),
+                      ns.paragraphRange(for: alpha)]
+
+        let painted = overlays(style(text, scoped: scoped))
+            .filter { NSLocationInRange($0.loc, ns.paragraphRange(for: alpha)) }
+
+        // `1. alpha` is item 1 of its own list: display == literal, nothing to
+        // paint. Before the fix it inherited the upper list's count and painted "3.".
+        #expect(painted.isEmpty)
+        #expect(overlays(style(text)).isEmpty)   // and the full pass agrees
+    }
+
+    /// The counterpart: a blank line is loose-list spacing, not a terminator,
+    /// so a scope that only sees the tail must still continue the run above it.
+    @Test("scoped tail of a blank-split list keeps counting")
+    func scopedTailOfBlankSplitListStillContinues() {
+        let text = "1. one\n\n1. two\n"
+        let ns = text as NSString
+        let tail = ns.range(of: "1. two")
+
+        let painted = overlays(style(text, scoped: [ns.paragraphRange(for: tail)]))
+
+        #expect(painted.map(\.text) == ["2."])
+        #expect(painted.first?.loc == tail.location)
+    }
+
+    // MARK: Caret
+
+    /// The caret parked at the line start is where every whole-line delete and
+    /// line-join leaves it — treating that as "editing the digits" is what made
+    /// a 1./2./3. list read 1./1. after deleting item 2.
+    @Test("caret at the line start keeps the display number")
+    func caretAtTheLineStartKeepsTheDisplayNumber() {
+        let painted = overlays(style("1. a\n1. b", caret: 5))
+
+        #expect(painted.map(\.text) == ["2."])
+        #expect(painted.first?.loc == 5)
+    }
+
+    @Test("caret on the digits reveals the raw marker")
+    func caretOnTheDigitsRevealsTheRawMarker() {
+        #expect(overlays(style("1. a\n1. b", caret: 6)).isEmpty)   // between `1` and `.`
+        #expect(overlays(style("1. a\n1. b", caret: 7)).isEmpty)   // the space after `1.`
+        #expect(overlays(style("1. a\n1. b", caret: 8)).count == 1) // content: overlay is back
+    }
+
+    // MARK: Coordinator wiring
+
+    /// The load-bearing half: the styler's reveal is caret-dependent, so a
+    /// caret move across the marker has to trigger a restyle. Nothing else
+    /// signals it (markers aren't tokens, the bullet regex has no digits).
+    @Test("caret leaving the marker restyles the line")
+    func caretLeavingTheMarkerRestylesTheLine() {
+        let (_, tv) = makeEditor("1. a\n1. b")
+
+        tv.setSelectedRange(NSRange(location: 6, length: 0))    // inside the digits
+        #expect(overlays(in: tv).isEmpty)
+
+        tv.setSelectedRange(NSRange(location: 2, length: 0))    // away, onto line 1
+        #expect(overlays(in: tv).map(\.text) == ["2."])
+    }
+
+    /// End-to-end repro of the shipped-looking bug: delete the middle item and
+    /// the survivor must renumber instead of showing its stale literal.
+    @Test("deleting an item renumbers the survivor")
+    func deletingAnItemRenumbersTheSurvivor() {
+        let (_, tv) = makeEditor("1. a\n1. b\n1. c")
+        #expect(overlays(in: tv).map(\.text) == ["2.", "3."])
+
+        tv.insertText("", replacementRange: NSRange(location: 5, length: 5))   // remove "1. b\n"
+
+        #expect(tv.string == "1. a\n1. c")
+        #expect(overlays(in: tv).map(\.text) == ["2."])
+    }
+}

--- a/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
+++ b/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
@@ -105,6 +105,33 @@ struct OrderedListDisplayNumberingTests {
         #expect(painted.first?.loc == tail.location)
     }
 
+    /// The seed scans BACKWARD from the item's marker — which for an indented
+    /// item still sits inside its own line, so it used to count that item and
+    /// every nested list rendered one too high with no gesture at all.
+    @Test("a nested ordered list starts at its own number")
+    func nestedListDoesNotCountItself() {
+        #expect(overlays(style("- outer\n  1. a\n  2. b")).isEmpty)
+        #expect(overlays(style("- outer\n\t1. a\n\t2. b")).isEmpty)
+        #expect(overlays(style("  1. alpha")).isEmpty)
+        #expect(overlays(style("1. top\n  1. nested\n  2. nested")).isEmpty)
+    }
+
+    /// A hole of blank lines between two scoped blocks is loose-list spacing,
+    /// so the count carries; a hole holding another item re-seeds from the
+    /// source and lands on the same number. Both must agree with a full pass.
+    @Test("a scope with holes counts through a loose list")
+    func scopeWithHolesCountsThroughLooseList() {
+        let text = "1. one\n\n1. two\n\n1. three\n"
+        let ns = text as NSString
+        let scoped = [ns.paragraphRange(for: NSRange(location: 0, length: 0)),
+                      ns.paragraphRange(for: ns.range(of: "1. three"))]
+
+        let painted = overlays(style(text, scoped: scoped))
+
+        #expect(painted.map(\.text) == ["3."])
+        #expect(overlays(style(text)).map(\.text) == ["2.", "3."])   // full pass agrees
+    }
+
     // MARK: Caret
 
     /// The caret parked at the line start is where every whole-line delete and
@@ -139,6 +166,20 @@ struct OrderedListDisplayNumberingTests {
 
         tv.setSelectedRange(NSRange(location: 2, length: 0))    // away, onto line 1
         #expect(overlays(in: tv).map(\.text) == ["2."])
+    }
+
+    /// A content keystroke shifts no number, so it keeps the default paragraph
+    /// scope instead of restyling the whole list block — the numbers below it
+    /// must survive that narrower pass untouched.
+    @Test("typing inside an item leaves the run's numbers alone")
+    func contentEditKeepsTheNumbers() {
+        let (_, tv) = makeEditor("1. a\n1. b\n1. c")
+        #expect(overlays(in: tv).map(\.text) == ["2.", "3."])
+
+        tv.insertText("x", replacementRange: NSRange(location: 9, length: 0))   // end of item 2's content
+
+        #expect(tv.string == "1. a\n1. bx\n1. c")
+        #expect(overlays(in: tv).map(\.text) == ["2.", "3."])
     }
 
     /// End-to-end repro of the shipped-looking bug: delete the middle item and


### PR DESCRIPTION
Two things that turned out to be one branch: ordered-list numbering, and the caret/I-beam work the inverted highlight in Nodes needed.

## Ordered lists render their POSITION

An ordered item's number is computed from its position in the run and painted over the source digits. The `.md` file is never rewritten, so every gesture (type, delete, merge, paste) renumbers while the source stays valid CommonMark. The styler hides the whole source marker as one unit and kerns the slot to the display width, so the dot travels with the digits at any digit count; the layout fragment paints it and reveals the raw digits while they are edited.

Two contracts the styler cannot see on its own:

- **The block array a scoped restyle gets is not the document.** A multi-region scope (caret paragraph + previous-caret paragraph — what every click builds) drops the blocks in between, so the prose that ends a run is absent and the count flowed into the next list: clicking into a second list painted "3. alpha". Every discontinuity now re-seeds from the source, the only thing that can still see the skipped text. A hole of pure blank lines is loose-list spacing and keeps the count.
- **The overlay is caret-aware and no existing signal covered ordered markers** (they aren't tokens, `bulletListRegex` has no digits), so a line kept whatever it painted last. Adds `orderedSyntaxRange` plus the crossing signal, next to the task/HR/bullet ones. The caret AT the line start deliberately does not count as editing the digits — that is where every whole-line delete parks it, and counting it left the survivor showing its stale literal (1./1.).

## Cursors follow the ink of the span they are in

Off by default behind `MarkdownEditorConfiguration.cursorFollowsSpanInk`. It only matters for an extension that INVERTS its content (dark ink on a light block), where both cursors are otherwise drawn in the block's own color and disappear inside it.

- **Caret**: resolved from the extension whose CONTENT holds it (on the `==` markers the background is the page again, so the body color is right there), cached because `updateNSView` has no tokens to hand and its unconditional `bodyText` reset would stomp it.
- **I-beam**: the system glyph is one appearance-independent image — measured 23x22pt, bitwise identical in aqua and darkAqua, a dark core inside a light halo (2463 dark / 5286 light of 7799 opaque pixels). macOS inverts it against the EDITOR's backdrop, not against the run under the pointer. `InvertedIBeamCursor` recolors the LIVE `NSCursor.iBeam` image (core -> the run's ink, halo -> its block), which keeps the system shape and the user's pointer size instead of hand-drawing a cursor that ignores both.

## Cost

Everything measured Debug, median of 5+, fresh editor each run.

| | before | after |
|---|---|---|
| one Return, 800-item loose list | 944 ms, quadratic in n | 67 ms, linear |
| typing in a 1600-item ordered list | 89 ms/key | 41 ms/key (bullets 41, prose 31) |
| caret ink per keystroke, 1600 spans | 0.134 ms | 0.002 ms |

The run is scoped as ONE merged range rather than one per block (the styler matches every block against every scoped range), widening only happens on a structural edit and only when the block actually holds a number, and the caret ink reuses the coordinator's memoized active-token set instead of walking the document again.

## Verification

269 tests green. 9 of them are new and every one was checked against the pre-fix code: the nested-list test reproduces 2./3., the scope test reproduces "3. alpha", the caret tests reproduce the stuck overlay.

Two adversarial review passes drove this branch (17 and 21 agents, each finding independently verified). The second pass is why the last two commits exist: the first scope fix introduced an off-by-one that made every NESTED list render one too high, and turned a single Return in a loose list quadratic. Both are fixed and covered.

## Knowingly left open

- A list item's continuation line is a `.paragraph`, which ends the run — a multi-line item switches numbering off for everything below it.
- A loose list keeps stale numbers after a pure digit edit (a digit edit is not classified structural).
- `orderedSyntaxRange` ends after the whole spacer while the styler stops at one space, so `1.  b` disagrees for two offsets; self-heals on the next crossing, and `bulletSyntaxRange` has the same shape.
- Ordered task items (`1. [ ] x`) consume a number but render none — older than this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)