### PR TITLE
Add append-only Markdown streaming renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,41 @@ highlighting, themes, wiki-link state, and more.
 > `documentId: "your-doc-id"` so undo history and pending replacements
 > stay scoped to each editor instance.
 
+### AI and token streaming
+
+For generated responses, set `streamingState` to `.streaming` while cumulative
+text updates arrive, then return it to `.idle` to commit one full Markdown parse,
+style, and syntax-highlight pass:
+
+```swift
+NativeTextViewWrapper(
+    text: .constant(response),
+    documentId: responseID,
+    isEditable: false,
+    streamingState: isGenerating ? .streaming : .idle
+)
+```
+
+Streaming uses `.safe` prefix validation by default. It detects replacement or
+mutation of previously rendered content and falls back to a full plain-text reset.
+
+AI/token pipelines that build every cumulative value exclusively by appending
+trusted deltas can opt out of that validation scan:
+
+```swift
+NativeTextViewWrapper(
+    text: .constant(response),
+    documentId: responseID,
+    isEditable: false,
+    streamingState: isGenerating ? .streaming : .idle,
+    streamingValidation: .trustedAppendOnly
+)
+```
+
+Use `.trustedAppendOnly` only when the producer guarantees that existing content
+cannot change during the transaction. Violating that contract can leave the
+displayed prefix out of sync until the final `.idle` commit rebuilds the document.
+
 ## Customization
 
 ### Service Protocols

--- a/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
+++ b/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
@@ -15,6 +15,19 @@ public enum MarkdownStreamingState: Sendable, Equatable {
     case streaming
 }
 
+/// Selects how an active streaming transaction validates cumulative updates.
+public enum MarkdownStreamingValidation: Sendable, Equatable {
+    /// Verifies that every cumulative update preserves the previously rendered prefix.
+    /// This is the default and safely falls back to a reset when the prefix changes.
+    case safe
+
+    /// Trusts the producer's append-only contract and skips prefix verification.
+    ///
+    /// Use this only for AI/token streaming pipelines that construct each cumulative
+    /// value by appending trusted deltas to the previous value.
+    case trustedAppendOnly
+}
+
 /// Tracks the append cursor for one streaming document.
 ///
 /// This deliberately does not retain or update an AST: streaming presentation is
@@ -38,33 +51,46 @@ final class StreamingMarkdownDocument {
         prefixFingerprint = 0
     }
 
-    func update(documentID: String, text: String, forceReset: Bool = false) -> Mutation {
+    func update(
+        documentID: String,
+        text: String,
+        validation: MarkdownStreamingValidation = .safe,
+        forceReset: Bool = false
+    ) -> Mutation {
         let newLength = (text as NSString).length
 
         guard !forceReset,
               self.documentID == documentID,
               newLength >= utf16Length else {
-            adopt(documentID: documentID, text: text)
+            adopt(documentID: documentID, text: text, validation: validation)
             return .reset(text)
         }
 
         if newLength == utf16Length {
+            guard validation == .safe else { return .none }
             let currentHash = fingerprint(text, utf16Length: newLength)
             guard currentHash == prefixFingerprint else {
-                adopt(documentID: documentID, text: text)
+                adopt(documentID: documentID, text: text, validation: validation)
                 return .reset(text)
             }
             return .none
         }
 
-        let currentPrefixHash = fingerprint(text, utf16Length: utf16Length)
-        guard currentPrefixHash == prefixFingerprint else {
-            adopt(documentID: documentID, text: text)
-            return .reset(text)
+        if validation == .safe {
+            let currentPrefixHash = fingerprint(text, utf16Length: utf16Length)
+            guard currentPrefixHash == prefixFingerprint else {
+                adopt(documentID: documentID, text: text, validation: validation)
+                return .reset(text)
+            }
         }
 
         let tail = (text as NSString).substring(from: utf16Length)
-        adoptStreamingAppend(documentID: documentID, text: text, newLength: newLength)
+        adoptStreamingAppend(
+            documentID: documentID,
+            text: text,
+            newLength: newLength,
+            validation: validation
+        )
         return .append(tail)
     }
 
@@ -74,16 +100,29 @@ final class StreamingMarkdownDocument {
         prefixFingerprint = 0
     }
 
-    private func adopt(documentID: String, text: String) {
+    private func adopt(
+        documentID: String,
+        text: String,
+        validation: MarkdownStreamingValidation
+    ) {
         self.documentID = documentID
         utf16Length = (text as NSString).length
-        prefixFingerprint = fingerprint(text, utf16Length: utf16Length)
+        prefixFingerprint = validation == .safe
+            ? fingerprint(text, utf16Length: utf16Length)
+            : 0
     }
 
-    private func adoptStreamingAppend(documentID: String, text: String, newLength: Int) {
+    private func adoptStreamingAppend(
+        documentID: String,
+        text: String,
+        newLength: Int,
+        validation: MarkdownStreamingValidation
+    ) {
         self.documentID = documentID
         utf16Length = newLength
-        prefixFingerprint = fingerprint(text, utf16Length: newLength)
+        prefixFingerprint = validation == .safe
+            ? fingerprint(text, utf16Length: newLength)
+            : 0
     }
 
     private func fingerprint(_ text: String, utf16Length: Int) -> UInt64 {

--- a/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
+++ b/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
@@ -1,0 +1,75 @@
+//
+//  StreamingMarkdownDocument.swift
+//  MarkdownEngine
+//
+
+import Foundation
+
+/// Selects how externally supplied document updates are rendered.
+public enum MarkdownRenderingMode: Sendable, Equatable {
+    /// Normal editor/document behavior: parse and style the complete Markdown document.
+    case editor
+
+    /// Read-only append-only behavior for generated text.
+    ///
+    /// While this mode is active, updates must preserve the existing text and only
+    /// append new characters. The engine renders appended text with base attributes,
+    /// without parsing Markdown or invoking syntax highlighting. Switch back to
+    /// ``editor`` when generation completes to run one authoritative full render.
+    case streamingReadOnly
+}
+
+/// Tracks the append cursor for one streaming document.
+///
+/// This deliberately does not retain or update an AST: streaming presentation is
+/// plain/base-styled text, so parsing an active block would be work whose result is
+/// discarded at completion. The normal document pipeline remains the single source
+/// of truth for the final Markdown render.
+final class StreamingMarkdownDocument {
+    enum Mutation: Equatable {
+        case none
+        case reset(String)
+        case append(String)
+    }
+
+    private(set) var documentID: String?
+    private(set) var utf16Length = 0
+    private var lastText = ""
+
+    func update(documentID: String, text: String, forceReset: Bool = false) -> Mutation {
+        let newLength = (text as NSString).length
+
+        guard forceReset == false,
+              self.documentID == documentID,
+              newLength >= utf16Length else {
+            adopt(documentID: documentID, text: text, utf16Length: newLength)
+            return .reset(text)
+        }
+
+        if newLength == utf16Length {
+            guard text != lastText else { return .none }
+            adopt(documentID: documentID, text: text, utf16Length: newLength)
+            return .reset(text)
+        }
+
+        // `.streamingReadOnly` is an append-only contract, so avoid an O(document)
+        // prefix comparison on every update. Extract only the newly appended UTF-16
+        // tail; callers end a stream by switching modes and replace a stream by using
+        // a different document ID.
+        let appendedText = (text as NSString).substring(from: utf16Length)
+        adopt(documentID: documentID, text: text, utf16Length: newLength)
+        return .append(appendedText)
+    }
+
+    func finish() {
+        documentID = nil
+        utf16Length = 0
+        lastText = ""
+    }
+
+    private func adopt(documentID: String, text: String, utf16Length: Int) {
+        self.documentID = documentID
+        self.utf16Length = utf16Length
+        lastText = text
+    }
+}

--- a/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
+++ b/Sources/MarkdownEngine/Renderer/StreamingMarkdownDocument.swift
@@ -5,18 +5,14 @@
 
 import Foundation
 
-/// Selects how externally supplied document updates are rendered.
-public enum MarkdownRenderingMode: Sendable, Equatable {
-    /// Normal editor/document behavior: parse and style the complete Markdown document.
-    case editor
+/// Controls the explicit lifecycle of an append-only generated document.
+public enum MarkdownStreamingState: Sendable, Equatable {
+    /// Normal parsed Markdown rendering.
+    case idle
 
-    /// Read-only append-only behavior for generated text.
-    ///
-    /// While this mode is active, updates must preserve the existing text and only
-    /// append new characters. The engine renders appended text with base attributes,
-    /// without parsing Markdown or invoking syntax highlighting. Switch back to
-    /// ``editor`` when generation completes to run one authoritative full render.
-    case streamingReadOnly
+    /// An active append-only transaction. Markdown parsing and syntax highlighting
+    /// are deferred until the state returns to ``idle``.
+    case streaming
 }
 
 /// Tracks the append cursor for one streaming document.
@@ -34,42 +30,70 @@ final class StreamingMarkdownDocument {
 
     private(set) var documentID: String?
     private(set) var utf16Length = 0
-    private var lastText = ""
+    private var prefixFingerprint: UInt64 = 0
+
+    func begin(documentID: String) {
+        self.documentID = documentID
+        utf16Length = 0
+        prefixFingerprint = 0
+    }
 
     func update(documentID: String, text: String, forceReset: Bool = false) -> Mutation {
         let newLength = (text as NSString).length
 
-        guard forceReset == false,
+        guard !forceReset,
               self.documentID == documentID,
               newLength >= utf16Length else {
-            adopt(documentID: documentID, text: text, utf16Length: newLength)
+            adopt(documentID: documentID, text: text)
             return .reset(text)
         }
 
         if newLength == utf16Length {
-            guard text != lastText else { return .none }
-            adopt(documentID: documentID, text: text, utf16Length: newLength)
+            let currentHash = fingerprint(text, utf16Length: newLength)
+            guard currentHash == prefixFingerprint else {
+                adopt(documentID: documentID, text: text)
+                return .reset(text)
+            }
+            return .none
+        }
+
+        let currentPrefixHash = fingerprint(text, utf16Length: utf16Length)
+        guard currentPrefixHash == prefixFingerprint else {
+            adopt(documentID: documentID, text: text)
             return .reset(text)
         }
 
-        // `.streamingReadOnly` is an append-only contract, so avoid an O(document)
-        // prefix comparison on every update. Extract only the newly appended UTF-16
-        // tail; callers end a stream by switching modes and replace a stream by using
-        // a different document ID.
-        let appendedText = (text as NSString).substring(from: utf16Length)
-        adopt(documentID: documentID, text: text, utf16Length: newLength)
-        return .append(appendedText)
+        let tail = (text as NSString).substring(from: utf16Length)
+        adoptStreamingAppend(documentID: documentID, text: text, newLength: newLength)
+        return .append(tail)
     }
 
     func finish() {
         documentID = nil
         utf16Length = 0
-        lastText = ""
+        prefixFingerprint = 0
     }
 
-    private func adopt(documentID: String, text: String, utf16Length: Int) {
+    private func adopt(documentID: String, text: String) {
         self.documentID = documentID
-        self.utf16Length = utf16Length
-        lastText = text
+        utf16Length = (text as NSString).length
+        prefixFingerprint = fingerprint(text, utf16Length: utf16Length)
+    }
+
+    private func adoptStreamingAppend(documentID: String, text: String, newLength: Int) {
+        self.documentID = documentID
+        utf16Length = newLength
+        prefixFingerprint = fingerprint(text, utf16Length: newLength)
+    }
+
+    private func fingerprint(_ text: String, utf16Length: Int) -> UInt64 {
+        let nsText = text as NSString
+        let prefix = nsText.substring(with: NSRange(location: 0, length: utf16Length))
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        for byte in prefix.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return hash
     }
 }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -13,6 +13,21 @@
 import AppKit
 
 extension NativeTextViewCoordinator {
+    /// Starts a new append-only transaction for `documentID`.
+    public func beginStreamingDocument(documentID: String) {
+        streamingDocument.begin(documentID: documentID)
+    }
+
+    /// Ends the append-only transaction and performs one authoritative Markdown render.
+    public func commitStreamingDocument(
+        _ textView: NSTextView,
+        scrollView: NSScrollView,
+        text: String
+    ) {
+        streamingDocument.finish()
+        rebuildTextStorageAndStyle(textView, from: text)
+    }
+
     /// Applies externally generated text without parsing or touching previously
     /// rendered storage. The final `.editor` update remains authoritative.
     func updateStreamingDocument(

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -35,11 +35,13 @@ extension NativeTextViewCoordinator {
         in scrollView: NSScrollView,
         documentID: String,
         text: String,
+        validation: MarkdownStreamingValidation = .safe,
         forceReset: Bool
     ) {
         let mutation = streamingDocument.update(
             documentID: documentID,
             text: text,
+            validation: validation,
             forceReset: forceReset
         )
         guard mutation != .none else { return }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -13,6 +13,75 @@
 import AppKit
 
 extension NativeTextViewCoordinator {
+    /// Applies externally generated text without parsing or touching previously
+    /// rendered storage. The final `.editor` update remains authoritative.
+    func updateStreamingDocument(
+        _ textView: NativeTextView,
+        in scrollView: NSScrollView,
+        documentID: String,
+        text: String,
+        forceReset: Bool
+    ) {
+        let mutation = streamingDocument.update(
+            documentID: documentID,
+            text: text,
+            forceReset: forceReset
+        )
+        guard mutation != .none else { return }
+
+        let (baseFont, paragraphStyle) = TextStylingService.makeBaseFontAndStyle(
+            fontName: fontName,
+            fontSize: fontSize,
+            layoutBridge: layoutBridge,
+            configuration: configuration
+        )
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: baseFont,
+            .foregroundColor: configuration.theme.bodyText,
+            .paragraphStyle: paragraphStyle,
+        ]
+
+        isRebuildingDocument = true
+        defer { isRebuildingDocument = false }
+        let replacedDocument: Bool
+        switch mutation {
+        case .none:
+            return
+        case .reset(let completeText):
+            replacedDocument = true
+            textView.textStorage?.setAttributedString(
+                NSAttributedString(string: completeText, attributes: baseAttributes)
+            )
+        case .append(let tail):
+            replacedDocument = false
+            textView.textStorage?.append(
+                NSAttributedString(string: tail, attributes: baseAttributes)
+            )
+        }
+
+        lastSyncedText = text
+        lastComputedStorage = text
+        previousDisplayLength = (text as NSString).length
+        parseGeneration &+= 1
+        cachedParsedDocument = nil
+        cachedParsedText = nil
+        activeTokenIndices = []
+        cachedCodeBlockTokens = []
+        wikiLinkMetadata = [:]
+        resolvedCaretColor = nil
+        parseState.invalidate()
+        textView.refreshPlaceholderVisibility()
+
+        // The end-fragment measurement keeps TextKit's work scoped to the changed
+        // tail. The debug tag intentionally avoids recalcOverscroll's full-layout
+        // path, which is reserved for document switches and width changes.
+        textView.recalcOverscroll(for: scrollView, debugTag: "streamAppend")
+        scrollView.invalidateIntrinsicContentSize()
+        if replacedDocument {
+            onCodeBlockSelectionChange?([])
+        }
+    }
+
     /// Atomically rebuilds contents + base attrs + Markdown styling from storage-form `text`.
     func rebuildTextStorageAndStyle(
         _ textView: NSTextView,

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -73,7 +73,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var onInlinePreviewKey: ((InlinePreviewKey) -> Bool)?
     var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
     var didInitialFormatting: Bool = false
-    var renderingMode: MarkdownRenderingMode = .editor
+    var streamingState: MarkdownStreamingState = .idle
     let streamingDocument = StreamingMarkdownDocument()
     /// One-shot guard so `updateCodeBlockSelection` only forces a full-document layout once per document.
     var didEnsureLayoutForCurrentDocument: Bool = false

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -73,6 +73,8 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var onInlinePreviewKey: ((InlinePreviewKey) -> Bool)?
     var onCodeBlockSelectionChange: (([CodeBlockSelection]) -> Void)?
     var didInitialFormatting: Bool = false
+    var renderingMode: MarkdownRenderingMode = .editor
+    let streamingDocument = StreamingMarkdownDocument()
     /// One-shot guard so `updateCodeBlockSelection` only forces a full-document layout once per document.
     var didEnsureLayoutForCurrentDocument: Bool = false
     /// True only while `rebuildTextStorageAndStyle` runs. Assigning `textView.string`
@@ -466,4 +468,3 @@ extension NSTextView {
         return boundingRect
     }
 }
-

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -71,6 +71,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     public var documentId: String
     /// When `false` the editor renders read-only with no caret.
     public var isEditable: Bool
+    /// Selects the normal parsed editor pipeline or the append-only generated-text path.
+    public var renderingMode: MarkdownRenderingMode
     /// Optional paste hook. Return a Markdown image-embed string (e.g.
     /// `"![[my-image]]"`) to insert at the caret, or `nil` to fall through
     /// to the system's default plain-text paste.
@@ -137,6 +139,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         fontSize: CGFloat = 16,
         documentId: String = "default",
         isEditable: Bool = true,
+        renderingMode: MarkdownRenderingMode = .editor,
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
@@ -160,6 +163,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.fontSize = fontSize
         self.documentId = documentId
         self.isEditable = isEditable
+        self.renderingMode = renderingMode
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
@@ -247,8 +251,19 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.isEditable = isEditable
         textView.isSelectable = true
         textView.isRichText = true
-        let initialState = WikiLinkService.makeDisplayState(from: text) { configuration.services.wikiLinks.name(forID: $0) }
-        textView.string = initialState.display
+        let initialDisplayText: String
+        let initialWikiLinkMetadata: [WikiLinkService.RangeKey: WikiLinkService.LinkMetadata]
+        if renderingMode == .streamingReadOnly {
+            initialDisplayText = text
+            initialWikiLinkMetadata = [:]
+        } else {
+            let initialState = WikiLinkService.makeDisplayState(from: text) {
+                configuration.services.wikiLinks.name(forID: $0)
+            }
+            initialDisplayText = initialState.display
+            initialWikiLinkMetadata = initialState.metadata
+        }
+        textView.string = initialDisplayText
         textView.delegate = context.coordinator
         textView.isVerticallyResizable = true
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
@@ -308,7 +323,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         scrollView.reflectScrolledClipView(scrollView.contentView)
 
         context.coordinator.textView = textView
-        context.coordinator.wikiLinkMetadata = initialState.metadata
+        context.coordinator.wikiLinkMetadata = initialWikiLinkMetadata
+        context.coordinator.renderingMode = renderingMode
         context.coordinator.onCaretRectChange = onCaretRectChange
         context.coordinator.onBuildContextMenu = onBuildContextMenu
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
@@ -381,6 +397,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         reconcileHeader(textView: textView, context: context)
 
         let isNodeSwitch = context.coordinator.documentId != documentId
+        let renderingModeChanged = context.coordinator.renderingMode != renderingMode
 
         // Drop remembered offsets for documents no longer retained (always keep
         // the current one). Only rebuilds the dict when something must go.
@@ -545,7 +562,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
         if context.coordinator.didInitialFormatting
             && context.coordinator.lastSyncedText == text
-            && !fontChanged {
+            && !fontChanged
+            && !renderingModeChanged {
             return
         }
         if fontChanged {
@@ -589,6 +607,25 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         let font = NSFont(name: fontName, size: fontSize) ?? NSFont.systemFont(ofSize: fontSize)
         textView.font = font
         textView.baseFont = font
+        // Sync coordinator inputs before either rendering pipeline uses them.
+        context.coordinator.fontName = fontName
+        context.coordinator.fontSize = fontSize
+        context.coordinator.renderingMode = renderingMode
+        if renderingMode == .streamingReadOnly {
+            context.coordinator.updateStreamingDocument(
+                textView,
+                in: nsView,
+                documentID: documentId,
+                text: text,
+                forceReset: isNodeSwitch || renderingModeChanged || fontChanged
+            )
+            context.coordinator.didInitialFormatting = true
+            return
+        }
+        if renderingModeChanged {
+            context.coordinator.streamingDocument.finish()
+            context.coordinator.didInitialFormatting = false
+        }
         // Skip on switch: textView.string still holds the OUTGOING doc here, so the "?"
         // tag would force a full ensureLayout of the doc about to be discarded (~274ms /
         // 7714 frags @346k). recalcOverscroll#2 after the rebuild measures the new doc;
@@ -599,10 +636,6 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         }
         (nsView as? ClampedScrollView)?.clampToInsets()
 
-        // Sync coordinator's font fields BEFORE the rebuild so the helper
-        // reads the current values from the View struct.
-        context.coordinator.fontName = fontName
-        context.coordinator.fontSize = fontSize
         context.coordinator.rebuildTextStorageAndStyle(
             textView,
             from: text,

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -71,8 +71,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     public var documentId: String
     /// When `false` the editor renders read-only with no caret.
     public var isEditable: Bool
-    /// Selects the normal parsed editor pipeline or the append-only generated-text path.
-    public var renderingMode: MarkdownRenderingMode
+    /// Explicitly begins or commits an append-only generated-text transaction.
+    public var streamingState: MarkdownStreamingState
     /// Optional paste hook. Return a Markdown image-embed string (e.g.
     /// `"![[my-image]]"`) to insert at the caret, or `nil` to fall through
     /// to the system's default plain-text paste.
@@ -139,7 +139,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         fontSize: CGFloat = 16,
         documentId: String = "default",
         isEditable: Bool = true,
-        renderingMode: MarkdownRenderingMode = .editor,
+        streamingState: MarkdownStreamingState = .idle,
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
@@ -163,7 +163,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.fontSize = fontSize
         self.documentId = documentId
         self.isEditable = isEditable
-        self.renderingMode = renderingMode
+        self.streamingState = streamingState
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
@@ -253,7 +253,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.isRichText = true
         let initialDisplayText: String
         let initialWikiLinkMetadata: [WikiLinkService.RangeKey: WikiLinkService.LinkMetadata]
-        if renderingMode == .streamingReadOnly {
+        if streamingState == .streaming {
             initialDisplayText = text
             initialWikiLinkMetadata = [:]
         } else {
@@ -324,7 +324,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
         context.coordinator.textView = textView
         context.coordinator.wikiLinkMetadata = initialWikiLinkMetadata
-        context.coordinator.renderingMode = renderingMode
+        context.coordinator.streamingState = streamingState
+        if streamingState == .streaming {
+            context.coordinator.beginStreamingDocument(documentID: documentId)
+            _ = context.coordinator.streamingDocument.update(documentID: documentId, text: text)
+        }
         context.coordinator.onCaretRectChange = onCaretRectChange
         context.coordinator.onBuildContextMenu = onBuildContextMenu
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
@@ -397,7 +401,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         reconcileHeader(textView: textView, context: context)
 
         let isNodeSwitch = context.coordinator.documentId != documentId
-        let renderingModeChanged = context.coordinator.renderingMode != renderingMode
+        let streamingStateChanged = context.coordinator.streamingState != streamingState
 
         // Drop remembered offsets for documents no longer retained (always keep
         // the current one). Only rebuilds the dict when something must go.
@@ -563,7 +567,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         if context.coordinator.didInitialFormatting
             && context.coordinator.lastSyncedText == text
             && !fontChanged
-            && !renderingModeChanged {
+            && !streamingStateChanged {
             return
         }
         if fontChanged {
@@ -610,21 +614,28 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         // Sync coordinator inputs before either rendering pipeline uses them.
         context.coordinator.fontName = fontName
         context.coordinator.fontSize = fontSize
-        context.coordinator.renderingMode = renderingMode
-        if renderingMode == .streamingReadOnly {
+        let previousStreamingState = context.coordinator.streamingState
+        context.coordinator.streamingState = streamingState
+        if streamingState == .streaming {
+            if previousStreamingState != .streaming || isNodeSwitch {
+                context.coordinator.beginStreamingDocument(documentID: documentId)
+            }
             context.coordinator.updateStreamingDocument(
                 textView,
                 in: nsView,
                 documentID: documentId,
                 text: text,
-                forceReset: isNodeSwitch || renderingModeChanged || fontChanged
+                forceReset: isNodeSwitch || previousStreamingState != .streaming || fontChanged
             )
             context.coordinator.didInitialFormatting = true
             return
         }
-        if renderingModeChanged {
-            context.coordinator.streamingDocument.finish()
-            context.coordinator.didInitialFormatting = false
+        if previousStreamingState == .streaming {
+            context.coordinator.commitStreamingDocument(textView, scrollView: nsView, text: text)
+            context.coordinator.didInitialFormatting = true
+            textView.recalcOverscroll(for: nsView)
+            (nsView as? ClampedScrollView)?.clampToInsets()
+            return
         }
         // Skip on switch: textView.string still holds the OUTGOING doc here, so the "?"
         // tag would force a full ensureLayout of the doc about to be discarded (~274ms /

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -73,6 +73,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     public var isEditable: Bool
     /// Explicitly begins or commits an append-only generated-text transaction.
     public var streamingState: MarkdownStreamingState
+    /// Prefix-validation policy used while ``streamingState`` is ``MarkdownStreamingState/streaming``.
+    public var streamingValidation: MarkdownStreamingValidation
     /// Optional paste hook. Return a Markdown image-embed string (e.g.
     /// `"![[my-image]]"`) to insert at the caret, or `nil` to fall through
     /// to the system's default plain-text paste.
@@ -140,6 +142,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         documentId: String = "default",
         isEditable: Bool = true,
         streamingState: MarkdownStreamingState = .idle,
+        streamingValidation: MarkdownStreamingValidation = .safe,
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
@@ -164,6 +167,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.documentId = documentId
         self.isEditable = isEditable
         self.streamingState = streamingState
+        self.streamingValidation = streamingValidation
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
@@ -327,7 +331,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.streamingState = streamingState
         if streamingState == .streaming {
             context.coordinator.beginStreamingDocument(documentID: documentId)
-            _ = context.coordinator.streamingDocument.update(documentID: documentId, text: text)
+            _ = context.coordinator.streamingDocument.update(
+                documentID: documentId,
+                text: text,
+                validation: streamingValidation
+            )
         }
         context.coordinator.onCaretRectChange = onCaretRectChange
         context.coordinator.onBuildContextMenu = onBuildContextMenu
@@ -625,6 +633,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                 in: nsView,
                 documentID: documentId,
                 text: text,
+                validation: streamingValidation,
                 forceReset: isNodeSwitch || previousStreamingState != .streaming || fontChanged
             )
             context.coordinator.didInitialFormatting = true

--- a/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
+++ b/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
@@ -29,6 +29,30 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.update(documentID: "other", text: "Other") == .reset("Other"))
     }
 
+    @Test func changedPrefixDoesNotAppend() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "a", text: "hello world")
+
+        #expect(
+            document.update(documentID: "a", text: "hello brave world")
+                == .reset("hello brave world")
+        )
+    }
+
+    @Test func sameLengthReplacementResets() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "a", text: "hello")
+
+        #expect(document.update(documentID: "a", text: "hxllo") == .reset("hxllo"))
+    }
+
+    @Test func validAppendStaysFast() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "a", text: "hello")
+
+        #expect(document.update(documentID: "a", text: "hello world") == .append(" world"))
+    }
+
     @Test func utf16TailExtractionHandlesEmoji() {
         let document = StreamingMarkdownDocument()
         _ = document.update(documentID: "answer", text: "Hi 👋")
@@ -98,8 +122,11 @@ struct StreamingMarkdownRenderingTests {
         ) as? NSFont
         #expect(streamedFont?.pointSize == 16)
 
-        stack.coordinator.streamingDocument.finish()
-        stack.coordinator.rebuildTextStorageAndStyle(stack.textView, from: complete)
+        stack.coordinator.commitStreamingDocument(
+            stack.textView,
+            scrollView: stack.scrollView,
+            text: complete
+        )
 
         let parsed = stack.coordinator.parsedDocument(for: stack.textView.string)
         #expect(parsed.tokens.contains { $0.kind == .heading })

--- a/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
+++ b/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
@@ -53,6 +53,23 @@ struct StreamingMarkdownDocumentTests {
         #expect(document.update(documentID: "a", text: "hello world") == .append(" world"))
     }
 
+    @Test func trustedAppendOnlySkipsPrefixValidation() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(
+            documentID: "a",
+            text: "hello world",
+            validation: .trustedAppendOnly
+        )
+
+        #expect(
+            document.update(
+                documentID: "a",
+                text: "hxllo world!!!",
+                validation: .trustedAppendOnly
+            ) == .append("!!!")
+        )
+    }
+
     @Test func utf16TailExtractionHandlesEmoji() {
         let document = StreamingMarkdownDocument()
         _ = document.update(documentID: "answer", text: "Hi 👋")

--- a/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
+++ b/Tests/MarkdownEngineTests/StreamingMarkdownDocumentTests.swift
@@ -1,0 +1,147 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Streaming Markdown document")
+struct StreamingMarkdownDocumentTests {
+    @Test func firstUpdateResetsThenLaterUpdatesAppendOnlyTheTail() {
+        let document = StreamingMarkdownDocument()
+
+        #expect(document.update(documentID: "answer", text: "Hello") == .reset("Hello"))
+        #expect(document.update(documentID: "answer", text: "Hello **wor") == .append(" **wor"))
+        #expect(document.update(documentID: "answer", text: "Hello **world**") == .append("ld**"))
+    }
+
+    @Test func unchangedTextDoesNoWork() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "answer", text: "Hello")
+
+        #expect(document.update(documentID: "answer", text: "Hello") == .none)
+    }
+
+    @Test func replacementAndDocumentSwitchReset() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "answer", text: "Long answer")
+
+        #expect(document.update(documentID: "answer", text: "Short") == .reset("Short"))
+        #expect(document.update(documentID: "other", text: "Other") == .reset("Other"))
+    }
+
+    @Test func utf16TailExtractionHandlesEmoji() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "answer", text: "Hi 👋")
+
+        #expect(document.update(documentID: "answer", text: "Hi 👋 world") == .append(" world"))
+    }
+
+    @Test func finishStartsAnewStreamingDocument() {
+        let document = StreamingMarkdownDocument()
+        _ = document.update(documentID: "answer", text: "First")
+        document.finish()
+
+        #expect(document.update(documentID: "answer", text: "Second") == .reset("Second"))
+    }
+}
+
+@MainActor
+@Suite("Streaming Markdown rendering")
+struct StreamingMarkdownRenderingTests {
+    private func makeStack() -> (
+        coordinator: NativeTextViewCoordinator,
+        scrollView: ClampedScrollView,
+        textView: NativeTextView
+    ) {
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(""),
+            fontName: "SF Pro",
+            fontSize: 16,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        let stack = HeightBehaviorStack(heightBehavior: .fitsContent)
+        coordinator.configuration = stack.textView.configuration
+        coordinator.textView = stack.textView
+        stack.textView.delegate = coordinator
+        return (coordinator, stack.scrollView, stack.textView)
+    }
+
+    @Test func streamingAppendLeavesMarkdownUnparsedUntilFinalRebuild() {
+        let stack = makeStack()
+        let first = "# Answer\n\n**hel"
+        let complete = "# Answer\n\n**hello**"
+
+        stack.coordinator.updateStreamingDocument(
+            stack.textView,
+            in: stack.scrollView,
+            documentID: "answer",
+            text: first,
+            forceReset: false
+        )
+        stack.coordinator.updateStreamingDocument(
+            stack.textView,
+            in: stack.scrollView,
+            documentID: "answer",
+            text: complete,
+            forceReset: false
+        )
+
+        #expect(stack.textView.string == complete)
+        #expect(stack.coordinator.cachedParsedDocument == nil)
+        #expect(stack.coordinator.activeTokenIndices.isEmpty)
+        let streamedFont = stack.textView.textStorage?.attribute(
+            .font,
+            at: 0,
+            effectiveRange: nil
+        ) as? NSFont
+        #expect(streamedFont?.pointSize == 16)
+
+        stack.coordinator.streamingDocument.finish()
+        stack.coordinator.rebuildTextStorageAndStyle(stack.textView, from: complete)
+
+        let parsed = stack.coordinator.parsedDocument(for: stack.textView.string)
+        #expect(parsed.tokens.contains { $0.kind == .heading })
+        #expect(parsed.tokens.contains { $0.kind == .bold })
+    }
+
+    @Test func appendPreservesExistingAttributedPrefix() {
+        let stack = makeStack()
+        stack.coordinator.updateStreamingDocument(
+            stack.textView,
+            in: stack.scrollView,
+            documentID: "answer",
+            text: "prefix",
+            forceReset: false
+        )
+        stack.textView.textStorage?.addAttribute(
+            .backgroundColor,
+            value: NSColor.systemPink,
+            range: NSRange(location: 0, length: 6)
+        )
+
+        stack.coordinator.updateStreamingDocument(
+            stack.textView,
+            in: stack.scrollView,
+            documentID: "answer",
+            text: "prefix tail",
+            forceReset: false
+        )
+
+        #expect(
+            stack.textView.textStorage?.attribute(
+                .backgroundColor,
+                at: 0,
+                effectiveRange: nil
+            ) as? NSColor == NSColor.systemPink
+        )
+        #expect(
+            stack.textView.textStorage?.attribute(
+                .backgroundColor,
+                at: 7,
+                effectiveRange: nil
+            ) == nil
+        )
+    }
+}

--- a/Tests/MarkdownEngineTests/StreamingMarkdownPerformanceTests.swift
+++ b/Tests/MarkdownEngineTests/StreamingMarkdownPerformanceTests.swift
@@ -12,12 +12,17 @@ import Testing
 struct StreamingMarkdownPerformanceTests {
     private static let benchmarkEnvironmentKey = "STREAMING_MARKDOWN_BENCHMARK"
 
-    @Test func compareFullRenderWithAppendOnlyStreaming() {
+    @Test func compareTextKitRenderingForAITokenStreaming() {
         guard ProcessInfo.processInfo.environment[Self.benchmarkEnvironmentKey] == "1" else {
             return
         }
 
-        let updates = generatedUpdates(totalUTF16Length: 50_000, chunkLength: 100)
+        let totalUTF16Length = 30_000
+        let chunkLength = 32
+        let updates = generatedAIResponseUpdates(
+            totalUTF16Length: totalUTF16Length,
+            chunkLength: chunkLength
+        )
         let fullRender = medianDuration(of: 3) {
             let stack = makeStack()
             for text in updates {
@@ -25,29 +30,51 @@ struct StreamingMarkdownPerformanceTests {
                 stack.textView.recalcOverscroll(for: stack.scrollView, debugTag: "benchmarkFull")
             }
         }
-        let appendOnly = medianDuration(of: 3) {
-            let stack = makeStack()
-            for text in updates {
-                stack.coordinator.updateStreamingDocument(
-                    stack.textView,
-                    in: stack.scrollView,
-                    documentID: "benchmark",
-                    text: text,
-                    forceReset: false
-                )
-            }
+        let safe = medianDuration(of: 3) {
+            renderStreaming(updates, validation: .safe)
+        }
+        let trustedAppendOnly = medianDuration(of: 3) {
+            renderStreaming(updates, validation: .trustedAppendOnly)
         }
 
-        let speedup = fullRender / appendOnly
-        let speedupText = String(format: "%.2f", speedup)
+        let safeSpeedup = fullRender / safe
+        let trustedSpeedup = fullRender / trustedAppendOnly
         print(
-            "STREAMING_MARKDOWN_BENCHMARK "
-                + "updates=\(updates.count) utf16=50000 chunk=100 "
+            "STREAMING_MARKDOWN_TEXTKIT_BENCHMARK "
+                + "updates=\(updates.count) utf16=\(totalUTF16Length) chunk=\(chunkLength) "
                 + "full_ms=\(milliseconds(fullRender)) "
-                + "streaming_ms=\(milliseconds(appendOnly)) "
-                + "speedup=\(speedupText)x"
+                + "safe_ms=\(milliseconds(safe)) "
+                + "safe_speedup=\(String(format: "%.2f", safeSpeedup))x "
+                + "trusted_ms=\(milliseconds(trustedAppendOnly)) "
+                + "trusted_speedup=\(String(format: "%.2f", trustedSpeedup))x"
         )
-        #expect(appendOnly < fullRender)
+        #expect(safe < fullRender)
+        #expect(trustedAppendOnly < safe)
+    }
+
+    private func renderStreaming(
+        _ updates: [String],
+        validation: MarkdownStreamingValidation
+    ) {
+        guard let finalText = updates.last else { return }
+        let stack = makeStack()
+        stack.coordinator.beginStreamingDocument(documentID: "benchmark")
+        for text in updates {
+            stack.coordinator.updateStreamingDocument(
+                stack.textView,
+                in: stack.scrollView,
+                documentID: "benchmark",
+                text: text,
+                validation: validation,
+                forceReset: false
+            )
+        }
+        stack.coordinator.commitStreamingDocument(
+            stack.textView,
+            scrollView: stack.scrollView,
+            text: finalText
+        )
+        stack.textView.recalcOverscroll(for: stack.scrollView, debugTag: "benchmarkCommit")
     }
 
     private func makeStack() -> (
@@ -70,18 +97,44 @@ struct StreamingMarkdownPerformanceTests {
         return (coordinator, stack.scrollView, stack.textView)
     }
 
-    private func generatedUpdates(totalUTF16Length: Int, chunkLength: Int) -> [String] {
-        let line = "let value = compute(\"streaming markdown\") // generated response\n"
-        var complete = "```swift\n"
-        while (complete as NSString).length < totalUTF16Length - 4 {
-            complete += line
+    private func generatedAIResponseUpdates(
+        totalUTF16Length: Int,
+        chunkLength: Int
+    ) -> [String] {
+        let section = """
+        ## Implementation notes
+
+        The renderer receives **small cumulative token updates** and keeps completed text stable.
+
+        - Validate the public contract.
+        - Update only the TextKit tail.
+        - Parse Markdown once when generation completes.
+
+        ```swift
+        for await delta in stream {
+            response.append(delta)
+            render(response)
         }
-        complete = (complete as NSString).substring(to: totalUTF16Length - 4) + "```\n"
+        ```
+
+        This paragraph mixes `inline code`, emphasis, and a [documentation link](https://example.com).
+
+
+        """
+        var complete = "# Streaming Markdown response\n\n"
+        while (complete as NSString).length < totalUTF16Length {
+            complete += section
+        }
+        complete = (complete as NSString).substring(to: totalUTF16Length)
 
         let ns = complete as NSString
-        return stride(from: chunkLength, through: ns.length, by: chunkLength).map { length in
+        var updates = stride(from: chunkLength, through: ns.length, by: chunkLength).map { length in
             ns.substring(to: min(length, ns.length))
         }
+        if updates.last.map({ ($0 as NSString).length }) != ns.length {
+            updates.append(complete)
+        }
+        return updates
     }
 
     private func medianDuration(of iterations: Int, operation: () -> Void) -> Double {

--- a/Tests/MarkdownEngineTests/StreamingMarkdownPerformanceTests.swift
+++ b/Tests/MarkdownEngineTests/StreamingMarkdownPerformanceTests.swift
@@ -1,0 +1,101 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+/// Opt-in benchmark for generated Markdown. Run with:
+///
+/// `STREAMING_MARKDOWN_BENCHMARK=1 swift test -c release --filter StreamingMarkdownPerformanceTests`
+@MainActor
+@Suite("Streaming Markdown performance", .serialized)
+struct StreamingMarkdownPerformanceTests {
+    private static let benchmarkEnvironmentKey = "STREAMING_MARKDOWN_BENCHMARK"
+
+    @Test func compareFullRenderWithAppendOnlyStreaming() {
+        guard ProcessInfo.processInfo.environment[Self.benchmarkEnvironmentKey] == "1" else {
+            return
+        }
+
+        let updates = generatedUpdates(totalUTF16Length: 50_000, chunkLength: 100)
+        let fullRender = medianDuration(of: 3) {
+            let stack = makeStack()
+            for text in updates {
+                stack.coordinator.rebuildTextStorageAndStyle(stack.textView, from: text)
+                stack.textView.recalcOverscroll(for: stack.scrollView, debugTag: "benchmarkFull")
+            }
+        }
+        let appendOnly = medianDuration(of: 3) {
+            let stack = makeStack()
+            for text in updates {
+                stack.coordinator.updateStreamingDocument(
+                    stack.textView,
+                    in: stack.scrollView,
+                    documentID: "benchmark",
+                    text: text,
+                    forceReset: false
+                )
+            }
+        }
+
+        let speedup = fullRender / appendOnly
+        let speedupText = String(format: "%.2f", speedup)
+        print(
+            "STREAMING_MARKDOWN_BENCHMARK "
+                + "updates=\(updates.count) utf16=50000 chunk=100 "
+                + "full_ms=\(milliseconds(fullRender)) "
+                + "streaming_ms=\(milliseconds(appendOnly)) "
+                + "speedup=\(speedupText)x"
+        )
+        #expect(appendOnly < fullRender)
+    }
+
+    private func makeStack() -> (
+        coordinator: NativeTextViewCoordinator,
+        scrollView: ClampedScrollView,
+        textView: NativeTextView
+    ) {
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(""),
+            fontName: "SF Pro",
+            fontSize: 16,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        let stack = HeightBehaviorStack(heightBehavior: .fitsContent)
+        coordinator.configuration = stack.textView.configuration
+        coordinator.textView = stack.textView
+        stack.textView.delegate = coordinator
+        return (coordinator, stack.scrollView, stack.textView)
+    }
+
+    private func generatedUpdates(totalUTF16Length: Int, chunkLength: Int) -> [String] {
+        let line = "let value = compute(\"streaming markdown\") // generated response\n"
+        var complete = "```swift\n"
+        while (complete as NSString).length < totalUTF16Length - 4 {
+            complete += line
+        }
+        complete = (complete as NSString).substring(to: totalUTF16Length - 4) + "```\n"
+
+        let ns = complete as NSString
+        return stride(from: chunkLength, through: ns.length, by: chunkLength).map { length in
+            ns.substring(to: min(length, ns.length))
+        }
+    }
+
+    private func medianDuration(of iterations: Int, operation: () -> Void) -> Double {
+        var samples: [Double] = []
+        samples.reserveCapacity(iterations)
+        for _ in 0..<iterations {
+            let start = ProcessInfo.processInfo.systemUptime
+            operation()
+            samples.append(ProcessInfo.processInfo.systemUptime - start)
+        }
+        return samples.sorted()[iterations / 2]
+    }
+
+    private func milliseconds(_ seconds: Double) -> String {
+        String(format: "%.2f", seconds * 1_000)
+    }
+}


### PR DESCRIPTION
## Summary

- Add an explicit `MarkdownStreamingState` lifecycle for append-only generation.
- Append only the new UTF-16 tail to `NSTextStorage` using base attributes.
- Skip Markdown AST parsing, syntax highlighting, and full attributed-string rebuilding while generation is active.
- Enter `.streaming` to begin a transaction and return to `.idle` to commit one final full Markdown render.
- Validate the retained UTF-16 prefix with an O(1)-state fingerprint so prefix edits reset safely instead of being misclassified as appends.
- Keep `.safe` validation as the default and offer `.trustedAppendOnly` for AI/token producers that guarantee cumulative append-only values.
- Safely fall back to a full reset when the document identity, content prefix, font, or rendering mode changes.
- Add correctness tests and an opt-in performance comparison.

## Why

Externally supplied LLM deltas are append-only, but the editor-oriented rendering path rebuilt, reparsed, and restyled the full attributed document for every update. The new mode keeps prior content untouched and limits active work to the appended tail.

## Performance

TextKit-backed warmed Debug benchmark using a mixed AI-style Markdown response with headings, prose, lists, inline formatting, links, and fenced Swift code. It delivers 30,000 UTF-16 units in 938 cumulative updates of 32 units each and includes text-storage mutation, layout, explicit begin, and the final full Markdown commit. Results are the median of three samples:

| Path | Time |
| --- | ---: |
| Full editor render per update | 31,819.22 ms |
| Safe streaming | 713.13 ms (**44.62x**) |
| Trusted append-only streaming | 209.52 ms (**151.87x**) |

Command:

```sh
STREAMING_MARKDOWN_BENCHMARK=1 MD_PERF=0 swift test --filter StreamingMarkdownPerformanceTests
```

This measures the real TextKit renderer path rather than the parser or mutation object alone. It is still a deterministic benchmark, not an Instruments capture of a complete host application.

## Validation

- `MD_PERF=0 swift test`: 312 tests across 57 suites passed.
- Opt-in performance benchmark passed.
- Downstream BananaCode compile-only macOS integration build passed.

## Usage contract

Set `streamingState` to `.streaming` only while content is append-only and the document identity remains stable. Return it to `.idle` at completion to commit the transaction and produce the fully parsed and highlighted final document.

`.safe` is the default and verifies the retained prefix. `.trustedAppendOnly` skips that scan and is intended specifically for AI/token pipelines that construct every cumulative value by appending trusted deltas. Violating the trusted contract can leave the displayed prefix stale until the final `.idle` commit. Prefix mutations, same-length replacements, document switches, and forced resets remain safe under the default policy.
