### PR TITLE
Restyle narrow tables after width changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.markdownBlockBackground` now, so the block is continuous at any font size.
   Table cells rasterize their own text and keep the glyph-box fill.
 
+### Fixed
+- Initially narrow tables reflow when the editor width shrinks instead of
+  retaining stale image geometry until an unrelated full restyle.
+
 ## [0.11.0] - 2026-07-31
 
 ### Added

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -31,7 +31,7 @@ extension NSAttributedString.Key {
     static let scrollableBlockSourceID = NSAttributedString.Key("ScrollableBlockSourceID")
     /// CGFloat — total reserved height (image + scroller strip) for overlay sizing.
     static let scrollableBlockTotalHeight = NSAttributedString.Key("ScrollableBlockTotalHeight")
-    /// NSValue(range:) — full multi-line range of the wide-table source, used to scope width-change restyles.
+    /// NSValue(range:) — full multi-line range of a rendered table, used to scope width-change restyles.
     static let scrollableBlockFullRange = NSAttributedString.Key("ScrollableBlockFullRange")
 }
 

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -270,6 +270,7 @@ extension MarkdownStyler {
                 paragraphSpacing: ctx.baseDefaultLineHeight * 0.5,
                 alignment: .left,
                 mode: mode,
+                restyleOnWidthChange: true,
                 ctx: ctx,
                 attrs: &attrs
             )

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -299,6 +299,7 @@ extension MarkdownStyler {
         paragraphSpacing: CGFloat,
         alignment: NSTextAlignment,
         mode: RenderedStandaloneBlockMode,
+        restyleOnWidthChange: Bool = false,
         ctx: StylingContext,
         attrs: inout [StyledRange]
     ) -> Bool {
@@ -308,6 +309,9 @@ extension MarkdownStyler {
         let baseLineHeight = layoutBridgeDefaultLineHeight(for: ctx.baseFont, using: ctx.layoutBridge)
         para.paragraphSpacingBefore = max(para.paragraphSpacingBefore, paragraphSpacingBefore)
         para.alignment = alignment
+        let widthChangeAnchorAttrs: [NSAttributedString.Key: Any] = restyleOnWidthChange
+            ? [.scrollableBlockFullRange: NSValue(range: paraRange)]
+            : [:]
 
         switch mode {
         case .collapsedSource(let markerTexts):
@@ -321,7 +325,7 @@ extension MarkdownStyler {
                 paraRange: paraRange,
                 advanceWidth: imageBounds.width,
                 neededLineHeight: imageBounds.height,
-                extraAnchorAttrs: [:],
+                extraAnchorAttrs: widthChangeAnchorAttrs,
                 markerTexts: markerTexts,
                 ctx: ctx,
                 attrs: &attrs
@@ -330,6 +334,10 @@ extension MarkdownStyler {
         case .collapsedSourceScrollable(let markerTexts, let displayWidth, let sourceID):
             let scrollerStrip = MarkdownTextLayoutFragment.scrollableBlockScrollerStrip
             let totalHeight = imageBounds.height + scrollerStrip
+            var anchorAttrs = widthChangeAnchorAttrs
+            anchorAttrs[.scrollableBlockNaturalWidth] = imageBounds.width
+            anchorAttrs[.scrollableBlockSourceID] = sourceID
+            anchorAttrs[.scrollableBlockTotalHeight] = totalHeight
             emitCollapsedAttrs(
                 token: token,
                 rawContent: rawContent,
@@ -340,12 +348,7 @@ extension MarkdownStyler {
                 paraRange: paraRange,
                 advanceWidth: displayWidth,
                 neededLineHeight: totalHeight,
-                extraAnchorAttrs: [
-                    .scrollableBlockNaturalWidth: imageBounds.width,
-                    .scrollableBlockSourceID: sourceID,
-                    .scrollableBlockTotalHeight: totalHeight,
-                    .scrollableBlockFullRange: NSValue(range: paraRange)
-                ],
+                extraAnchorAttrs: anchorAttrs,
                 markerTexts: markerTexts,
                 ctx: ctx,
                 attrs: &attrs

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -269,20 +269,21 @@ extension NativeTextView {
 
         recalcOverscroll(for: scrollView, targetWidth: newSize.width, debugTag: "setFrameSize")
 
-        // Width change → only wide-table paragraphs need restyling (their kern bakes in displayWidth).
+        // Width change → only rendered table paragraphs need restyling. Their image
+        // width can change, and an initially narrow table can become scrollable.
         if widthChanged {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if self.configuration.readingWidth == nil {
-                    self.restyleWideTableParagraphsForWidthChange()
+                    self.restyleTableParagraphsForWidthChange()
                 }
                 self.updateWideTableOverlays()
             }
         }
     }
 
-    /// Restyle only wide-table paragraphs via stamped anchor ranges; avoids re-tokenizing the doc.
-    private func restyleWideTableParagraphsForWidthChange() {
+    /// Restyle only table paragraphs via stamped anchor ranges; avoids re-tokenizing the doc.
+    private func restyleTableParagraphsForWidthChange() {
         guard let storage = textStorage,
               let coord = delegate as? NativeTextViewCoordinator else { return }
         var ranges: [NSRange] = []

--- a/Tests/MarkdownEngineTests/TableWidthChangeRestyleTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeRestyleTests.swift
@@ -1,0 +1,48 @@
+//
+//  TableWidthChangeRestyleTests.swift
+//  MarkdownEngine
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Table width-change restyling")
+struct TableWidthChangeRestyleTests {
+
+    @Test("Initially narrow tables stamp their paragraph for width-change restyling")
+    func narrowTableStampsWidthChangeRange() throws {
+        _ = NSApplication.shared
+        let text = "| a | b |\n|---|---|\n| 1 | 2 |"
+        let nsText = text as NSString
+        let tokens = MarkdownTokenizer.parseTokensViaAST(in: text)
+        let tableToken = try #require(tokens.first { $0.kind == .table })
+        let font = NSFont.systemFont(ofSize: 15)
+        let context = MarkdownStyler.StylingContext(
+            nsText: nsText,
+            tokens: tokens,
+            codeTokens: [],
+            activeTokenIndices: [],
+            baseFont: font,
+            layoutBridge: nil,
+            baseDefaultLineHeight: 18,
+            codeBackgroundColor: .windowBackgroundColor,
+            latexMarkerFont: font,
+            configuration: .default,
+            wikiLinkIDProvider: { _ in nil }
+        )
+
+        let attributes = MarkdownStyler.styleTables(context)
+        let stampedAnchor = try #require(attributes.first {
+            $0.attributes[.scrollableBlockFullRange] != nil
+        })
+
+        #expect(stampedAnchor.range.length == 1)
+        #expect(stampedAnchor.attributes[.scrollableBlockNaturalWidth] == nil)
+        let stampedRange = try #require(
+            stampedAnchor.attributes[.scrollableBlockFullRange] as? NSValue
+        ).rangeValue
+        #expect(stampedRange == nsText.paragraphRange(for: tableToken.range))
+    }
+}


### PR DESCRIPTION
## Summary

- stamp the width-change restyle range on every rendered table, including tables that initially fit
- reuse the existing paragraph-scoped resize path so unrelated document content is not restyled
- add a regression test and changelog entry

## Root cause

The resize path discovers table paragraphs through the anchor's `ScrollableBlockFullRange` attribute. The styler previously emitted that attribute only for `.collapsedSourceScrollable`, so a table rendered initially through `.collapsedSource` was invisible when the editor later became narrower.

The rendered-block helper now accepts an explicit width-change restyle flag. Table styling enables it before choosing either render mode, which stamps the same paragraph range in both cases without tagging unrelated image or LaTeX blocks.

Fixes #113.

## Validation

- `swift build`
- `swift test --filter TableWidthChangeRestyleTests`
- `swift test`: 299 of 301 tests passed; the two headless animation tests in `ScrollingHeaderControllerTests` failed because their AppKit animations did not advance. `collapseAnimatesBackToCollapsedHeight` fails identically on untouched commit `eaed9dd`, confirming that failure predates this change.
