### PR TITLE
Opt-in list indent grid (ListStyle.markerTextGap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom heading typeface and color: `HeadingStyle.fontName` renders headings
+  in a specific PostScript face (honored exactly, so the chosen weight is
+  respected; an unresolvable name falls back to the stock bold base font),
+  and `MarkdownEditorTheme.headingText` colors heading text independently of
+  `bodyText` — the `#` glyphs stay on `headingMarker`, and inline constructs
+  inside a heading keep their own ink (both opt-in; the defaults are
+  unchanged).
+
 ## [0.11.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Opt-in list indent grid: `ListStyle.markerTextGap` puts list markers on a
+  deterministic `depth × indentPerLevel` grid (level 1 aligned with the body
+  origin), neutralizes the raw source whitespace as the visual indent, and
+  hangs content a fixed slot after the marker for every marker kind (bullet,
+  any digit count, task box — which left-aligns to the slot origin). Wrapped
+  lines hang at the content edge. `nil` (the default) keeps the historical
+  geometry exactly.
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -299,19 +299,48 @@ public struct ListStyle: Sendable {
     public var maximumNestingLevel: Int
     /// Extra line height added on top of the default to give list items room.
     public var extraLineHeight: CGFloat
+    /// Width (in points) of the marker slot — from the marker glyph's left
+    /// edge to the item content's left edge. Setting it opts the list layout
+    /// into a fixed indent GRID; `nil` (the default) keeps the historical
+    /// geometry exactly.
+    ///
+    /// Historically the visual indent is the raw source whitespace: every
+    /// first line starts at a flat `indentPerLevel`, nesting shows only as
+    /// the advance of the leading spaces/tabs (≈8pt for two spaces — far off
+    /// any design grid), and the marker→content gap is whatever `- ` happens
+    /// to measure.
+    ///
+    /// With a gap set, geometry becomes deterministic:
+    /// - a level-`n` item's marker starts at `n × indentPerLevel` from the
+    ///   text origin (level 1 aligns with body text),
+    /// - the leading source whitespace collapses (hidden-marker font; tabs
+    ///   advance by a sub-point interval) so it no longer shifts the line,
+    /// - content starts `markerTextGap` after the marker for every marker
+    ///   kind (bullet, any digit count, task box), via a kern on the final
+    ///   spacer character — so wrapped lines and the caret keep working on
+    ///   real text advances,
+    /// - wrapped lines hang at the content edge (`depth × indentPerLevel +
+    ///   markerTextGap`).
+    ///
+    /// A slot narrower than the marker itself widens just enough to keep the
+    /// spacer's advance positive. Note that in grid mode literal tabs inside
+    /// item CONTENT also advance by the sub-point interval.
+    public var markerTextGap: CGFloat?
 
     public init(
         helpersEnabled: Bool = true,
         autoClosePairsEnabled: Bool = true,
         indentPerLevel: CGFloat = 27.5,
         maximumNestingLevel: Int = 3,
-        extraLineHeight: CGFloat = 2
+        extraLineHeight: CGFloat = 2,
+        markerTextGap: CGFloat? = nil
     ) {
         self.helpersEnabled = helpersEnabled
         self.autoClosePairsEnabled = autoClosePairsEnabled
         self.indentPerLevel = indentPerLevel
         self.maximumNestingLevel = maximumNestingLevel
         self.extraLineHeight = extraLineHeight
+        self.markerTextGap = markerTextGap
     }
 
     public static let `default` = ListStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -349,15 +349,30 @@ public struct TaskCheckboxStyle: Sendable {
 /// Per-level heading metrics. Defaults follow the historical Nodes ratios,
 /// which are loosely based on browser default heading sizes.
 public struct HeadingStyle: Sendable {
+    /// PostScript name of the typeface used for heading text, for example
+    /// `"AvenirNext-DemiBold"`. `nil` (the default) keeps the historical
+    /// behavior: headings render in the editor's base font with the bold
+    /// trait added.
+    ///
+    /// The name is honored exactly, so the chosen face's weight and style
+    /// are respected — pick a `-Bold` / `-Semibold` face for heavier
+    /// headings. Emphasis inside a heading still composes on top of it:
+    /// bold / italic add their traits while the family and the per-level
+    /// size are kept. A name that doesn't resolve falls back to the default
+    /// heading font at draw time, so a typo degrades to the stock look
+    /// instead of changing metrics.
+    public var fontName: String?
     /// Font-size multiplier per heading level (1...6).
     public var fontMultipliers: [CGFloat]
     /// Top spacing in `em` units per heading level (1...6).
     public var topSpacingEm: [CGFloat]
 
     public init(
+        fontName: String? = nil,
         fontMultipliers: [CGFloat] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67],
         topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10]
     ) {
+        self.fontName = fontName
         self.fontMultipliers = fontMultipliers
         self.topSpacingEm = topSpacingEm
     }

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -36,6 +36,15 @@ public struct MarkdownEditorTheme: Sendable {
     /// Foreground color for content the engine wants to deemphasize further
     /// than `mutedText` — for example, broken wiki-links.
     public var disabledText: NSColor
+    /// Foreground color for heading text. `nil` (the default) keeps the
+    /// historical behavior: headings render in ``bodyText`` like the rest
+    /// of the document.
+    ///
+    /// Only the heading's own text takes this color. The `#` marker glyphs
+    /// stay on ``headingMarker``, and inline constructs inside a heading
+    /// (links, inline code, extension spans) keep their own colors, exactly
+    /// as they do over ``bodyText``.
+    public var headingText: NSColor?
     /// Foreground color for heading marker glyphs (`#`, `##`, …).
     public var headingMarker: NSColor
 
@@ -85,6 +94,7 @@ public struct MarkdownEditorTheme: Sendable {
         bodyText: NSColor = .labelColor,
         mutedText: NSColor = .secondaryLabelColor,
         disabledText: NSColor = .tertiaryLabelColor,
+        headingText: NSColor? = nil,
         headingMarker: NSColor = .gray,
         link: NSColor = .linkColor,
         incompleteLink: NSColor = .systemBlue,
@@ -98,6 +108,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.bodyText = bodyText
         self.mutedText = mutedText
         self.disabledText = disabledText
+        self.headingText = headingText
         self.headingMarker = headingMarker
         self.link = link
         self.incompleteLink = incompleteLink

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -624,10 +624,14 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             // char's font (0.1pt in a heading-first doc → 1px boxes).
             let font = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.baseFont
                 ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+            let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
+                ?? .default
             let ascent = max(0, font.ascender)
             let descent = max(0, -font.descender)
             let size = TaskCheckboxGeometry.size(for: font)
-            let boxX = TaskCheckboxGeometry.boxX(contentX: pos.x, size: size)
+            let boxX = TaskCheckboxGeometry.boxX(
+                contentX: pos.x, size: size, markerTextGap: configuration.lists.markerTextGap
+            )
             let centerY = pos.baselineY + (descent - ascent) / 2
             let boxY = centerY - size / 2
 
@@ -641,8 +645,6 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
             let iconInset = max(0.0, size * 0.01)
             let iconRect = boxRect.insetBy(dx: iconInset, dy: iconInset)
-            let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
-                ?? .default
             let style = configuration.taskCheckbox
             let symbolName = isChecked ? style.checkedSymbolName : style.uncheckedSymbolName
             let fallbackName = isChecked

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -28,8 +28,17 @@ enum TaskCheckboxGeometry {
         return max(1.0, min(floor(fontHeight * 1.2), floor(markerWidth * 1.2)))
     }
 
-    /// Left edge of the square: right-aligned to the content start x with `gap`.
-    static func boxX(contentX: CGFloat, size: CGFloat) -> CGFloat {
-        contentX - size - gap
+    /// Left edge of the square.
+    ///
+    /// Legacy layout right-aligns the box to the content start x with `gap`.
+    /// In the indent grid (``ListStyle/markerTextGap`` set) the box is
+    /// LEFT-aligned to the marker slot's origin instead, matching where a
+    /// bullet or number would start — clamped so a slot narrower than the
+    /// box itself falls back to the right-aligned position.
+    static func boxX(contentX: CGFloat, size: CGFloat, markerTextGap: CGFloat? = nil) -> CGFloat {
+        if let markerTextGap {
+            return contentX - max(markerTextGap, size + gap)
+        }
+        return contentX - size - gap
     }
 }

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -30,14 +30,17 @@ enum TaskCheckboxGeometry {
 
     /// Left edge of the square.
     ///
-    /// Legacy layout right-aligns the box to the content start x with `gap`.
-    /// In the indent grid (``ListStyle/markerTextGap`` set) the box is
-    /// LEFT-aligned to the marker slot's origin instead, matching where a
-    /// bullet or number would start — clamped so a slot narrower than the
-    /// box itself falls back to the right-aligned position.
+    /// Legacy layout right-aligns the box to the content start x with `gap`
+    /// (the hidden `[ ] ` sits at the content edge because `- ` keeps full
+    /// advance). In the indent grid (``ListStyle/markerTextGap`` set) the
+    /// styler collapses the WHOLE `- [ ] `, so the box range's own position is
+    /// the marker-slot origin — the square is LEFT-aligned there, matching
+    /// where a bullet or number glyph would start. Gaps narrower than
+    /// `size + gap` let the square run into the content; configure
+    /// ``ListStyle/markerTextGap`` at least that wide.
     static func boxX(contentX: CGFloat, size: CGFloat, markerTextGap: CGFloat? = nil) -> CGFloat {
-        if let markerTextGap {
-            return contentX - max(markerTextGap, size + gap)
+        if markerTextGap != nil {
+            return contentX
         }
         return contentX - size - gap
     }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -377,15 +377,48 @@ enum MarkdownASTStyler {
         ps.paragraphSpacing = ctx.baseParagraphSpacing
         ps.paragraphSpacingBefore = 0
         ps.tabStops = []
-        ps.defaultTabInterval = ctx.config.lists.indentPerLevel
-        ps.firstLineHeadIndent = ctx.config.lists.indentPerLevel
-        // Wrapped lines hang under the first line's content (indent + marker
-        // width). No checkbox-specific extra: the box is a drawn overlay that
-        // doesn't change text advance, so adding it here (and only here, not to
-        // firstLineHeadIndent) shifted an unchecked task's wrapped lines right
-        // of its first line.
-        ps.headIndent = ctx.config.lists.indentPerLevel + depthIndent + markerWidth
-        attrs.append((line, [.paragraphStyle: ps]))
+        if let gap = ctx.config.lists.markerTextGap,
+           item.contentRange.location - 1 >= NSMaxRange(item.marker) {
+            // Indent GRID (opt-in, see ListStyle.markerTextGap): the marker
+            // starts at depth × indentPerLevel — level 1 on the body origin —
+            // and content hangs a fixed slot after it. The raw source
+            // whitespace is neutralized below, so tabs must stop advancing to
+            // indentPerLevel stops; a sub-point interval reduces each tab to
+            // layout noise instead.
+            ps.defaultTabInterval = 0.25
+            ps.firstLineHeadIndent = depthIndent
+            // The slot can widen freely but only narrow until the final spacer
+            // char would reach a negative advance (content folding back over
+            // the marker glyphs).
+            let spacerRange = NSRange(location: item.contentRange.location - 1, length: 1)
+            let spacerWidth = HeadingHelpers.textWidth(ctx.ns.substring(with: spacerRange), font: ctx.baseFont)
+            let slot = max(gap, markerWidth - spacerWidth + 0.5)
+            ps.headIndent = depthIndent + slot
+            attrs.append((line, [.paragraphStyle: ps]))
+            // Collapse the leading whitespace so the SOURCE indent stops being
+            // the visual indent — the paragraph indent above owns it now.
+            // (Tabs keep their sub-point interval advance; spaces take the
+            // hidden-marker font like every other collapsed syntax char.)
+            if wsRange.length > 0 {
+                attrs.append((wsRange, [.font: ctx.inlineMarkerFont]))
+            }
+            // Land the content exactly on the slot edge by kerning the final
+            // spacer char. markerWidth already measures the DISPLAY marker
+            // while the ordered overlay is active and the raw marker in every
+            // reveal state, so the same correction holds for every marker kind
+            // — content doesn't jump when the caret enters/leaves the syntax.
+            attrs.append((spacerRange, [.kern: slot - markerWidth]))
+        } else {
+            ps.defaultTabInterval = ctx.config.lists.indentPerLevel
+            ps.firstLineHeadIndent = ctx.config.lists.indentPerLevel
+            // Wrapped lines hang under the first line's content (indent + marker
+            // width). No checkbox-specific extra: the box is a drawn overlay that
+            // doesn't change text advance, so adding it here (and only here, not to
+            // firstLineHeadIndent) shifted an unchecked task's wrapped lines right
+            // of its first line.
+            ps.headIndent = ctx.config.lists.indentPerLevel + depthIndent + markerWidth
+            attrs.append((line, [.paragraphStyle: ps]))
+        }
 
         // 2. Marker decoration (suppressed while the caret edits the syntax).
         if let box = item.checkbox {

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -71,7 +71,8 @@ enum MarkdownASTStyler {
             extensionsByID: configuration.extensionsByID,
             wikiLinkID: wikiLinkIDProvider,
             scopedRanges: scopedRanges,
-            orderedDisplayNumbers: computeOrderedDisplayNumbers(blocks: blocks, ns: ns)
+            orderedDisplayNumbers: computeOrderedDisplayNumbers(blocks: blocks, ns: ns),
+            listDepths: computeListDepths(blocks: blocks, ns: ns)
         )
         var attrs: [StyledRange] = []
         for block in blocks where ctx.inScope(block.range) {
@@ -209,12 +210,13 @@ enum MarkdownASTStyler {
     /// hole between two scoped blocks" without materializing the substring.
     private static let nonWhitespace = CharacterSet.whitespacesAndNewlines.inverted
 
-    /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
-    /// in the full source: same-indent items counted, blank lines skipped, real
-    /// content stops it) and returns the next number per indent. Lets a scoped
-    /// restyle that only sees a local window continue the document's numbering.
-    private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
-        guard loc > 0, loc <= ns.length else { return [:] }
+    /// The list-item lines of the run that continues ABOVE `loc`, bottom-to-top
+    /// (scanning backward in the full source: list lines collected, blank lines
+    /// skipped, real content stops the scan). `number` is nil for bullets/tasks.
+    /// Shared by the ordered-counter and indent-stack seeds so a scoped restyle
+    /// that only sees a local window can rebuild the document-level run state.
+    private static func scanListRunLines(above loc: Int, in ns: NSString) -> [(indent: Int, number: Int?)] {
+        guard loc > 0, loc <= ns.length else { return [] }
         var runLines: [(indent: Int, number: Int?)] = []   // bottom-to-top; nil = bullet/other list
         // From the START of loc's line: callers pass a MARKER offset, which for
         // an indented item still sits inside its own line — scanning up from
@@ -240,8 +242,16 @@ enum MarkdownASTStyler {
             runLines.append(((ws as NSString).length, number))
             scan = lineRange.location
         }
+        return runLines
+    }
+
+    /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
+    /// in the full source: same-indent items counted, blank lines skipped, real
+    /// content stops it) and returns the next number per indent. Lets a scoped
+    /// restyle that only sees a local window continue the document's numbering.
+    private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
         var counters: [Int: Int] = [:]
-        for item in runLines.reversed() {                    // replay top-to-bottom
+        for item in scanListRunLines(above: loc, in: ns).reversed() {   // replay top-to-bottom
             if let number = item.number {
                 counters[item.indent] = (counters[item.indent] ?? number) + 1
             } else {
@@ -250,6 +260,63 @@ enum MarkdownASTStyler {
             for key in counters.keys where key > item.indent { counters[key] = nil }
         }
         return counters
+    }
+
+    /// Replays the list run that continues ABOVE `loc` and returns the stack of
+    /// open ancestor indent columns (outermost first) — the state
+    /// `computeListDepths` needs to keep a nested item's depth stable when a
+    /// scoped restyle starts mid-list.
+    private static func seedIndentStack(above loc: Int, in ns: NSString) -> [Int] {
+        var stack: [Int] = []
+        for item in scanListRunLines(above: loc, in: ns).reversed() {   // replay top-to-bottom
+            while let top = stack.last, top >= item.indent { stack.removeLast() }
+            stack.append(item.indent)
+        }
+        return stack
+    }
+
+    /// Structural nesting depth (0-based) per list item, keyed by marker
+    /// location. Derived from the ORDER of indent columns in the run — an item
+    /// is one level deeper than the nearest earlier item with a smaller indent
+    /// — instead of a fixed spaces-per-level divisor, so ordered nesting (3+
+    /// columns per level, marker-width driven) and bullet nesting (2 columns)
+    /// land on the same ladder. Mirrors `computeOrderedDisplayNumbers`'
+    /// gap/seed handling so scoped restyles see document-level depth.
+    private static func computeListDepths(blocks: [BlockNode], ns: NSString) -> [Int: Int] {
+        var result: [Int: Int] = [:]
+        var stack: [Int] = []          // open ancestor indent columns
+        var needsSeed = true
+        var contiguousEnd: Int?
+        for block in blocks {
+            if let contiguousEnd, block.range.location > contiguousEnd,
+               ns.rangeOfCharacter(from: Self.nonWhitespace, options: [],
+                                   range: NSRange(location: contiguousEnd,
+                                                  length: block.range.location - contiguousEnd)).location != NSNotFound {
+                stack = []
+                needsSeed = true
+            }
+            contiguousEnd = NSMaxRange(block.range)
+            switch block {
+            case .list(_, let items):
+                for item in items {
+                    if needsSeed {
+                        stack = seedIndentStack(above: item.marker.location, in: ns)
+                        needsSeed = false
+                    }
+                    while let top = stack.last, top >= item.indent { stack.removeLast() }
+                    result[item.marker.location] = stack.count
+                    stack.append(item.indent)
+                }
+            case .blank:
+                break                     // blank lines keep the run (spacing, not a reset)
+            case .paragraph(_, let inlines) where inlines.isEmpty:
+                break                     // an empty paragraph line is spacing too
+            default:
+                stack = []                // real text/content ends the run
+                needsSeed = false         // a seed scan would stop on this line anyway
+            }
+        }
+        return result
     }
 
     private static func computeOrderedDisplayNumbers(blocks: [BlockNode], ns: NSString) -> [Int: Int] {
@@ -359,6 +426,10 @@ enum MarkdownASTStyler {
         // Keep the source punctuation (`.` or `)`) when overlaying, so a paren list stays a paren list.
         let orderedPunct = orderedOverlayActive && item.marker.length > 0
             ? ctx.ns.substring(with: NSRange(location: NSMaxRange(item.marker) - 1, length: 1)) : "."
+        // A hidden task in the indent grid collapses its `- ` too (the drawn box
+        // replaces the whole marker slot, LEFT-aligned at the slot origin), so
+        // the slot kern below must measure the marker at its collapsed advance.
+        let gridHiddenTask = ctx.config.lists.markerTextGap != nil && item.checkbox != nil && !taskRevealed
         // Via the memoized measure — list markers are a tiny repeated set (`- `, `1. `).
         let markerWidth: CGFloat = {
             if orderedOverlayActive, let displayNumber {
@@ -366,9 +437,16 @@ enum MarkdownASTStyler {
                                                          length: item.contentRange.location - NSMaxRange(item.marker)))
                 return HeadingHelpers.textWidth("\(displayNumber)\(orderedPunct)" + gap, font: ctx.baseFont)
             }
-            return HeadingHelpers.textWidth(ctx.ns.substring(with: markerGroup), font: ctx.baseFont)
+            return HeadingHelpers.textWidth(ctx.ns.substring(with: markerGroup),
+                                            font: gridHiddenTask ? ctx.inlineMarkerFont : ctx.baseFont)
         }()
+        // Legacy layout derives depth from a fixed 2-columns-per-level divisor;
+        // the grid uses the STRUCTURAL depth (position of this item's indent in
+        // the run's indent ladder) so 3-column ordered nesting steps one level
+        // per parent, not one per two source columns.
         let depthIndent = CGFloat(MarkdownLists.indentLevel(from: ws)) * ctx.config.lists.indentPerLevel
+        let structuralDepth = ctx.listDepths[item.marker.location] ?? MarkdownLists.indentLevel(from: ws)
+        let gridDepthIndent = CGFloat(structuralDepth) * ctx.config.lists.indentPerLevel
         let ps = NSMutableParagraphStyle()
         let lineHeight = ctx.baseLineHeight + ctx.config.lists.extraLineHeight
         ps.minimumLineHeight = lineHeight
@@ -386,14 +464,14 @@ enum MarkdownASTStyler {
             // indentPerLevel stops; a sub-point interval reduces each tab to
             // layout noise instead.
             ps.defaultTabInterval = 0.25
-            ps.firstLineHeadIndent = depthIndent
+            ps.firstLineHeadIndent = gridDepthIndent
             // The slot can widen freely but only narrow until the final spacer
             // char would reach a negative advance (content folding back over
             // the marker glyphs).
             let spacerRange = NSRange(location: item.contentRange.location - 1, length: 1)
             let spacerWidth = HeadingHelpers.textWidth(ctx.ns.substring(with: spacerRange), font: ctx.baseFont)
             let slot = max(gap, markerWidth - spacerWidth + 0.5)
-            ps.headIndent = depthIndent + slot
+            ps.headIndent = gridDepthIndent + slot
             attrs.append((line, [.paragraphStyle: ps]))
             // Collapse the leading whitespace so the SOURCE indent stops being
             // the visual indent — the paragraph indent above owns it now.
@@ -424,11 +502,22 @@ enum MarkdownASTStyler {
         if let box = item.checkbox {
             if taskRevealed { return }
             let spacer = NSRange(location: NSMaxRange(item.marker), length: box.location - NSMaxRange(item.marker))
-            // `- ` keeps full advance (the box's slot, like the bullet `•`);
-            // `[ ]` + trailing space collapse to the hidden-marker font so the
-            // content starts at the bullet-content x.
-            attrs.append((item.marker, [.foregroundColor: NSColor.clear]))
-            if spacer.length > 0 { attrs.append((spacer, [.foregroundColor: NSColor.clear])) }
+            if gridHiddenTask {
+                // Indent grid: the WHOLE `- [ ] ` collapses so the box range's
+                // position IS the marker-slot origin — the drawn square sits
+                // LEFT-aligned there (where a bullet glyph would start) and the
+                // slot kern above already measures the collapsed marker.
+                attrs.append((item.marker, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
+                if spacer.length > 0 {
+                    attrs.append((spacer, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
+                }
+            } else {
+                // `- ` keeps full advance (the box's slot, like the bullet `•`);
+                // `[ ]` + trailing space collapse to the hidden-marker font so the
+                // content starts at the bullet-content x.
+                attrs.append((item.marker, [.foregroundColor: NSColor.clear]))
+                if spacer.length > 0 { attrs.append((spacer, [.foregroundColor: NSColor.clear])) }
+            }
             attrs.append((box, [.taskCheckbox: item.checked, .foregroundColor: NSColor.clear,
                                 .font: ctx.inlineMarkerFont]))
             let postGap = NSRange(location: NSMaxRange(box),
@@ -545,6 +634,9 @@ enum MarkdownASTStyler {
         let wikiLinkID: (NSRange) -> String?
         let scopedRanges: [NSRange]?
         let orderedDisplayNumbers: [Int: Int]
+        /// Structural nesting depth (0-based) per list item, keyed by marker
+        /// location — see `computeListDepths`.
+        let listDepths: [Int: Int]
 
         /// True when a non-empty selection overlaps `range` — the selection
         /// counterpart of `isActive` for elements that reveal on select.

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -548,9 +548,15 @@ enum MarkdownASTStyler {
 
         case .heading(let level, let range, let markers, let inlines):
             let multiplier = ctx.config.headings.fontMultiplier(for: level)
-            let headingBase = NSFont(name: ctx.fontName, size: ctx.baseFont.pointSize * multiplier)
-                ?? .systemFont(ofSize: ctx.baseFont.pointSize * multiplier)
-            let headingFont = adding(.bold, to: headingBase)
+            let headingSize = ctx.baseFont.pointSize * multiplier
+            // A configured heading face is honored exactly — its weight is the
+            // embedder's choice, so no synthetic bold on top. A name that
+            // doesn't resolve degrades to the stock heading font (base family,
+            // bold trait), mirroring TaskCheckboxStyle's symbol fallback.
+            let headingFont = ctx.config.headings.fontName
+                .flatMap { NSFont(name: $0, size: headingSize) }
+                ?? adding(.bold, to: NSFont(name: ctx.fontName, size: headingSize)
+                    ?? .systemFont(ofSize: headingSize))
             let lineHeight = ceil(headingFont.ascender - headingFont.descender + headingFont.leading) + 1
             let headingPara = NSMutableParagraphStyle()
             headingPara.minimumLineHeight = lineHeight
@@ -558,7 +564,15 @@ enum MarkdownASTStyler {
             headingPara.paragraphSpacingBefore = headingFont.pointSize * ctx.config.headings.topSpacingEm(for: level)
             headingPara.paragraphSpacing = ctx.baseParagraphSpacing
             attrs.append((ctx.ns.paragraphRange(for: range), [.paragraphStyle: headingPara]))
-            attrs.append((range, [.font: headingFont]))
+            // theme.headingText paints the whole heading line; the marker loop
+            // and the inline descent below both append LATER, so `#` glyphs
+            // keep headingMarker and links / code keep their own ink — the
+            // same later-range-wins layering the bodyText default relies on.
+            var headingAttrs: [NSAttributedString.Key: Any] = [.font: headingFont]
+            if let headingText = ctx.theme.headingText {
+                headingAttrs[.foregroundColor] = headingText
+            }
+            attrs.append((range, headingAttrs))
             for marker in markers {
                 attrs.append((marker, [.foregroundColor: ctx.theme.headingMarker]))
             }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -31,7 +31,10 @@ extension NativeTextView {
             guard let isChecked = value as? Bool else { return }
             let anchor = bridge.boundingRect(forCharacterRange: attrRange, in: textContainer)
             let rect = CGRect(
-                x: TaskCheckboxGeometry.boxX(contentX: anchor.minX, size: boxSize),
+                x: TaskCheckboxGeometry.boxX(
+                    contentX: anchor.minX, size: boxSize,
+                    markerTextGap: configuration.lists.markerTextGap
+                ),
                 y: anchor.minY,
                 width: boxSize,
                 height: max(anchor.height, boxSize)

--- a/Tests/MarkdownEngineTests/HeadingFontAndColorTests.swift
+++ b/Tests/MarkdownEngineTests/HeadingFontAndColorTests.swift
@@ -1,0 +1,179 @@
+//
+//  HeadingFontAndColorTests.swift
+//  MarkdownEngineTests
+//
+//  The two opt-in heading knobs: `HeadingStyle.fontName` (a dedicated heading
+//  typeface) and `MarkdownEditorTheme.headingText` (a dedicated heading text
+//  color). Both default to nil, which must keep the stock styling unchanged —
+//  headings derive from the base font with the bold trait and inherit the
+//  view-level bodyText foreground.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Heading font & color knobs")
+struct HeadingFontAndColorTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// A real, always-installed face that differs from the system font in both
+    /// family and weight, so assertions can see it was used verbatim.
+    private let headingFace = "Menlo-Regular"
+
+    /// Effective font at `pos`: the last styled range covering it that sets `.font`.
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
+    private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.foregroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    private func style(
+        _ text: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: configuration
+        )
+    }
+
+    // MARK: - HeadingStyle.fontName
+
+    @Test("headings.fontName renders headings in that face at the multiplied size")
+    func headingFontNameUsedVerbatimAtMultipliedSize() {
+        let config = MarkdownEditorConfiguration(headings: HeadingStyle(fontName: headingFace))
+        // "# One\n\nbody\n\n## Two": O=2, b=7, T=16
+        let attrs = style("# One\n\nbody\n\n## Two", configuration: config)
+
+        let h1 = font(in: attrs, at: 2)
+        #expect(h1?.fontName == headingFace)
+        #expect(h1?.pointSize == base * 2.0)
+        // The face is honored exactly: no synthetic bold on the chosen weight.
+        #expect(h1?.fontDescriptor.symbolicTraits.contains(.bold) == false)
+
+        // Per-level multipliers still apply to the custom face.
+        let h2 = font(in: attrs, at: 16)
+        #expect(h2?.fontName == headingFace)
+        #expect(h2?.pointSize == base * 1.5)
+
+        // Body text never takes the heading face (no .font range at all).
+        #expect(font(in: attrs, at: 7) == nil)
+    }
+
+    @Test("emphasis inside a custom-face heading keeps family and size, adds traits")
+    func emphasisComposesOnTheCustomHeadingFace() {
+        let config = MarkdownEditorConfiguration(headings: HeadingStyle(fontName: headingFace))
+        // "# **n*o*des**": n=4, o=6, d=8
+        let attrs = style("# **n*o*des**", configuration: config)
+        let n = font(in: attrs, at: 4)
+        let o = font(in: attrs, at: 6)
+        let d = font(in: attrs, at: 8)
+
+        #expect(n?.familyName == "Menlo")
+        #expect(o?.familyName == "Menlo")
+        #expect(d?.familyName == "Menlo")
+        #expect(n?.pointSize == base * 2.0)
+        #expect(o?.pointSize == base * 2.0)
+        #expect(d?.pointSize == base * 2.0)
+        #expect(n?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(o?.fontDescriptor.symbolicTraits.contains([.bold, .italic]) == true)
+        #expect(d?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test("an unresolvable fontName falls back to the stock heading font")
+    func unresolvableFontNameFallsBack() {
+        let config = MarkdownEditorConfiguration(
+            headings: HeadingStyle(fontName: "Not-A-Real-Font-Face")
+        )
+        let stock = font(in: style("# Title"), at: 2)
+        let fallback = font(in: style("# Title", configuration: config), at: 2)
+        #expect(fallback == stock)
+        #expect(fallback?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    // MARK: - MarkdownEditorTheme.headingText
+
+    @Test("theme.headingText colors heading text; # markers and body keep their own ink")
+    func headingTextColorsContentOnly() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# Title\n\nbody": marker=0..1, T=2, b=8
+        let attrs = style("# Title\n\nbody", configuration: config)
+
+        #expect(color(in: attrs, at: 2) == .systemPink)
+        // The `#` marker glyphs stay on headingMarker (the separate knob).
+        #expect(color(in: attrs, at: 0) == theme.headingMarker)
+        // Body text still inherits the view-level bodyText (no styled foreground).
+        #expect(color(in: attrs, at: 8) == nil)
+    }
+
+    @Test("a link inside a colored heading keeps the link ink")
+    func linkInsideColoredHeadingKeepsLinkColor() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# [x](https://e.com)": x=3
+        let attrs = style("# [x](https://e.com)", configuration: config)
+        #expect(color(in: attrs, at: 3) == theme.link)
+    }
+
+    @Test("emphasis inside a colored heading keeps the heading color")
+    func emphasisInsideColoredHeadingKeepsHeadingColor() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# **bold**": b=4 — emphasis composes fonts only, so the ink survives.
+        let attrs = style("# **bold**", configuration: config)
+        #expect(color(in: attrs, at: 4) == .systemPink)
+    }
+
+    // MARK: - Defaults stay byte-identical
+
+    @Test("nil knobs: heading content carries the stock font and no foreground")
+    func nilKnobsKeepStockHeadingAttributes() {
+        // "# Title": T=2
+        let attrs = style("# Title")
+        let heading = font(in: attrs, at: 2)
+        let stock = NSFont(name: fontName, size: base * 2.0) ?? .systemFont(ofSize: base * 2.0)
+        let stockBold = NSFont(
+            descriptor: stock.fontDescriptor.withSymbolicTraits(
+                stock.fontDescriptor.symbolicTraits.union(.bold)),
+            size: stock.pointSize
+        ) ?? stock
+        #expect(heading == stockBold)
+        // No styled range sets a heading foreground — bodyText inheritance.
+        #expect(color(in: attrs, at: 2) == nil)
+    }
+
+    @Test("explicit-nil knobs produce value-identical styling to .default")
+    func nilKnobsMatchDefaultsExactly() {
+        let doc = "# One **bold** *i*\n\nbody `code`\n\n## Two\n\n- item\n\n> quote\n"
+        let expected = style(doc)
+        let explicitNil = MarkdownEditorConfiguration(
+            theme: MarkdownEditorTheme(headingText: nil),
+            headings: HeadingStyle(fontName: nil)
+        )
+        let actual = style(doc, configuration: explicitNil)
+
+        #expect(actual.count == expected.count)
+        for (a, e) in zip(actual, expected) {
+            #expect(a.range == e.range)
+            #expect((a.attributes as NSDictionary).isEqual(to: e.attributes))
+        }
+    }
+}

--- a/Tests/MarkdownEngineTests/ListIndentGridTests.swift
+++ b/Tests/MarkdownEngineTests/ListIndentGridTests.swift
@@ -1,0 +1,182 @@
+//
+//  ListIndentGridTests.swift
+//  MarkdownEngineTests
+//
+//  The opt-in list indent grid (`ListStyle.markerTextGap`): markers on a
+//  deterministic depth × indentPerLevel grid with level 1 on the body origin,
+//  the raw source whitespace neutralized, and content hanging a fixed slot
+//  after the marker. `nil` (the default) must keep the historical geometry
+//  bit-for-bit.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("List indent grid (ListStyle.markerTextGap)")
+struct ListIndentGridTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+    private var baseFont: NSFont { NSFont.systemFont(ofSize: 16) }
+
+    private func gridConfig(gap: CGFloat = 36, indent: CGFloat = 24) -> MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(lists: ListStyle(indentPerLevel: indent, markerTextGap: gap))
+    }
+
+    private func style(_ text: String, _ config: MarkdownEditorConfiguration = .default) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base, configuration: config)
+    }
+
+    /// Effective paragraph style at `pos` (last styled range wins).
+    private func paragraphStyle(in attrs: [StyledRange], at pos: Int) -> NSParagraphStyle? {
+        var result: NSParagraphStyle?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+        }
+        return result
+    }
+
+    /// Effective kern at `pos`, if any styled range sets one.
+    private func kern(in attrs: [StyledRange], at pos: Int) -> CGFloat? {
+        var result: CGFloat?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let k = a[.kern] as? CGFloat { result = k }
+        }
+        return result
+    }
+
+    /// Effective font at `pos` (last styled range wins).
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    // MARK: - Default preserved
+
+    @Test("nil markerTextGap keeps the historical flat first-line indent and raw-whitespace nesting")
+    func nilGapKeepsLegacyGeometry() {
+        let text = "- top\n  - nested\n"
+        let attrs = style(text)
+        let perLevel = MarkdownEditorConfiguration.default.lists.indentPerLevel
+
+        let top = paragraphStyle(in: attrs, at: 0)
+        #expect(top?.firstLineHeadIndent == perLevel)
+        #expect(top?.defaultTabInterval == perLevel)
+        let markerWidth = HeadingHelpers.textWidth("- ", font: baseFont)
+        #expect(abs((top?.headIndent ?? 0) - (perLevel + markerWidth)) < 0.01)
+
+        // Nested: first line stays FLAT (raw whitespace is the visual indent),
+        // only the wrapped-line hang includes the depth.
+        let nested = paragraphStyle(in: attrs, at: 8)
+        #expect(nested?.firstLineHeadIndent == perLevel)
+        #expect(abs((nested?.headIndent ?? 0) - (perLevel + perLevel + markerWidth)) < 0.01)
+
+        // No kern correction and no whitespace collapse in legacy mode.
+        #expect(kern(in: attrs, at: 1) == nil)
+        #expect(font(in: attrs, at: 6)?.pointSize == nil || font(in: attrs, at: 6)?.pointSize == base)
+    }
+
+    // MARK: - Grid geometry
+
+    @Test("level 1 marker sits on the body origin; content hangs at the gap")
+    func levelOneOnBodyOrigin() {
+        let text = "- alpha beta\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+
+        // The final spacer char (before "alpha") is kerned so the marker→content
+        // advance lands exactly on the slot.
+        let markerWidth = HeadingHelpers.textWidth("- ", font: baseFont)
+        let k = kern(in: attrs, at: 1)
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
+    }
+
+    @Test("nesting steps by indentPerLevel and collapses the source whitespace")
+    func nestedStepsByIndentPerLevel() {
+        let text = "- top\n  - two\n    - three\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+
+        let two = paragraphStyle(in: attrs, at: ns.range(of: "- two").location)
+        #expect(two?.firstLineHeadIndent == 24)
+        #expect(abs((two?.headIndent ?? 0) - (24 + 36)) < 0.01)
+
+        let three = paragraphStyle(in: attrs, at: ns.range(of: "- three").location)
+        #expect(three?.firstLineHeadIndent == 48)
+        #expect(abs((three?.headIndent ?? 0) - (48 + 36)) < 0.01)
+
+        // The two leading spaces collapse to the hidden-marker font so the
+        // source indent stops shifting the line.
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        #expect(font(in: attrs, at: 6)?.pointSize == hidden)
+    }
+
+    @Test("tab-indented items land on the same grid; tabs advance by a sub-point interval")
+    func tabIndentedItemsUseGrid() {
+        let text = "- top\n\t- nested\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+        let nested = paragraphStyle(in: attrs, at: ns.range(of: "- nested").location)
+        #expect(nested?.firstLineHeadIndent == 24)
+        #expect(nested?.defaultTabInterval == 0.25)
+    }
+
+    @Test("ordered markers share the same slot so bullet and numbered content align")
+    func orderedMarkersShareTheSlot() {
+        let text = "1. first\n2. second\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+
+        let markerWidth = HeadingHelpers.textWidth("1. ", font: baseFont)
+        let k = kern(in: attrs, at: 2)   // the space between "1." and "first"
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
+    }
+
+    @Test("task items keep the grid geometry")
+    func taskItemsKeepGridGeometry() {
+        let text = "- [ ] task content\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+    }
+
+    @Test("a slot narrower than the marker widens just enough to keep the spacer advance positive")
+    func narrowSlotClamps() {
+        let text = "10. wide marker\n"
+        let attrs = style(text, gridConfig(gap: 4))
+        let markerWidth = HeadingHelpers.textWidth("10. ", font: baseFont)
+        let spacerWidth = HeadingHelpers.textWidth(" ", font: baseFont)
+        let expectedSlot = markerWidth - spacerWidth + 0.5
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(abs((ps?.headIndent ?? 0) - expectedSlot) < 0.01)
+        let k = kern(in: attrs, at: 3)
+        #expect(abs((k ?? 0) - (expectedSlot - markerWidth)) < 0.01)
+    }
+
+    // MARK: - Checkbox slot
+
+    @Test("the drawn checkbox left-aligns to the marker slot in grid mode and right-aligns otherwise")
+    func checkboxAlignmentPerMode() {
+        // Legacy: right-aligned to the content edge with the fixed gap.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17) == 100 - 17 - TaskCheckboxGeometry.gap)
+        // Grid: left-aligned to the slot origin.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 36) == 64)
+        // A slot narrower than the box falls back to the right-aligned position.
+        #expect(
+            TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 10)
+                == 100 - 17 - TaskCheckboxGeometry.gap
+        )
+    }
+}

--- a/Tests/MarkdownEngineTests/ListIndentGridTests.swift
+++ b/Tests/MarkdownEngineTests/ListIndentGridTests.swift
@@ -143,13 +143,42 @@ struct ListIndentGridTests {
         #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
     }
 
-    @Test("task items keep the grid geometry")
+    @Test("task items keep the grid geometry and collapse the whole `- [ ] ` marker")
     func taskItemsKeepGridGeometry() {
         let text = "- [ ] task content\n"
         let attrs = style(text, gridConfig())
         let ps = paragraphStyle(in: attrs, at: 0)
         #expect(ps?.firstLineHeadIndent == 0)
         #expect(ps?.headIndent == 36)
+
+        // The `- ` collapses too (the drawn box owns the slot, left-aligned at
+        // its origin), so the slot kern measures the collapsed marker and the
+        // content still lands on the slot edge.
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        #expect(font(in: attrs, at: 0)?.pointSize == hidden)   // "-"
+        #expect(font(in: attrs, at: 1)?.pointSize == hidden)   // " "
+        let collapsedFont = font(in: attrs, at: 0) ?? baseFont
+        let collapsedWidth = HeadingHelpers.textWidth("- ", font: collapsedFont)
+        let k = kern(in: attrs, at: 5)   // the space between "]" and "task"
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - collapsedWidth)) < 0.01)
+    }
+
+    @Test("ordered nesting steps one level per parent, not one per two source columns")
+    func orderedNestingUsesStructuralDepth() {
+        // CommonMark ordered nesting indents by the parent MARKER width — three
+        // columns here. The naive spaces/2 divisor would put "three" on level 3
+        // (72pt); the structural ladder keeps it on level 2 (48pt).
+        let text = "1. one\n   1. two\n      1. three\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+
+        let two = paragraphStyle(in: attrs, at: ns.range(of: "1. two").location)
+        #expect(two?.firstLineHeadIndent == 24)
+
+        let three = paragraphStyle(in: attrs, at: ns.range(of: "1. three").location)
+        #expect(three?.firstLineHeadIndent == 48)
+        #expect(abs((three?.headIndent ?? 0) - (48 + 36)) < 0.01)
     }
 
     @Test("a slot narrower than the marker widens just enough to keep the spacer advance positive")
@@ -169,14 +198,11 @@ struct ListIndentGridTests {
 
     @Test("the drawn checkbox left-aligns to the marker slot in grid mode and right-aligns otherwise")
     func checkboxAlignmentPerMode() {
-        // Legacy: right-aligned to the content edge with the fixed gap.
+        // Legacy: the hidden `[ ] ` sits at the content edge (the `- ` keeps
+        // full advance), so the square right-aligns to it with the fixed gap.
         #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17) == 100 - 17 - TaskCheckboxGeometry.gap)
-        // Grid: left-aligned to the slot origin.
-        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 36) == 64)
-        // A slot narrower than the box falls back to the right-aligned position.
-        #expect(
-            TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 10)
-                == 100 - 17 - TaskCheckboxGeometry.gap
-        )
+        // Grid: the whole `- [ ] ` collapses, so the box range's own position
+        // IS the marker-slot origin — the square draws right there.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 24, size: 17, markerTextGap: 36) == 24)
     }
 }


### PR DESCRIPTION
## Motivation

List geometry today is source-driven: every first line starts at a flat `indentPerLevel`, nesting shows only as the advance of the raw leading spaces/tabs (≈8pt for two spaces), and the marker→content gap is whatever `- ` happens to measure. Design systems that specify an indent grid (e.g. "each level steps 24pt, content hangs 36pt after the marker") can't be expressed.

## What's added

`ListStyle.markerTextGap: CGFloat?` — `nil` (the default) keeps the historical geometry exactly. When set, list layout becomes a deterministic grid:

- a level-`n` item's marker starts at `n × indentPerLevel` from the text origin (level 1 aligns with body text),
- leading source whitespace collapses via the hidden-marker font (tabs advance by a sub-point interval), so raw whitespace stops being the visual indent,
- content starts `markerTextGap` after the marker for every marker kind — bullet, any digit count, task box (which left-aligns to the slot origin) — via a kern on the final spacer character, so wrapped-line `headIndent` math and caret clamping keep working on real text advances,
- wrapped lines hang at the content edge (`depth × indentPerLevel + markerTextGap`).

A slot narrower than the marker itself widens just enough to keep the spacer's advance positive.

## Tests

`Tests/MarkdownEngineTests/ListIndentGridTests.swift` (8 tests): legacy geometry byte-identical when `nil`; grid first-line/hanging indents for levels 1–3; tab-indented items; ordered markers; task items and checkbox slot alignment; narrow-slot clamping.

`swift build` / `swift test` green locally (the two `ScrollingHeaderController` animation-timing failures are pre-existing/environmental).

## Notes

Stacks on #121 (branched from `feature/heading-font-and-color`; the diff over #121 is this feature only).

**Update (follow-up commit):** rendering against a real document surfaced two grid defects, fixed in the second commit:
- grid depth now comes from the item's STRUCTURAL position in the run's indent ladder (seeded across scoped-restyle windows like the ordered display numbers) instead of a spaces/2 divisor, so CommonMark ordered nesting (3+ columns per level) steps exactly one level per parent;
- a hidden task in the grid collapses its whole `- [ ] ` prefix so the drawn checkbox left-aligns at the marker-slot origin (previously it was offset from the box chars, which sit after the full-advance `- `, pushing the square to negative x where the container clipped it).

Legacy (`nil`) geometry remains untouched; tests updated/extended (structural-depth ladder, collapsed task marker, box left-alignment).

Made with [Cursor](https://cursor.com)
