### PR TITLE
Allow inline code spans in Markdown link labels

### DIFF
--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -17,10 +17,11 @@
 //                          automatically inert for every pass below.
 //    3. scanLinkFamily   — ![[…]], [[…]], ![…](…), […](…), $…$ (+ registered
 //                          extension spans) in precedence order. URLs allow
-//                          balanced parens. A
-//                          candidate overlapping a claimed span is rejected
-//                          (kept literal) — this is what stops a `$…$` from
-//                          spanning across a code span.
+//                          balanced parens. A candidate overlapping a claimed
+//                          span is rejected (kept literal), except for opaque
+//                          spans wholly nested inside a Markdown link's label.
+//                          This keeps `[x](y)` inert inside code while allowing
+//                          valid labels such as [`x`](y).
 //    4. resolveEmphasis  — `*`/`_` delimiter runs over text outside every
 //                          claimed span; may wrap claimed spans.
 //    5. buildTree        — containment tree. Emphasis nests already-collected
@@ -124,12 +125,16 @@ enum InlineParser {
                 return r
             }
         }
-        /// Region whose interior holds collected child spans — only emphasis qualifies.
+        /// Region whose interior can own already-collected child spans.
         var containerContent: NSRange? {
-            if case .emphasis(_, _, let open, let close) = self {
+            switch self {
+            case .emphasis(_, _, let open, let close):
                 return NSRange(location: NSMaxRange(open), length: close.location - NSMaxRange(open))
+            case .link(_, let textRange, _, _):
+                return textRange
+            default:
+                return nil
             }
-            return nil
         }
     }
 
@@ -203,14 +208,22 @@ enum InlineParser {
     // MARK: - 3. Link family / inline LaTeX / extension spans
 
     private static func scanLinkFamily(_ ns: NSString, len: Int, claimed: [NSRange], registry: ExtensionRegistry) -> [Span] {
-        func overlapsClaimed(_ range: NSRange) -> Bool {
-            claimed.contains { NSIntersectionRange($0, range).length > 0 }
+        func hasDisallowedClaimedOverlap(_ span: Span) -> Bool {
+            let overlaps = claimed.filter {
+                NSIntersectionRange($0, span.fullRange).length > 0
+            }
+            guard overlaps.isEmpty == false else { return false }
+            guard case .link(_, let textRange, _, _) = span else { return true }
+            return overlaps.contains {
+                rangeContains(textRange, $0) == false
+            }
         }
         var spans: [Span] = []
         var i = 0
         while i < len {
             if claimed.contains(where: { NSLocationInRange(i, $0) }) { i += 1; continue }
-            if let span = matchClaimedSpan(ns, len, at: i, registry: registry), !overlapsClaimed(span.fullRange) {
+            if let span = matchClaimedSpan(ns, len, at: i, registry: registry),
+               hasDisallowedClaimedOverlap(span) == false {
                 spans.append(span)
                 i = NSMaxRange(span.fullRange)
             } else {

--- a/Tests/MarkdownEngineTests/InlineParserTests.swift
+++ b/Tests/MarkdownEngineTests/InlineParserTests.swift
@@ -149,6 +149,64 @@ struct InlineParserTests {
         ])
     }
 
+    @Test("markdown link permits inline code inside its label")
+    func linkContainsInlineCode() {
+        #expect(InlineParser.parse("[`App`](/tmp/App.swift:56)") == [
+            .link(
+                range: r(0, 26),
+                textRange: r(1, 5),
+                url: r(8, 17),
+                markers: [r(0, 1), r(6, 1), r(7, 1), r(25, 1)],
+                children: [.code(range: r(1, 5), content: r(2, 3))]
+            ),
+        ])
+    }
+
+    @Test("markdown link permits multiple inline code spans in its label")
+    func linkContainsMultipleInlineCodeSpans() {
+        #expect(InlineParser.parse("[`a` and `b`](u)") == [
+            .link(
+                range: r(0, 16),
+                textRange: r(1, 11),
+                url: r(14, 1),
+                markers: [r(0, 1), r(12, 1), r(13, 1), r(15, 1)],
+                children: [
+                    .code(range: r(1, 3), content: r(2, 1)),
+                    .text(r(4, 5)),
+                    .code(range: r(9, 3), content: r(10, 1)),
+                ]
+            ),
+        ])
+    }
+
+    @Test("claimed span crossing a link-label boundary rejects the link")
+    func codeCrossingLinkLabelBoundaryRejectsLink() {
+        #expect(InlineParser.parse("[a `b](u)`") == [
+            .text(r(0, 3)),
+            .code(range: r(3, 7), content: r(4, 5)),
+        ])
+    }
+
+    @Test("markdown link permits escaped punctuation inside its label")
+    func linkContainsEscapedPunctuation() {
+        #expect(InlineParser.parse(#"[\*](u)"#) == [
+            .link(
+                range: r(0, 7),
+                textRange: r(1, 2),
+                url: r(5, 1),
+                markers: [r(0, 1), r(3, 1), r(4, 1), r(6, 1)],
+                children: [.escape(range: r(1, 2), character: r(2, 1), marker: r(1, 1))]
+            ),
+        ])
+    }
+
+    @Test("markdown-looking text inside code remains inert")
+    func codeContainingLinkStaysOpaque() {
+        #expect(InlineParser.parse("`[a](b)`") == [
+            .code(range: r(0, 8), content: r(1, 6)),
+        ])
+    }
+
     @Test("link URL keeps balanced parentheses (bug 4)")
     func linkWithBalancedParens() {
         #expect(InlineParser.parse("[a](b(c))") == [

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -102,6 +102,23 @@ struct MarkdownASTStylerTests {
         #expect(spellingStates(intersecting: prose).isEmpty)
     }
 
+    @Test("inline code inside a link receives both code and link styling")
+    func inlineCodeInsideLinkCombinesStyles() {
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "[`App`](u)",
+            fontName: fontName,
+            fontSize: base
+        )
+        let codeContentLocation = 2
+
+        #expect(attrs.contains { range, attributes in
+            NSLocationInRange(codeContentLocation, range) && attributes[.backgroundColor] != nil
+        })
+        #expect(attrs.contains { range, attributes in
+            NSLocationInRange(codeContentLocation, range) && attributes[.link] != nil
+        })
+    }
+
     /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
     private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
         var result: NSColor?


### PR DESCRIPTION
## Summary

Allow Markdown links to contain inline code and escaped punctuation in their labels while preserving the parser's existing overlap protections.

For example, this now parses and styles the code span inside:

```markdown
[`App`](/tmp/App.swift:56)
```

## Root cause

The inline parser scans code spans and escapes before links so those higher-precedence spans remain opaque. The link pass previously rejected every candidate that overlapped an already claimed span, including spans fully contained within the link label.

As a result, valid label content such as inline code caused the entire Markdown link to remain literal.

## Changes

- Permit previously claimed spans only when they are fully contained within a Markdown link's label.
- Treat links as containers when constructing the inline syntax tree.
- Continue rejecting partial overlaps and spans that cross a label boundary.
- Keep Markdown-looking content inside code spans opaque.
- Add parser coverage for:
  - inline code inside a link label
  - multiple code spans in one label
  - escaped punctuation in a label
  - a code span crossing the label boundary
  - link-looking text inside code
- Add a styling regression test confirming linked inline code receives both code and link attributes.

This changes no public API.

## Validation

- `swift test`
  - 306 tests passed across 54 suites
