### PR TITLE
Fix rendered table reflow after viewport resize

### DIFF
--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -30,8 +30,8 @@ extension NSAttributedString.Key {
     static let scrollableBlockSourceID = NSAttributedString.Key("ScrollableBlockSourceID")
     /// CGFloat — total reserved height (image + scroller strip) for overlay sizing.
     static let scrollableBlockTotalHeight = NSAttributedString.Key("ScrollableBlockTotalHeight")
-    /// NSValue(range:) — full multi-line range of the wide-table source, used to scope width-change restyles.
-    static let scrollableBlockFullRange = NSAttributedString.Key("ScrollableBlockFullRange")
+    /// NSValue(range:) — source range of a rendered block whose image depends on the text-container width.
+    static let containerWidthDependentBlockFullRange = NSAttributedString.Key("ContainerWidthDependentBlockFullRange")
 }
 
 final class MarkdownTextLayoutFragment: NSTextLayoutFragment {

--- a/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
+++ b/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
@@ -175,9 +175,7 @@ extension NativeTextView {
         }
         if pendingWideTableOverlayUpdate { return }
         pendingWideTableOverlayUpdate = true
-        // Keep overlays responsive while AppKit is running its live-resize
-        // event-tracking loop, while still coalescing bursts to one update.
-        RunLoop.main.perform(inModes: [.default, .eventTracking]) { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.pendingWideTableOverlayUpdate = false
             self.performWideTableOverlayUpdate()

--- a/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
+++ b/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
@@ -175,7 +175,9 @@ extension NativeTextView {
         }
         if pendingWideTableOverlayUpdate { return }
         pendingWideTableOverlayUpdate = true
-        DispatchQueue.main.async { [weak self] in
+        // Keep overlays responsive while AppKit is running its live-resize
+        // event-tracking loop, while still coalescing bursts to one update.
+        RunLoop.main.perform(inModes: [.default, .eventTracking]) { [weak self] in
             guard let self else { return }
             self.pendingWideTableOverlayUpdate = false
             self.performWideTableOverlayUpdate()

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -260,7 +260,7 @@ extension MarkdownStyler {
                     displayWidth: containerWidth,
                     sourceID: computedSourceID
                 )
-                : .collapsedSource(markerTexts: [])
+                : .collapsedSource(markerTexts: [], widthDependent: true)
             _ = appendRenderedStandaloneBlock(
                 for: token,
                 rawContent: source,

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -203,7 +203,7 @@ extension MarkdownStyler {
     }
 
     enum RenderedStandaloneBlockMode {
-        case collapsedSource(markerTexts: [String])
+        case collapsedSource(markerTexts: [String], widthDependent: Bool = false)
         case visibleSource(imageGap: CGFloat)
         /// Wide-table mode: anchor reserves container width, line gains scroller strip, tagged by sourceID.
         case collapsedSourceScrollable(
@@ -233,7 +233,7 @@ extension MarkdownStyler {
         para.alignment = alignment
 
         switch mode {
-        case .collapsedSource(let markerTexts):
+        case .collapsedSource(let markerTexts, let widthDependent):
             emitCollapsedAttrs(
                 token: token,
                 rawContent: rawContent,
@@ -244,7 +244,9 @@ extension MarkdownStyler {
                 paraRange: paraRange,
                 advanceWidth: imageBounds.width,
                 neededLineHeight: imageBounds.height,
-                extraAnchorAttrs: [:],
+                extraAnchorAttrs: widthDependent
+                    ? [.containerWidthDependentBlockFullRange: NSValue(range: paraRange)]
+                    : [:],
                 markerTexts: markerTexts,
                 ctx: ctx,
                 attrs: &attrs
@@ -267,7 +269,7 @@ extension MarkdownStyler {
                     .scrollableBlockNaturalWidth: imageBounds.width,
                     .scrollableBlockSourceID: sourceID,
                     .scrollableBlockTotalHeight: totalHeight,
-                    .scrollableBlockFullRange: NSValue(range: paraRange)
+                    .containerWidthDependentBlockFullRange: NSValue(range: paraRange)
                 ],
                 markerTexts: markerTexts,
                 ctx: ctx,

--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -15,6 +15,7 @@ final class ClampedScrollView: NSScrollView {
 
     /// Saved at the start of every live-resize (including spurious one-click resizes triggered by edge-cursor clicks) so the position is restored when the resize ends. Without this, NSScrollView's default top-anchor-during-resize would jolt a bottom-anchored user back up by hundreds of points on a single edge click.
     private var scrollYBeforeLiveResize: CGFloat?
+    private(set) var isPerformingLiveResize = false
 
     override var intrinsicContentSize: NSSize {
         guard fitsContent, let container = documentView as? NativeTextViewContainer else {
@@ -39,12 +40,16 @@ final class ClampedScrollView: NSScrollView {
 
     override func viewWillStartLiveResize() {
         super.viewWillStartLiveResize()
+        isPerformingLiveResize = true
+        nativeTextView?.beginLiveViewportResize()
         guard !fitsContent else { return }
         scrollYBeforeLiveResize = contentView.bounds.origin.y
     }
 
     override func viewDidEndLiveResize() {
         super.viewDidEndLiveResize()
+        nativeTextView?.endLiveViewportResize()
+        isPerformingLiveResize = false
         guard !fitsContent else { return }
         if let y = scrollYBeforeLiveResize {
             contentView.scroll(to: NSPoint(x: contentView.bounds.origin.x, y: y))

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -271,37 +271,114 @@ extension NativeTextView {
 
         // Width-dependent rendered blocks bake the container width into their image and kern.
         if widthChanged {
+            if (scrollView as? ClampedScrollView)?.isPerformingLiveResize == true {
+                restyleVisibleWidthDependentBlocksDuringLiveResize(in: scrollView)
+                return
+            }
             guard !pendingWidthDependentBlockRestyle else { return }
             pendingWidthDependentBlockRestyle = true
-            // Live window resizing runs the main run loop in event-tracking mode.
-            // Scheduling only on DispatchQueue.main can therefore defer table
-            // reflow until the user releases the resize handle.
-            RunLoop.main.perform(inModes: [.default, .eventTracking]) { [weak self] in
+            DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 self.pendingWidthDependentBlockRestyle = false
                 if self.configuration.readingWidth == nil {
-                    self.restyleWidthDependentBlockParagraphs()
+                    if self.restyleWidthDependentBlockParagraphs(in: nil) {
+                        self.recalcOverscroll(
+                            for: scrollView,
+                            targetWidth: self.frame.width,
+                            debugTag: "widthDependentBlock"
+                        )
+                    }
                 }
                 self.updateWideTableOverlays()
             }
         }
     }
 
+    func beginLiveViewportResize() {
+        lastLiveResizeTableWidth = nil
+    }
+
+    func endLiveViewportResize() {
+        guard lastLiveResizeTableWidth != nil else { return }
+        lastLiveResizeTableWidth = nil
+        guard configuration.readingWidth == nil,
+              let scrollView = enclosingScrollView else { return }
+        if restyleWidthDependentBlockParagraphs(in: nil) {
+            recalcOverscroll(
+                for: scrollView,
+                targetWidth: frame.width,
+                debugTag: "liveResizeEnd"
+            )
+            performWideTableOverlayUpdate()
+        }
+    }
+
+    private func restyleVisibleWidthDependentBlocksDuringLiveResize(
+        in scrollView: NSScrollView
+    ) {
+        guard configuration.readingWidth == nil else {
+            performWideTableOverlayUpdate()
+            return
+        }
+        let width = textContainer?.size.width ?? frame.width
+        if let previousWidth = lastLiveResizeTableWidth,
+           abs(width - previousWidth) < 8 {
+            return
+        }
+        lastLiveResizeTableWidth = width
+        if restyleWidthDependentBlockParagraphs(in: visibleCharacterRange()) {
+            recalcOverscroll(
+                for: scrollView,
+                targetWidth: frame.width,
+                debugTag: "liveResize"
+            )
+            performWideTableOverlayUpdate()
+        }
+    }
+
+    private func visibleCharacterRange() -> NSRange? {
+        guard let textLayoutManager,
+              let viewportRange = textLayoutManager
+                .textViewportLayoutController.viewportRange else {
+            return nil
+        }
+        let start = textLayoutManager.offset(
+            from: textLayoutManager.documentRange.location,
+            to: viewportRange.location
+        )
+        let length = textLayoutManager.offset(
+            from: viewportRange.location,
+            to: viewportRange.endLocation
+        )
+        guard start >= 0, length > 0 else { return nil }
+        return NSRange(location: start, length: length)
+    }
+
     /// Restyle only rendered blocks whose images depend on the current container width.
-    private func restyleWidthDependentBlockParagraphs() {
+    @discardableResult
+    private func restyleWidthDependentBlockParagraphs(
+        in visibleRange: NSRange?
+    ) -> Bool {
         guard let storage = textStorage,
-              let coord = delegate as? NativeTextViewCoordinator else { return }
+              let coord = delegate as? NativeTextViewCoordinator else {
+            return false
+        }
         var ranges: [NSRange] = []
         var seen: Set<String> = []
         let fullRange = NSRange(location: 0, length: storage.length)
-        storage.enumerateAttribute(.containerWidthDependentBlockFullRange, in: fullRange, options: []) { value, _, _ in
+        let enumerationRange = visibleRange.map {
+            NSIntersectionRange($0, fullRange)
+        } ?? fullRange
+        guard enumerationRange.length > 0 else { return false }
+        storage.enumerateAttribute(.containerWidthDependentBlockFullRange, in: enumerationRange, options: []) { value, _, _ in
             guard let v = value as? NSValue else { return }
             let r = v.rangeValue
             let key = "\(r.location):\(r.length)"
             if seen.insert(key).inserted { ranges.append(r) }
         }
-        guard !ranges.isEmpty else { return }
+        guard !ranges.isEmpty else { return false }
         coord.restyleParagraphs(ranges, in: self)
+        return true
     }
 
     override func scrollRangeToVisible(_ range: NSRange) {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -272,7 +272,7 @@ extension NativeTextView {
         // Width-dependent rendered blocks bake the container width into their image and kern.
         if widthChanged {
             if (scrollView as? ClampedScrollView)?.isPerformingLiveResize == true {
-                restyleVisibleWidthDependentBlocksDuringLiveResize(in: scrollView)
+                restyleWidthDependentBlocksDuringLiveResize(in: scrollView)
                 return
             }
             guard !pendingWidthDependentBlockRestyle else { return }
@@ -313,7 +313,7 @@ extension NativeTextView {
         }
     }
 
-    private func restyleVisibleWidthDependentBlocksDuringLiveResize(
+    private func restyleWidthDependentBlocksDuringLiveResize(
         in scrollView: NSScrollView
     ) {
         guard configuration.readingWidth == nil else {
@@ -326,7 +326,11 @@ extension NativeTextView {
             return
         }
         lastLiveResizeTableWidth = width
-        if restyleWidthDependentBlockParagraphs(in: visibleCharacterRange()) {
+        // Container width is document-wide layout state. Limiting this pass to
+        // TextKit 2's lazy viewport leaves off-screen table attachments stamped
+        // with obsolete image and kern widths, which can widen the document and
+        // shift its horizontal origin during a rapid shrink.
+        if restyleWidthDependentBlockParagraphs(in: nil) {
             recalcOverscroll(
                 for: scrollView,
                 targetWidth: frame.width,
@@ -334,24 +338,6 @@ extension NativeTextView {
             )
             performWideTableOverlayUpdate()
         }
-    }
-
-    private func visibleCharacterRange() -> NSRange? {
-        guard let textLayoutManager,
-              let viewportRange = textLayoutManager
-                .textViewportLayoutController.viewportRange else {
-            return nil
-        }
-        let start = textLayoutManager.offset(
-            from: textLayoutManager.documentRange.location,
-            to: viewportRange.location
-        )
-        let length = textLayoutManager.offset(
-            from: viewportRange.location,
-            to: viewportRange.endLocation
-        )
-        guard start >= 0, length > 0 else { return nil }
-        return NSRange(location: start, length: length)
     }
 
     /// Restyle only rendered blocks whose images depend on the current container width.

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -269,26 +269,29 @@ extension NativeTextView {
 
         recalcOverscroll(for: scrollView, targetWidth: newSize.width, debugTag: "setFrameSize")
 
-        // Width change → only wide-table paragraphs need restyling (their kern bakes in displayWidth).
+        // Width-dependent rendered blocks bake the container width into their image and kern.
         if widthChanged {
+            guard !pendingWidthDependentBlockRestyle else { return }
+            pendingWidthDependentBlockRestyle = true
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
+                self.pendingWidthDependentBlockRestyle = false
                 if self.configuration.readingWidth == nil {
-                    self.restyleWideTableParagraphsForWidthChange()
+                    self.restyleWidthDependentBlockParagraphs()
                 }
                 self.updateWideTableOverlays()
             }
         }
     }
 
-    /// Restyle only wide-table paragraphs via stamped anchor ranges; avoids re-tokenizing the doc.
-    private func restyleWideTableParagraphsForWidthChange() {
+    /// Restyle only rendered blocks whose images depend on the current container width.
+    private func restyleWidthDependentBlockParagraphs() {
         guard let storage = textStorage,
               let coord = delegate as? NativeTextViewCoordinator else { return }
         var ranges: [NSRange] = []
         var seen: Set<String> = []
         let fullRange = NSRange(location: 0, length: storage.length)
-        storage.enumerateAttribute(.scrollableBlockFullRange, in: fullRange, options: []) { value, _, _ in
+        storage.enumerateAttribute(.containerWidthDependentBlockFullRange, in: fullRange, options: []) { value, _, _ in
             guard let v = value as? NSValue else { return }
             let r = v.rangeValue
             let key = "\(r.location):\(r.length)"

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -273,7 +273,10 @@ extension NativeTextView {
         if widthChanged {
             guard !pendingWidthDependentBlockRestyle else { return }
             pendingWidthDependentBlockRestyle = true
-            DispatchQueue.main.async { [weak self] in
+            // Live window resizing runs the main run loop in event-tracking mode.
+            // Scheduling only on DispatchQueue.main can therefore defer table
+            // reflow until the user releases the resize handle.
+            RunLoop.main.perform(inModes: [.default, .eventTracking]) { [weak self] in
                 guard let self = self else { return }
                 self.pendingWidthDependentBlockRestyle = false
                 if self.configuration.readingWidth == nil {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -27,6 +27,9 @@ final class NativeTextView: NSTextView {
     var pendingWideTableOverlayUpdate = false
     /// Coalesces width-dependent block restyles to the final width of each runloop.
     var pendingWidthDependentBlockRestyle = false
+    /// Last width rendered during a live resize. Visible tables update in
+    /// small increments; resize-end always applies the exact final width.
+    var lastLiveResizeTableWidth: CGFloat?
     var suppressAutoRevealOnce: Bool = false
     // Set by clickedOnLink during a mouseDown: did the delegate fire (so
     // mouseDown can re-dispatch a click AppKit dropped), and did it navigate

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -25,6 +25,8 @@ final class NativeTextView: NSTextView {
     var pendingFullLayoutMeasure = false
     /// Coalesces wide-table overlay updates to once per runloop (resize fires many per frame).
     var pendingWideTableOverlayUpdate = false
+    /// Coalesces width-dependent block restyles to the final width of each runloop.
+    var pendingWidthDependentBlockRestyle = false
     var suppressAutoRevealOnce: Bool = false
     // Set by clickedOnLink during a mouseDown: did the delegate fire (so
     // mouseDown can re-dispatch a click AppKit dropped), and did it navigate

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -27,8 +27,8 @@ final class NativeTextView: NSTextView {
     var pendingWideTableOverlayUpdate = false
     /// Coalesces width-dependent block restyles to the final width of each runloop.
     var pendingWidthDependentBlockRestyle = false
-    /// Last width rendered during a live resize. Visible tables update in
-    /// small increments; resize-end always applies the exact final width.
+    /// Last width rendered during a live resize. Width-dependent blocks update
+    /// in small increments; resize-end always applies the exact final width.
     var lastLiveResizeTableWidth: CGFloat?
     var suppressAutoRevealOnce: Bool = false
     // Set by clickedOnLink during a mouseDown: did the delegate fire (so

--- a/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
@@ -16,7 +16,7 @@ import Testing
 @Suite("Table width changes")
 struct TableWidthChangeTests {
 
-    @Test func wrappedTableReflowsAfterRapidViewportShrink() async throws {
+    @Test func wrappedTableReflowsDuringRapidViewportShrink() async throws {
         let wrapper = NativeTextViewWrapper(
             text: .constant(Self.wideSource),
             isEditable: false
@@ -37,11 +37,27 @@ struct TableWidthChangeTests {
         )
         let initialContainerWidth = try #require(textView.textContainer?.size.width)
 
-        for width in [820.0, 760.0, 700.0, 680.0] {
+        for width in [820.0, 760.0] {
             window.setContentSize(NSSize(width: width, height: 680))
             window.layoutIfNeeded()
         }
-        await nextMainQueueTurn()
+        runNextTurn(in: .eventTracking)
+
+        let liveResizeBounds = try await renderedTableBounds(
+            in: textView,
+            tableRange: tableRange
+        )
+        let liveContainerWidth = try #require(textView.textContainer?.size.width)
+
+        #expect(liveContainerWidth < initialContainerWidth)
+        #expect(liveResizeBounds.width <= liveContainerWidth + 0.5)
+        #expect(liveResizeBounds.width < initialBounds.width - 20)
+
+        for width in [700.0, 680.0] {
+            window.setContentSize(NSSize(width: width, height: 680))
+            window.layoutIfNeeded()
+        }
+        runNextTurn(in: .eventTracking)
 
         let resizedBounds = try await renderedTableBounds(
             in: textView,
@@ -53,6 +69,16 @@ struct TableWidthChangeTests {
         #expect(resizedBounds.width <= finalContainerWidth + 0.5)
         #expect(resizedBounds.width < initialBounds.width - 20)
         _ = window
+    }
+
+    private func runNextTurn(in mode: RunLoop.Mode) {
+        var didRun = false
+        RunLoop.main.perform(inModes: [mode]) {
+            didRun = true
+        }
+        let cfMode = CFRunLoopMode(mode.rawValue as CFString)
+        _ = CFRunLoopRunInMode(cfMode, 1, true)
+        #expect(didRun)
     }
 
     private func nativeTextView(in rootView: NSView) async throws -> NativeTextView {

--- a/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
@@ -36,12 +36,13 @@ struct TableWidthChangeTests {
             tableRange: tableRange
         )
         let initialContainerWidth = try #require(textView.textContainer?.size.width)
+        let scrollView = try #require(textView.enclosingScrollView as? ClampedScrollView)
 
+        scrollView.viewWillStartLiveResize()
         for width in [820.0, 760.0] {
             window.setContentSize(NSSize(width: width, height: 680))
             window.layoutIfNeeded()
         }
-        runNextTurn(in: .eventTracking)
 
         let liveResizeBounds = try await renderedTableBounds(
             in: textView,
@@ -57,7 +58,7 @@ struct TableWidthChangeTests {
             window.setContentSize(NSSize(width: width, height: 680))
             window.layoutIfNeeded()
         }
-        runNextTurn(in: .eventTracking)
+        scrollView.viewDidEndLiveResize()
 
         let resizedBounds = try await renderedTableBounds(
             in: textView,
@@ -69,16 +70,6 @@ struct TableWidthChangeTests {
         #expect(resizedBounds.width <= finalContainerWidth + 0.5)
         #expect(resizedBounds.width < initialBounds.width - 20)
         _ = window
-    }
-
-    private func runNextTurn(in mode: RunLoop.Mode) {
-        var didRun = false
-        RunLoop.main.perform(inModes: [mode]) {
-            didRun = true
-        }
-        let cfMode = CFRunLoopMode(mode.rawValue as CFString)
-        _ = CFRunLoopRunInMode(cfMode, 1, true)
-        #expect(didRun)
     }
 
     private func nativeTextView(in rootView: NSView) async throws -> NativeTextView {

--- a/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
@@ -72,6 +72,77 @@ struct TableWidthChangeTests {
         _ = window
     }
 
+    @Test func tableOutsideLaidOutViewportReflowsDuringLiveResize() async throws {
+        let source = Self.wideSource
+            + "\n\n"
+            + String(
+                repeating: "Spacer paragraph keeps the document scrollable.\n\n",
+                count: 160
+            )
+        let wrapper = NativeTextViewWrapper(
+            text: .constant(source),
+            isEditable: false
+        )
+        let host = NSHostingController(rootView: wrapper)
+        let window = NSWindow(contentViewController: host)
+        window.minSize = NSSize(width: 680, height: 440)
+        window.styleMask.insert(.fullSizeContentView)
+        window.setContentSize(NSSize(width: 900, height: 680))
+        window.layoutIfNeeded()
+        await nextMainQueueTurn()
+
+        let textView = try await nativeTextView(in: host.view)
+        let tableRange = (source as NSString).range(of: "| Rechtsform")
+        let initialBounds = try await renderedTableBounds(
+            in: textView,
+            tableRange: tableRange
+        )
+        let initialContainerWidth = try #require(textView.textContainer?.size.width)
+        let scrollView = try #require(textView.enclosingScrollView as? ClampedScrollView)
+        let textLayoutManager = try #require(textView.textLayoutManager)
+
+        textLayoutManager.ensureLayout(for: textLayoutManager.documentRange)
+        window.layoutIfNeeded()
+        let bottomY = max(
+            0,
+            (scrollView.documentView?.bounds.height ?? 0)
+                - scrollView.contentView.bounds.height
+        )
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: bottomY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        await nextMainQueueTurn()
+        textLayoutManager.textViewportLayoutController.layoutViewport()
+
+        let viewportRange = try #require(
+            textLayoutManager.textViewportLayoutController.viewportRange
+        )
+        let viewportLocation = textLayoutManager.offset(
+            from: textLayoutManager.documentRange.location,
+            to: viewportRange.location
+        )
+        #expect(scrollView.contentView.bounds.origin.y > 0)
+        #expect(viewportLocation > NSMaxRange(tableRange))
+
+        scrollView.viewWillStartLiveResize()
+        for width in [820.0, 760.0] {
+            window.setContentSize(NSSize(width: width, height: 680))
+            window.layoutIfNeeded()
+        }
+
+        let liveResizeBounds = try await renderedTableBounds(
+            in: textView,
+            tableRange: tableRange
+        )
+        let liveContainerWidth = try #require(textView.textContainer?.size.width)
+
+        #expect(liveContainerWidth < initialContainerWidth)
+        #expect(liveResizeBounds.width <= liveContainerWidth + 0.5)
+        #expect(liveResizeBounds.width < initialBounds.width - 20)
+
+        scrollView.viewDidEndLiveResize()
+        _ = window
+    }
+
     private func nativeTextView(in rootView: NSView) async throws -> NativeTextView {
         for _ in 0..<20 {
             if let textView = descendantViews(in: rootView)

--- a/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeTests.swift
@@ -1,0 +1,118 @@
+//
+//  TableWidthChangeTests.swift
+//  MarkdownEngineTests
+//
+//  Rendered tables cache an image whose cell wrapping depends on the current
+//  text-container width. Resizing must restyle those table paragraphs so the
+//  cached attachment cannot keep an obsolete, wider layout.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Table width changes")
+struct TableWidthChangeTests {
+
+    @Test func wrappedTableReflowsAfterRapidViewportShrink() async throws {
+        let wrapper = NativeTextViewWrapper(
+            text: .constant(Self.wideSource),
+            isEditable: false
+        )
+        let host = NSHostingController(rootView: wrapper)
+        let window = NSWindow(contentViewController: host)
+        window.minSize = NSSize(width: 680, height: 440)
+        window.styleMask.insert(.fullSizeContentView)
+        window.setContentSize(NSSize(width: 900, height: 680))
+        window.layoutIfNeeded()
+        await nextMainQueueTurn()
+
+        let textView = try await nativeTextView(in: host.view)
+        let tableRange = (Self.wideSource as NSString).range(of: "| Rechtsform")
+        let initialBounds = try await renderedTableBounds(
+            in: textView,
+            tableRange: tableRange
+        )
+        let initialContainerWidth = try #require(textView.textContainer?.size.width)
+
+        for width in [820.0, 760.0, 700.0, 680.0] {
+            window.setContentSize(NSSize(width: width, height: 680))
+            window.layoutIfNeeded()
+        }
+        await nextMainQueueTurn()
+
+        let resizedBounds = try await renderedTableBounds(
+            in: textView,
+            tableRange: tableRange
+        )
+        let finalContainerWidth = try #require(textView.textContainer?.size.width)
+
+        #expect(finalContainerWidth < initialContainerWidth)
+        #expect(resizedBounds.width <= finalContainerWidth + 0.5)
+        #expect(resizedBounds.width < initialBounds.width - 20)
+        _ = window
+    }
+
+    private func nativeTextView(in rootView: NSView) async throws -> NativeTextView {
+        for _ in 0..<20 {
+            if let textView = descendantViews(in: rootView)
+                .compactMap({ $0 as? NativeTextView })
+                .first {
+                return textView
+            }
+            await nextMainQueueTurn()
+        }
+        Issue.record("NativeTextView was not attached")
+        throw TestFailure.missingTextView
+    }
+
+    private func renderedTableBounds(
+        in textView: NativeTextView,
+        tableRange: NSRange
+    ) async throws -> CGRect {
+        for _ in 0..<20 {
+            var bounds: CGRect?
+            textView.textStorage?.enumerateAttribute(
+                .latexBounds,
+                in: tableRange,
+                options: []
+            ) { value, _, stop in
+                guard let value = value as? NSValue else { return }
+                bounds = value.rectValue
+                stop.pointee = true
+            }
+            if let bounds { return bounds }
+            await nextMainQueueTurn()
+        }
+        Issue.record("Rendered table bounds were not available")
+        throw TestFailure.missingTableBounds
+    }
+
+    private func nextMainQueueTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func descendantViews(in view: NSView) -> [NSView] {
+        view.subviews.flatMap { child in
+            [child] + descendantViews(in: child)
+        }
+    }
+
+    private enum TestFailure: Error {
+        case missingTextView
+        case missingTableBounds
+    }
+
+    private static let wideSource = """
+    | Rechtsform | Gründungskosten | Laufende Kosten |
+    |---|---|---|
+    | Einzelunternehmen (Kleingewerbe) | 20–60€ Gewerbeanmeldung, jeder Gesellschafter meldet einzeln an | ~0€, nur Steuerberater optional, dreihundert bis achthundert Euro |
+    | GbR | Notar und Handelsregister etwa dreihundert bis fünfhundert Euro | Gesellschaftervertrag empfohlen, Anwalt fünfhundert bis eintausendfünfhundert |
+    """
+}


### PR DESCRIPTION
## What changed

- Mark every rendered table paragraph whose image depends on the text-container width.
- Restyle only those marked paragraphs when the viewport width changes.
- Coalesce rapid width changes to one targeted restyle per main-run-loop turn.
- Add an end-to-end regression test that rapidly shrinks the viewport and verifies the table rewraps to the final width.

## Root cause

The width-change path only restyled tables already using the horizontal-scroll overlay. A normally wrapped table therefore retained the image and kern generated for its previous container width, allowing the stale attachment to exceed a newly narrowed viewport.

## Impact

Rendered tables now rewrap after both slow and rapid window resizing without forcing a full-document restyle. Small tables and other rendered block types retain their existing behavior.

## Validation

- `swift test --filter TableWidthChangeTests`
- `swift test` (254 tests, 46 suites)
- DarthScriptum integration regression: 803 pt table shrinks into a 584 pt text container
