### PR TITLE
Fix: caret-follow in .scrolls mode (TextKit 2); optional smooth follow animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Code-block CARD rendering (opt-in): `CodeBlockStyle.cornerRadius` draws a
+  fenced block as one continuous rounded card spanning the whole block —
+  wrapped lines included — instead of square per-paragraph fills, and
+  `CodeBlockStyle.cardVerticalPadding` pins the hidden fence lines' height so
+  they read as the card's interior padding (fences revert to their natural
+  height while the caret reveals them). Selection stays visible above the
+  card. `nil` (the default) keeps the historical rendering exactly.
+- Inline-code CHIP rendering (opt-in): `InlineCodeStyle.chipCornerRadius`
+  draws a small rounded background hugging each inline `code` span (per
+  wrapped line) with `chipHorizontalPadding` of breathing room, replacing the
+  square glyph-run fill. `MarkdownEditorTheme.inlineCodeBackground` colors the
+  chip (nil = `codeBackground`, then the syntax-highlighter background).
 - Code typography and background knobs: `CodeBlockStyle.fontName` and
   `InlineCodeStyle.fontName` swap the code face (nil = the
   syntax-highlighter service's font, as before; inline follows the block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Caret x on marker-only list lines in the indent grid: a fresh Enter
+  continuation (`- `, `1. `, `- [ ] ` with no content yet) placed the
+  insertion point at the raw collapsed-marker advance (the line's left
+  edge) because Core Text drops the content-offset kern when the spacer is
+  the line's last glyph. The insertion indicator now snaps to the
+  paragraph's content origin — exactly where the first typed character
+  lands — for every marker kind. Legacy (nil `markerTextGap`) geometry is
+  untouched.
+
 ### Added
 - `ListStyle.markerSlotWidth` (opt-in, on top of the indent grid): every list
   marker occupies an invisible fixed-width column at its depth indent — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Code typography and background knobs: `CodeBlockStyle.fontName` and
+  `InlineCodeStyle.fontName` swap the code face (nil = the
+  syntax-highlighter service's font, as before; inline follows the block
+  face unless set independently), and `MarkdownEditorTheme.codeBackground`
+  replaces the background behind fenced blocks and inline spans (nil = the
+  service's background, as before).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TaskCheckboxRenderer` service (`MarkdownEditorServices.taskCheckboxes`):
+  embedders can supply the image drawn for task-list checkboxes — for example
+  a design-system box — while the engine keeps ownership of the box's
+  geometry, invalidation, and click hit-testing. The default
+  `SystemTaskCheckboxRenderer` defers to the stock SF-symbol rendering, so
+  behavior is unchanged unless a renderer is injected.
 - Checked-task treatment knobs: `TaskCheckboxStyle.strikethroughCompletedTasks`
   gates the completed label's strikethrough (default on, as before),
   `MarkdownEditorTheme.completedTaskText` colors the completed label (nil =

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TableStyle.verticalRules` (default `true`) controls interior column
+  separators in rendered tables. When `false`, only the outer border and the
+  horizontal rules between rows (including the header/body rule) draw, with
+  the horizontal rules spanning the full inner width; column sizing and cell
+  padding are unchanged. The knob participates in the table image cache key.
 - `TableStyle.cornerRadius` rounds the rendered table wrapper's corners:
   interior painting (header fill, separator rules) clips to the rounded
   shape and the outer border rule strokes along the rounded path, staying
@@ -25,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bodyText` — the `#` glyphs stay on `headingMarker`, and inline constructs
   inside a heading keep their own ink (both opt-in; the defaults are
   unchanged).
+
+### Fixed
+- Interior table rules stroke in the themed rule color again. The rounded
+  wrapper change moved the outer border's `setStroke` below the separator
+  pass, which left interior rules on the drawing context's default black
+  instead of `MarkdownEditorTheme.tableRule`.
 
 ## [0.11.0] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Ordered-marker lettering per depth: `ListStyle.orderedMarkerStyles` renders
+  nested ordered markers as letters or roman numerals (`[.numeric,
+  .lowerAlpha, .lowerRoman]` → `1.` / `a.` / `i.`, cycling below that). Only
+  the painted overlay changes — the source digits stay valid CommonMark. The
+  default (a single `.numeric`) keeps every level numeric as before.
+- `MarkdownEditorTheme.listMarker` colors the painted bullet `•` and ordered
+  markers independently of `bodyText` (`nil`, the default, keeps body ink).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Custom heading typeface and color: `HeadingStyle.fontName` renders headings
+  in a specific PostScript face (honored exactly, so the chosen weight is
+  respected; an unresolvable name falls back to the stock bold base font),
+  and `MarkdownEditorTheme.headingText` colors heading text independently of
+  `bodyText` — the `#` glyphs stay on `headingMarker`, and inline constructs
+  inside a heading keep their own ink (both opt-in; the defaults are
+  unchanged).
+
 ## [0.11.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Opt-in list indent grid: `ListStyle.markerTextGap` puts list markers on a
+  deterministic `depth × indentPerLevel` grid (level 1 aligned with the body
+  origin), neutralizes the raw source whitespace as the visual indent, and
+  hangs content a fixed slot after the marker for every marker kind (bullet,
+  any digit count, task box — which left-aligns to the slot origin). Wrapped
+  lines hang at the content edge. `nil` (the default) keeps the historical
+  geometry exactly.
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Caret-follow in `.scrolls` mode now works for every editor, not only the
+  reading column. AppKit's native `scrollRangeToVisible` routes through the
+  absent TextKit 1 layout manager in a TextKit 2 text view and silently
+  no-ops for off-screen content, so typing at the bottom of a small viewport
+  never scrolled the caret into view. The manual TextKit-2 fragment reveal
+  (previously gated on `readingWidth`) now serves all `.scrolls` editors,
+  with the reveal target clamped to the scrollable content before moving.
 - Interior table rules stroke in the themed rule color again. The rounded
   wrapper change moved the outer border's `setStroke` below the separator
   pass, which left interior rules on the drawing context's default black
@@ -35,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the editor's window isn't key.
 
 ### Added
+- `MarkdownEditorConfiguration.caretFollowAnimationDuration` (default `0` =
+  the historical instant jump): a short ease-out animation for the
+  caret-follow scroll in `.scrolls` mode, with no bounce. Ignored in
+  `.fitsContent`, where the enclosing page scroller owns the reveal.
 - `TableStyle.verticalRules` (default `true`) controls interior column
   separators in rendered tables. When `false`, only the outer border and the
   horizontal rules between rows (including the header/body rule) draw, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Heading metric knobs: `HeadingStyle.lineHeights` pins fixed per-level line
+  heights (empty = derived from the resolved heading font's metrics, as
+  before) and `HeadingStyle.paragraphSpacing` sets the below-heading gap
+  independently (nil = the editor's base paragraph spacing, as before).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The theme's `link` color now reaches the screen. `NSTextView` layers its
+  `linkTextAttributes` over every `.link` range at display time, and AppKit's
+  default paints them `.linkColor` blue — silently overriding the foreground
+  the styler set. The editor now derives `linkTextAttributes` from the theme
+  (link ink + underline + pointing hand), so custom palettes color links as
+  configured; the default theme renders exactly as before.
+
 ### Added
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Checked-task treatment knobs: `TaskCheckboxStyle.strikethroughCompletedTasks`
+  gates the completed label's strikethrough (default on, as before),
+  `MarkdownEditorTheme.completedTaskText` colors the completed label (nil =
+  body ink; inline constructs keep their own colors), and
+  `MarkdownEditorTheme.taskCheckboxChecked` / `taskCheckboxUnchecked` tint the
+  drawn checkbox symbols (nil = the historical `bodyText` / `mutedText`).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Blockquote styling knobs: `BlockquoteStyle.barWidth` / `textIndent` expose
+  the previously hard-coded bar width and per-level indent (defaults 3/18 as
+  before), `MarkdownEditorTheme.blockquoteBar` colors the painted bar (nil =
+  the historical half-transparent muted ink), and
+  `MarkdownEditorTheme.blockquoteText` lifts the historical content muting
+  (nil = muted, as before; revealed `>` markers stay muted either way).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- The drawn task checkbox now shows the pointing-hand cursor on hover in
+  edit mode (it toggles on click, so it reads as a button, like links) —
+  previously the plain arrow. An app-active tracking area also keeps hover
+  cursors (the checkbox hand, the read-only link hand) responsive while
+  the editor's window isn't key.
+
 ### Added
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Inline-formatting keyboard shortcuts: ⌘B (bold), ⌘I (italic), ⌘E
+  (inline code), and ⌘⇧K (link scaffold) drive the same toggleable
+  wrap/unwrap actions the context menu exposes. Gated by
+  `MarkdownEditorConfiguration.formattingShortcutsEnabled` (default on,
+  like the list helpers). Plain ⌘K is never consumed — it is a common
+  embedder binding (command palettes).
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Table theming slots: `MarkdownEditorTheme.tableHeaderBackground` fills the
+  rendered header row (nil = the historical mutedText at 8% alpha) and
+  `MarkdownEditorTheme.tableRule` strokes the outer border and internal
+  rules (nil = mutedText at 50% alpha). Both participate in the table image
+  cache key.
 - Custom heading typeface and color: `HeadingStyle.fontName` renders headings
   in a specific PostScript face (honored exactly, so the chosen weight is
   respected; an unresolvable name falls back to the stock bold base font),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `TableStyle.cornerRadius` rounds the rendered table wrapper's corners:
+  interior painting (header fill, separator rules) clips to the rounded
+  shape and the outer border rule strokes along the rounded path, staying
+  crisp at the corners. `0` (the default) keeps the historical
+  square-cornered rendering exactly.
 - Table theming slots: `MarkdownEditorTheme.tableHeaderBackground` fills the
   rendered header row (nil = the historical mutedText at 8% alpha) and
   `MarkdownEditorTheme.tableRule` strokes the outer border and internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `ListStyle.markerSlotWidth` (opt-in, on top of the indent grid): every list
+  marker occupies an invisible fixed-width column at its depth indent — the
+  painted bullet and ordered marker center horizontally in the column (ordered
+  markers always paint in this mode), the drawn task checkbox fills it exactly
+  — and item content hangs `markerSlotWidth + markerTextGap` after the marker
+  origin, so checkbox, bullet, and number items share one alignment grid.
+  `nil` (the default) keeps the gap-only grid geometry exactly.
 - Ordered-marker lettering per depth: `ListStyle.orderedMarkerStyles` renders
   nested ordered markers as letters or roman numerals (`[.numeric,
   .lowerAlpha, .lowerRoman]` → `1.` / `a.` / `i.`, cycling below that). Only

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -491,8 +491,16 @@ public struct TableStyle: Sendable {
     /// historical square-cornered rendering exactly.
     public var cornerRadius: CGFloat
 
-    public init(cornerRadius: CGFloat = 0) {
+    /// Whether interior vertical column separators are drawn. `true` (the
+    /// default) keeps the historical full-grid look. When `false`, only the
+    /// outer border and the horizontal rules between rows (including the
+    /// header/body rule) are painted; the horizontal rules span the full
+    /// inner width, and column sizing and cell padding are unchanged.
+    public var verticalRules: Bool
+
+    public init(cornerRadius: CGFloat = 0, verticalRules: Bool = true) {
         self.cornerRadius = max(0, cornerRadius)
+        self.verticalRules = verticalRules
     }
 
     public static let `default` = TableStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -299,19 +299,48 @@ public struct ListStyle: Sendable {
     public var maximumNestingLevel: Int
     /// Extra line height added on top of the default to give list items room.
     public var extraLineHeight: CGFloat
+    /// Width (in points) of the marker slot — from the marker glyph's left
+    /// edge to the item content's left edge. Setting it opts the list layout
+    /// into a fixed indent GRID; `nil` (the default) keeps the historical
+    /// geometry exactly.
+    ///
+    /// Historically the visual indent is the raw source whitespace: every
+    /// first line starts at a flat `indentPerLevel`, nesting shows only as
+    /// the advance of the leading spaces/tabs (≈8pt for two spaces — far off
+    /// any design grid), and the marker→content gap is whatever `- ` happens
+    /// to measure.
+    ///
+    /// With a gap set, geometry becomes deterministic:
+    /// - a level-`n` item's marker starts at `n × indentPerLevel` from the
+    ///   text origin (level 1 aligns with body text),
+    /// - the leading source whitespace collapses (hidden-marker font; tabs
+    ///   advance by a sub-point interval) so it no longer shifts the line,
+    /// - content starts `markerTextGap` after the marker for every marker
+    ///   kind (bullet, any digit count, task box), via a kern on the final
+    ///   spacer character — so wrapped lines and the caret keep working on
+    ///   real text advances,
+    /// - wrapped lines hang at the content edge (`depth × indentPerLevel +
+    ///   markerTextGap`).
+    ///
+    /// A slot narrower than the marker itself widens just enough to keep the
+    /// spacer's advance positive. Note that in grid mode literal tabs inside
+    /// item CONTENT also advance by the sub-point interval.
+    public var markerTextGap: CGFloat?
 
     public init(
         helpersEnabled: Bool = true,
         autoClosePairsEnabled: Bool = true,
         indentPerLevel: CGFloat = 27.5,
         maximumNestingLevel: Int = 3,
-        extraLineHeight: CGFloat = 2
+        extraLineHeight: CGFloat = 2,
+        markerTextGap: CGFloat? = nil
     ) {
         self.helpersEnabled = helpersEnabled
         self.autoClosePairsEnabled = autoClosePairsEnabled
         self.indentPerLevel = indentPerLevel
         self.maximumNestingLevel = maximumNestingLevel
         self.extraLineHeight = extraLineHeight
+        self.markerTextGap = markerTextGap
     }
 
     public static let `default` = ListStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -366,15 +366,27 @@ public struct HeadingStyle: Sendable {
     public var fontMultipliers: [CGFloat]
     /// Top spacing in `em` units per heading level (1...6).
     public var topSpacingEm: [CGFloat]
+    /// Fixed line heights (points) per heading level (1...6). Empty (the
+    /// default) keeps the historical behavior of deriving the line height
+    /// from the resolved heading font's metrics. Levels beyond the array's
+    /// count reuse its last entry, mirroring `fontMultipliers`.
+    public var lineHeights: [CGFloat]
+    /// Spacing (points) below a heading. `nil` (the default) keeps the
+    /// historical behavior of using the editor's base paragraph spacing.
+    public var paragraphSpacing: CGFloat?
 
     public init(
         fontName: String? = nil,
         fontMultipliers: [CGFloat] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67],
-        topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10]
+        topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10],
+        lineHeights: [CGFloat] = [],
+        paragraphSpacing: CGFloat? = nil
     ) {
         self.fontName = fontName
         self.fontMultipliers = fontMultipliers
         self.topSpacingEm = topSpacingEm
+        self.lineHeights = lineHeights
+        self.paragraphSpacing = paragraphSpacing
     }
 
     public func fontMultiplier(for level: Int) -> CGFloat {
@@ -385,6 +397,14 @@ public struct HeadingStyle: Sendable {
     public func topSpacingEm(for level: Int) -> CGFloat {
         let index = max(1, min(level, topSpacingEm.count)) - 1
         return topSpacingEm[index]
+    }
+
+    /// Fixed line height for `level`, or `nil` when the level should fall
+    /// back to font-metric derivation (i.e. `lineHeights` is empty).
+    public func lineHeight(for level: Int) -> CGFloat? {
+        guard !lineHeights.isEmpty else { return nil }
+        let index = max(1, min(level, lineHeights.count)) - 1
+        return lineHeights[index]
     }
 
     public static let `default` = HeadingStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -260,17 +260,35 @@ public struct CodeBlockStyle: Sendable {
     public var paragraphSpacing: CGFloat
     /// Left/right indent (in points) so code blocks don't run into the gutter.
     public var horizontalIndent: CGFloat
+    /// Corner radius of the code-block CARD. Setting it opts the block into
+    /// card rendering: one continuous rounded background spanning the whole
+    /// fenced block (wrapped lines included), with the corners rounded on the
+    /// block's first and last lines only. `nil` (the default) keeps the
+    /// historical rendering — a square per-paragraph fill from the
+    /// `.backgroundColor` attribute.
+    public var cornerRadius: CGFloat?
+    /// Interior vertical padding of the card: the hidden fence lines' pinned
+    /// line height, i.e. the space between the card's edge and the first/last
+    /// code line. Only takes effect in card mode while the fences are hidden;
+    /// while the caret reveals the fences they keep their natural code line
+    /// height so editing them stays comfortable. `nil` (the default) keeps
+    /// the fences' natural height.
+    public var cardVerticalPadding: CGFloat?
 
     public init(
         fontName: String? = nil,
         fontSizeScale: CGFloat = 0.85,
         paragraphSpacing: CGFloat = 2.0,
-        horizontalIndent: CGFloat = 12.0
+        horizontalIndent: CGFloat = 12.0,
+        cornerRadius: CGFloat? = nil,
+        cardVerticalPadding: CGFloat? = nil
     ) {
         self.fontName = fontName
         self.fontSizeScale = fontSizeScale
         self.paragraphSpacing = paragraphSpacing
         self.horizontalIndent = horizontalIndent
+        self.cornerRadius = cornerRadius
+        self.cardVerticalPadding = cardVerticalPadding
     }
 
     public static let `default` = CodeBlockStyle()
@@ -287,10 +305,27 @@ public struct InlineCodeStyle: Sendable {
     /// the code-block font. A name that doesn't resolve degrades the same
     /// way.
     public var fontName: String?
+    /// Corner radius of the inline-code CHIP. Setting it opts inline `code`
+    /// spans into chip rendering: a small rounded background drawn behind the
+    /// span (per wrapped line) with `chipHorizontalPadding` of breathing room
+    /// on each side, hugging the code text's own height instead of the whole
+    /// line box. `nil` (the default) keeps the historical rendering — a
+    /// square glyph-run fill from the `.backgroundColor` attribute.
+    public var chipCornerRadius: CGFloat?
+    /// Horizontal padding (in points) the chip extends beyond the span's
+    /// first and last glyph. Only read in chip mode.
+    public var chipHorizontalPadding: CGFloat
 
-    public init(fontSizeScale: CGFloat = 0.85, fontName: String? = nil) {
+    public init(
+        fontSizeScale: CGFloat = 0.85,
+        fontName: String? = nil,
+        chipCornerRadius: CGFloat? = nil,
+        chipHorizontalPadding: CGFloat = 3.0
+    ) {
         self.fontSizeScale = fontSizeScale
         self.fontName = fontName
+        self.chipCornerRadius = chipCornerRadius
+        self.chipHorizontalPadding = chipHorizontalPadding
     }
 
     public static let `default` = InlineCodeStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -32,6 +32,7 @@ public struct MarkdownEditorConfiguration: Sendable {
     public var codeBlock: CodeBlockStyle
     public var inlineCode: InlineCodeStyle
     public var lists: ListStyle
+    public var table: TableStyle
     public var taskCheckbox: TaskCheckboxStyle
     public var headings: HeadingStyle
     public var imageEmbed: ImageEmbedStyle
@@ -92,6 +93,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         codeBlock: CodeBlockStyle = .default,
         inlineCode: InlineCodeStyle = .default,
         lists: ListStyle = .default,
+        table: TableStyle = .default,
         taskCheckbox: TaskCheckboxStyle = .default,
         headings: HeadingStyle = .default,
         imageEmbed: ImageEmbedStyle = .default,
@@ -118,6 +120,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.codeBlock = codeBlock
         self.inlineCode = inlineCode
         self.lists = lists
+        self.table = table
         self.taskCheckbox = taskCheckbox
         self.headings = headings
         self.imageEmbed = imageEmbed
@@ -475,6 +478,24 @@ public struct BlockquoteStyle: Sendable {
     }
 
     public static let `default` = BlockquoteStyle()
+}
+
+// MARK: - Tables
+
+/// GFM table wrapper rendering knobs.
+public struct TableStyle: Sendable {
+    /// Corner radius of the rendered table's outer wrapper. The interior
+    /// painting (header fill, separator rules) is clipped to the rounded
+    /// shape and the outer border rule is stroked along the rounded path,
+    /// so the rules stay crisp at the corners. `0` (the default) keeps the
+    /// historical square-cornered rendering exactly.
+    public var cornerRadius: CGFloat
+
+    public init(cornerRadius: CGFloat = 0) {
+        self.cornerRadius = max(0, cornerRadius)
+    }
+
+    public static let `default` = TableStyle()
 }
 
 // MARK: - Links

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -285,6 +285,64 @@ public struct InlineCodeStyle: Sendable {
 
 // MARK: - Lists
 
+/// How an ordered item's computed position is rendered in its painted marker.
+///
+/// Only the painted overlay changes; the source digits are untouched, so the
+/// file stays valid CommonMark whatever it says (mirroring how display
+/// numbering already works).
+public enum OrderedMarkerStyle: Sendable, Equatable {
+    /// `1.` `2.` `3.` — the historical rendering.
+    case numeric
+    /// `a.` `b.` … `z.` `aa.` (spreadsheet-style bijective base-26).
+    case lowerAlpha
+    /// `A.` `B.` … `Z.` `AA.`
+    case upperAlpha
+    /// `i.` `ii.` `iii.` `iv.` …
+    case lowerRoman
+    /// `I.` `II.` `III.` `IV.` …
+    case upperRoman
+
+    /// The marker label (without punctuation) for the 1-based `number`.
+    /// Zero/negative positions cannot come out of display numbering, but a
+    /// literal `0.` in the source falls back to the digits themselves.
+    public func label(for number: Int) -> String {
+        guard number > 0 else { return "\(number)" }
+        switch self {
+        case .numeric: return "\(number)"
+        case .lowerAlpha: return Self.alphaLabel(number)
+        case .upperAlpha: return Self.alphaLabel(number).uppercased()
+        case .lowerRoman: return Self.romanLabel(number)
+        case .upperRoman: return Self.romanLabel(number).uppercased()
+        }
+    }
+
+    /// Bijective base-26: 1 → a … 26 → z, 27 → aa, 28 → ab.
+    private static func alphaLabel(_ number: Int) -> String {
+        var n = number
+        var label = ""
+        while n > 0 {
+            n -= 1
+            label = String(UnicodeScalar(UInt8(97 + n % 26))) + label
+            n /= 26
+        }
+        return label
+    }
+
+    private static func romanLabel(_ number: Int) -> String {
+        let values = [1000, 900, 500, 400, 100, 90, 50, 40, 10, 9, 5, 4, 1]
+        let numerals = ["m", "cm", "d", "cd", "c", "xc", "l", "xl", "x", "ix", "v", "iv", "i"]
+        var n = number
+        var label = ""
+        for (value, numeral) in zip(values, numerals) {
+            while n >= value {
+                label += numeral
+                n -= value
+            }
+        }
+        return label
+    }
+}
+
 /// Behavior toggles and metrics for ordered / unordered list editing.
 public struct ListStyle: Sendable {
     /// Master switch for list-related editing helpers (auto-continue,
@@ -299,19 +357,34 @@ public struct ListStyle: Sendable {
     public var maximumNestingLevel: Int
     /// Extra line height added on top of the default to give list items room.
     public var extraLineHeight: CGFloat
+    /// Marker rendering style per nesting depth for ordered items. Depth 0
+    /// (top level) uses the first entry and deeper levels CYCLE through the
+    /// array, so `[.numeric, .lowerAlpha, .lowerRoman]` renders `1.` / `a.` /
+    /// `i.` and starts over one level further down. The default — a single
+    /// `.numeric` — keeps every level numeric, the historical rendering.
+    public var orderedMarkerStyles: [OrderedMarkerStyle]
 
     public init(
         helpersEnabled: Bool = true,
         autoClosePairsEnabled: Bool = true,
         indentPerLevel: CGFloat = 27.5,
         maximumNestingLevel: Int = 3,
-        extraLineHeight: CGFloat = 2
+        extraLineHeight: CGFloat = 2,
+        orderedMarkerStyles: [OrderedMarkerStyle] = [.numeric]
     ) {
         self.helpersEnabled = helpersEnabled
         self.autoClosePairsEnabled = autoClosePairsEnabled
         self.indentPerLevel = indentPerLevel
         self.maximumNestingLevel = maximumNestingLevel
         self.extraLineHeight = extraLineHeight
+        self.orderedMarkerStyles = orderedMarkerStyles
+    }
+
+    /// The ordered-marker style for a 0-based nesting `depth`, cycling
+    /// through ``orderedMarkerStyles`` (an empty array reads as `.numeric`).
+    public func orderedMarkerStyle(forDepth depth: Int) -> OrderedMarkerStyle {
+        guard !orderedMarkerStyles.isEmpty else { return .numeric }
+        return orderedMarkerStyles[max(0, depth) % orderedMarkerStyles.count]
     }
 
     public static let `default` = ListStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -349,15 +349,30 @@ public struct TaskCheckboxStyle: Sendable {
 /// Per-level heading metrics. Defaults follow the historical Nodes ratios,
 /// which are loosely based on browser default heading sizes.
 public struct HeadingStyle: Sendable {
+    /// PostScript name of the typeface used for heading text, for example
+    /// `"AvenirNext-DemiBold"`. `nil` (the default) keeps the historical
+    /// behavior: headings render in the editor's base font with the bold
+    /// trait added.
+    ///
+    /// The name is honored exactly, so the chosen face's weight and style
+    /// are respected — pick a `-Bold` / `-Semibold` face for heavier
+    /// headings. Emphasis inside a heading still composes on top of it:
+    /// bold / italic add their traits while the family and the per-level
+    /// size are kept. A name that doesn't resolve falls back to the default
+    /// heading font at draw time, so a typo degrades to the stock look
+    /// instead of changing metrics.
+    public var fontName: String?
     /// Font-size multiplier per heading level (1...6).
     public var fontMultipliers: [CGFloat]
     /// Top spacing in `em` units per heading level (1...6).
     public var topSpacingEm: [CGFloat]
 
     public init(
+        fontName: String? = nil,
         fontMultipliers: [CGFloat] = [2.0, 1.5, 1.17, 1.0, 0.83, 0.67],
         topSpacingEm: [CGFloat] = [0.35, 0.30, 0.25, 0.20, 0.15, 0.10]
     ) {
+        self.fontName = fontName
         self.fontMultipliers = fontMultipliers
         self.topSpacingEm = topSpacingEm
     }

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -91,6 +91,12 @@ public struct MarkdownEditorConfiguration: Sendable {
     /// helpers; turn off when the embedder owns these keys. Plain ⌘K is
     /// never consumed — it is a common embedder binding (command palettes).
     public var formattingShortcutsEnabled: Bool
+    /// Duration of the caret-follow scroll in `.scrolls` mode, when typing or
+    /// caret movement pushes the caret out of the viewport. `0` (the default)
+    /// keeps the historical instant jump; a short duration (0.1–0.2s) gives a
+    /// smooth ease-out follow with no bounce. Ignored in `.fitsContent`
+    /// (the enclosing page scroller owns the reveal there).
+    public var caretFollowAnimationDuration: CGFloat
 
     public init(
         theme: MarkdownEditorTheme = .default,
@@ -119,7 +125,8 @@ public struct MarkdownEditorConfiguration: Sendable {
         rawSourceMode: Bool = false,
         extensions: [any MarkdownExtension] = [],
         cursorFollowsSpanInk: Bool = false,
-        formattingShortcutsEnabled: Bool = true
+        formattingShortcutsEnabled: Bool = true,
+        caretFollowAnimationDuration: CGFloat = 0
     ) {
         self.theme = theme
         self.services = services
@@ -148,6 +155,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.extensions = extensions
         self.cursorFollowsSpanInk = cursorFollowsSpanInk
         self.formattingShortcutsEnabled = formattingShortcutsEnabled
+        self.caretFollowAnimationDuration = max(0, caretFollowAnimationDuration)
     }
 
     public static let `default` = MarkdownEditorConfiguration()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -460,7 +460,7 @@ public struct InlineLatexStyle: Sendable {
 
 // MARK: - Blockquote
 
-/// Extra line height added to blockquote lines.
+/// Metrics for blockquote lines.
 ///
 /// By default blockquote lines use the font's natural line height with no
 /// extra spacing. Set `extraLineHeight` to add breathing room, matching
@@ -469,9 +469,23 @@ public struct InlineLatexStyle: Sendable {
 public struct BlockquoteStyle: Sendable {
     /// Extra height (points) added to the default line height for blockquote lines.
     public var extraLineHeight: CGFloat
+    /// Width (points) of each painted vertical quote bar.
+    public var barWidth: CGFloat
+    /// Horizontal space (points) each blockquote nesting level occupies.
+    /// A level-`n` quote's text hangs at `n × textIndent + textIndent / 2`
+    /// and the level-`i` bar paints `textIndent / 4` into its slot — the
+    /// historical geometry, now tunable. The defaults (3pt bar, 18pt
+    /// indent) reproduce the previous hard-coded constants exactly.
+    public var textIndent: CGFloat
 
-    public init(extraLineHeight: CGFloat = 0) {
+    public init(
+        extraLineHeight: CGFloat = 0,
+        barWidth: CGFloat = 3,
+        textIndent: CGFloat = 18
+    ) {
         self.extraLineHeight = extraLineHeight
+        self.barWidth = barWidth
+        self.textIndent = textIndent
     }
 
     public static let `default` = BlockquoteStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -390,6 +390,22 @@ public struct ListStyle: Sendable {
     /// spacer's advance positive. Note that in grid mode literal tabs inside
     /// item CONTENT also advance by the sub-point interval.
     public var markerTextGap: CGFloat?
+    /// Width (in points) of a fixed marker COLUMN on the indent grid, shared
+    /// by every marker kind. Only takes effect together with
+    /// ``markerTextGap``; `nil` (the default) keeps the gap-only grid
+    /// geometry exactly.
+    ///
+    /// With a slot width set, every list marker occupies an invisible
+    /// fixed-width column starting at the item's depth indent:
+    /// - the painted bullet `•` and the painted ordered marker are CENTERED
+    ///   horizontally in the column (ordered markers always paint in this
+    ///   mode so the source digits' natural left alignment can't leak),
+    /// - the drawn task checkbox fills the column exactly (its square's side
+    ///   becomes `markerSlotWidth`),
+    /// - item content starts `markerSlotWidth + markerTextGap` after the
+    ///   marker origin, so checkbox, bullet, and number items share one
+    ///   alignment grid.
+    public var markerSlotWidth: CGFloat?
 
     public init(
         helpersEnabled: Bool = true,
@@ -398,7 +414,8 @@ public struct ListStyle: Sendable {
         maximumNestingLevel: Int = 3,
         extraLineHeight: CGFloat = 2,
         orderedMarkerStyles: [OrderedMarkerStyle] = [.numeric],
-        markerTextGap: CGFloat? = nil
+        markerTextGap: CGFloat? = nil,
+        markerSlotWidth: CGFloat? = nil
     ) {
         self.helpersEnabled = helpersEnabled
         self.autoClosePairsEnabled = autoClosePairsEnabled
@@ -407,6 +424,14 @@ public struct ListStyle: Sendable {
         self.extraLineHeight = extraLineHeight
         self.orderedMarkerStyles = orderedMarkerStyles
         self.markerTextGap = markerTextGap
+        self.markerSlotWidth = markerSlotWidth
+    }
+
+    /// The marker-column width actually in effect: ``markerSlotWidth`` gated
+    /// on grid mode (``markerTextGap`` set), since the slot is defined on the
+    /// grid's geometry only.
+    public var effectiveMarkerSlotWidth: CGFloat? {
+        markerTextGap != nil ? markerSlotWidth : nil
     }
 
     /// The ordered-marker style for a 0-based nesting `depth`, cycling

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -84,6 +84,12 @@ public struct MarkdownEditorConfiguration: Sendable {
     /// so this stays the embedder's explicit decision rather than something the
     /// engine infers from a color it happens to see.
     public var cursorFollowsSpanInk: Bool
+    /// Inline-formatting key equivalents (⌘B bold, ⌘I italic, ⌘E inline
+    /// code, ⌘⇧K link scaffold), driving the same toggleable wrap/unwrap
+    /// actions the context menu exposes. On by default, like the list
+    /// helpers; turn off when the embedder owns these keys. Plain ⌘K is
+    /// never consumed — it is a common embedder binding (command palettes).
+    public var formattingShortcutsEnabled: Bool
 
     public init(
         theme: MarkdownEditorTheme = .default,
@@ -110,7 +116,8 @@ public struct MarkdownEditorConfiguration: Sendable {
         heightBehavior: HeightBehavior = .scrolls,
         rawSourceMode: Bool = false,
         extensions: [any MarkdownExtension] = [],
-        cursorFollowsSpanInk: Bool = false
+        cursorFollowsSpanInk: Bool = false,
+        formattingShortcutsEnabled: Bool = true
     ) {
         self.theme = theme
         self.services = services
@@ -137,6 +144,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.rawSourceMode = rawSourceMode
         self.extensions = extensions
         self.cursorFollowsSpanInk = cursorFollowsSpanInk
+        self.formattingShortcutsEnabled = formattingShortcutsEnabled
     }
 
     public static let `default` = MarkdownEditorConfiguration()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -325,20 +325,28 @@ public struct ListStyle: Sendable {
 /// example `"circle"` / `"checkmark.circle.fill"`. A name that doesn't
 /// resolve falls back to the corresponding default symbol at draw time, so a
 /// typo degrades to the stock look instead of drawing nothing. Tint colors
-/// stay theme-driven (`MarkdownEditorTheme/mutedText` unchecked,
-/// `MarkdownEditorTheme/bodyText` checked).
+/// are theme-driven: ``MarkdownEditorTheme/taskCheckboxUnchecked`` /
+/// ``MarkdownEditorTheme/taskCheckboxChecked``, which default to
+/// `mutedText` unchecked and `bodyText` checked.
 public struct TaskCheckboxStyle: Sendable {
     /// SF Symbol drawn for an unchecked task item (`[ ]`).
     public var uncheckedSymbolName: String
     /// SF Symbol drawn for a checked task item (`[x]`).
     public var checkedSymbolName: String
+    /// Whether a checked item's label is struck through. `true` (the
+    /// default) keeps the historical rendering. Designs that mark completion
+    /// by ink alone can turn this off and set
+    /// ``MarkdownEditorTheme/completedTaskText`` instead.
+    public var strikethroughCompletedTasks: Bool
 
     public init(
         uncheckedSymbolName: String = "square",
-        checkedSymbolName: String = "checkmark.square.fill"
+        checkedSymbolName: String = "checkmark.square.fill",
+        strikethroughCompletedTasks: Bool = true
     ) {
         self.uncheckedSymbolName = uncheckedSymbolName
         self.checkedSymbolName = checkedSymbolName
+        self.strikethroughCompletedTasks = strikethroughCompletedTasks
     }
 
     public static let `default` = TaskCheckboxStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -249,6 +249,11 @@ public struct MarkerStyle: Sendable {
 
 /// Styling for fenced code blocks (```language ... ```).
 public struct CodeBlockStyle: Sendable {
+    /// PostScript name of the typeface used for code-block text, for example
+    /// `"GeistMono-Regular"`. `nil` (the default) keeps the historical
+    /// behavior: the syntax-highlighter service's code font. A name that
+    /// doesn't resolve degrades to that service font as well.
+    public var fontName: String?
     /// Code-block font size as a fraction of the document base font size.
     public var fontSizeScale: CGFloat
     /// Vertical paragraph spacing applied above and below the code block.
@@ -257,10 +262,12 @@ public struct CodeBlockStyle: Sendable {
     public var horizontalIndent: CGFloat
 
     public init(
+        fontName: String? = nil,
         fontSizeScale: CGFloat = 0.85,
         paragraphSpacing: CGFloat = 2.0,
         horizontalIndent: CGFloat = 12.0
     ) {
+        self.fontName = fontName
         self.fontSizeScale = fontSizeScale
         self.paragraphSpacing = paragraphSpacing
         self.horizontalIndent = horizontalIndent
@@ -275,9 +282,15 @@ public struct CodeBlockStyle: Sendable {
 public struct InlineCodeStyle: Sendable {
     /// Inline-code reuses the code block font size scale by default.
     public var fontSizeScale: CGFloat
+    /// PostScript name of the typeface used for inline-code text. `nil`
+    /// (the default) keeps the historical behavior: inline code renders in
+    /// the code-block font. A name that doesn't resolve degrades the same
+    /// way.
+    public var fontName: String?
 
-    public init(fontSizeScale: CGFloat = 0.85) {
+    public init(fontSizeScale: CGFloat = 0.85, fontName: String? = nil) {
         self.fontSizeScale = fontSizeScale
+        self.fontName = fontName
     }
 
     public static let `default` = InlineCodeStyle()

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -95,6 +95,12 @@ public struct MarkdownEditorTheme: Sendable {
     /// syntax-highlighter service's background color.
     public var codeBackground: NSColor?
 
+    /// Background color of the inline-code CHIP
+    /// (``InlineCodeStyle/chipCornerRadius`` set). `nil` (the default) falls
+    /// back to ``codeBackground`` and then to the syntax-highlighter
+    /// service's background color.
+    public var inlineCodeBackground: NSColor?
+
     // MARK: Init
 
     public init(
@@ -111,7 +117,8 @@ public struct MarkdownEditorTheme: Sendable {
         latexDarkModeText: NSColor = .white,
         strikethroughColor: NSColor = .labelColor,
         highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4),
-        codeBackground: NSColor? = nil
+        codeBackground: NSColor? = nil,
+        inlineCodeBackground: NSColor? = nil
     ) {
         self.bodyText = bodyText
         self.mutedText = mutedText
@@ -127,6 +134,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.strikethroughColor = strikethroughColor
         self.highlightColor = highlightColor
         self.codeBackground = codeBackground
+        self.inlineCodeBackground = inlineCodeBackground
     }
 
     /// System-native palette built from `NSColor` dynamic system colors.

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -47,6 +47,23 @@ public struct MarkdownEditorTheme: Sendable {
     public var headingText: NSColor?
     /// Foreground color for heading marker glyphs (`#`, `##`, …).
     public var headingMarker: NSColor
+    /// Foreground color for a CHECKED task item's label. `nil` (the default)
+    /// keeps the historical behavior: the label stays on the document's body
+    /// ink. Inline constructs inside the label (links, code, extension
+    /// spans) keep their own colors either way, exactly as they do over
+    /// ``bodyText``. Pairs with
+    /// ``TaskCheckboxStyle/strikethroughCompletedTasks`` for designs that
+    /// mark completion by ink instead of a strikethrough.
+    public var completedTaskText: NSColor?
+
+    // MARK: Task checkboxes
+
+    /// Tint of the drawn checkbox symbol for a CHECKED task item. `nil`
+    /// (the default) keeps the historical ``bodyText`` tint.
+    public var taskCheckboxChecked: NSColor?
+    /// Tint of the drawn checkbox symbol for an UNCHECKED task item. `nil`
+    /// (the default) keeps the historical ``mutedText`` tint.
+    public var taskCheckboxUnchecked: NSColor?
 
     // MARK: Links
 
@@ -96,6 +113,9 @@ public struct MarkdownEditorTheme: Sendable {
         disabledText: NSColor = .tertiaryLabelColor,
         headingText: NSColor? = nil,
         headingMarker: NSColor = .gray,
+        completedTaskText: NSColor? = nil,
+        taskCheckboxChecked: NSColor? = nil,
+        taskCheckboxUnchecked: NSColor? = nil,
         link: NSColor = .linkColor,
         incompleteLink: NSColor = .systemBlue,
         findMatchHighlight: NSColor = .systemYellow,
@@ -110,6 +130,9 @@ public struct MarkdownEditorTheme: Sendable {
         self.disabledText = disabledText
         self.headingText = headingText
         self.headingMarker = headingMarker
+        self.completedTaskText = completedTaskText
+        self.taskCheckboxChecked = taskCheckboxChecked
+        self.taskCheckboxUnchecked = taskCheckboxUnchecked
         self.link = link
         self.incompleteLink = incompleteLink
         self.findMatchHighlight = findMatchHighlight

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -36,6 +36,15 @@ public struct MarkdownEditorTheme: Sendable {
     /// Foreground color for content the engine wants to deemphasize further
     /// than `mutedText` — for example, broken wiki-links.
     public var disabledText: NSColor
+    /// Foreground color for heading text. `nil` (the default) keeps the
+    /// historical behavior: headings render in ``bodyText`` like the rest
+    /// of the document.
+    ///
+    /// Only the heading's own text takes this color. The `#` marker glyphs
+    /// stay on ``headingMarker``, and inline constructs inside a heading
+    /// (links, inline code, extension spans) keep their own colors, exactly
+    /// as they do over ``bodyText``.
+    public var headingText: NSColor?
     /// Foreground color for heading marker glyphs (`#`, `##`, …).
     public var headingMarker: NSColor
 
@@ -85,6 +94,7 @@ public struct MarkdownEditorTheme: Sendable {
         bodyText: NSColor = .labelColor,
         mutedText: NSColor = .secondaryLabelColor,
         disabledText: NSColor = .tertiaryLabelColor,
+        headingText: NSColor? = nil,
         headingMarker: NSColor = .gray,
         link: NSColor = .linkColor,
         incompleteLink: NSColor = .systemBlue,
@@ -98,6 +108,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.bodyText = bodyText
         self.mutedText = mutedText
         self.disabledText = disabledText
+        self.headingText = headingText
         self.headingMarker = headingMarker
         self.link = link
         self.incompleteLink = incompleteLink

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -126,3 +126,22 @@ public struct MarkdownEditorTheme: Sendable {
     /// `NSTextView`. It's also the default when no theme is supplied.
     public static let `default` = MarkdownEditorTheme()
 }
+
+// MARK: - Display attributes
+
+extension MarkdownEditorTheme {
+    /// Attributes for `NSTextView.linkTextAttributes`, which AppKit layers
+    /// over every `.link` range at DISPLAY time — on top of whatever
+    /// foreground the styler already set. Left at AppKit's default, links
+    /// always render `.linkColor` blue, so a custom ``link`` ink never
+    /// reaches the screen. Re-declaring the theme's link ink (plus the
+    /// standard underline and pointing-hand cursor the default also carries)
+    /// makes the displayed color follow the theme.
+    var linkTextAttributes: [NSAttributedString.Key: Any] {
+        [
+            .foregroundColor: link,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .cursor: NSCursor.pointingHand,
+        ]
+    }
+}

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -88,6 +88,13 @@ public struct MarkdownEditorTheme: Sendable {
     /// Background color used for `==highlight==` inline markup.
     public var highlightColor: NSColor
 
+    // MARK: Code
+
+    /// Background color behind fenced code blocks and inline `` `code` ``
+    /// spans. `nil` (the default) keeps the historical behavior: the
+    /// syntax-highlighter service's background color.
+    public var codeBackground: NSColor?
+
     // MARK: Init
 
     public init(
@@ -103,7 +110,8 @@ public struct MarkdownEditorTheme: Sendable {
         latexLightModeText: NSColor = .black,
         latexDarkModeText: NSColor = .white,
         strikethroughColor: NSColor = .labelColor,
-        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4)
+        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4),
+        codeBackground: NSColor? = nil
     ) {
         self.bodyText = bodyText
         self.mutedText = mutedText
@@ -118,6 +126,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.latexDarkModeText = latexDarkModeText
         self.strikethroughColor = strikethroughColor
         self.highlightColor = highlightColor
+        self.codeBackground = codeBackground
     }
 
     /// System-native palette built from `NSColor` dynamic system colors.

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -88,6 +88,15 @@ public struct MarkdownEditorTheme: Sendable {
     /// Background color used for `==highlight==` inline markup.
     public var highlightColor: NSColor
 
+    // MARK: Tables
+
+    /// Fill behind a rendered table's header row. `nil` (the default) keeps
+    /// the historical ``mutedText`` at 8% alpha.
+    public var tableHeaderBackground: NSColor?
+    /// Stroke color of a rendered table's outer border and internal rules.
+    /// `nil` (the default) keeps the historical ``mutedText`` at 50% alpha.
+    public var tableRule: NSColor?
+
     // MARK: Init
 
     public init(
@@ -103,7 +112,9 @@ public struct MarkdownEditorTheme: Sendable {
         latexLightModeText: NSColor = .black,
         latexDarkModeText: NSColor = .white,
         strikethroughColor: NSColor = .labelColor,
-        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4)
+        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4),
+        tableHeaderBackground: NSColor? = nil,
+        tableRule: NSColor? = nil
     ) {
         self.bodyText = bodyText
         self.mutedText = mutedText
@@ -118,6 +129,8 @@ public struct MarkdownEditorTheme: Sendable {
         self.latexDarkModeText = latexDarkModeText
         self.strikethroughColor = strikethroughColor
         self.highlightColor = highlightColor
+        self.tableHeaderBackground = tableHeaderBackground
+        self.tableRule = tableRule
     }
 
     /// System-native palette built from `NSColor` dynamic system colors.

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -47,6 +47,12 @@ public struct MarkdownEditorTheme: Sendable {
     public var headingText: NSColor?
     /// Foreground color for heading marker glyphs (`#`, `##`, …).
     public var headingMarker: NSColor
+    /// Foreground color for painted list marker glyphs — the bullet `•` and
+    /// the ordered `1.` overlays, including the raw source characters those
+    /// painters reveal while the marker sits inside a selection. `nil` (the
+    /// default) keeps the historical behavior: markers render in
+    /// ``bodyText`` like the item content.
+    public var listMarker: NSColor?
 
     // MARK: Links
 
@@ -96,6 +102,7 @@ public struct MarkdownEditorTheme: Sendable {
         disabledText: NSColor = .tertiaryLabelColor,
         headingText: NSColor? = nil,
         headingMarker: NSColor = .gray,
+        listMarker: NSColor? = nil,
         link: NSColor = .linkColor,
         incompleteLink: NSColor = .systemBlue,
         findMatchHighlight: NSColor = .systemYellow,
@@ -110,6 +117,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.disabledText = disabledText
         self.headingText = headingText
         self.headingMarker = headingMarker
+        self.listMarker = listMarker
         self.link = link
         self.incompleteLink = incompleteLink
         self.findMatchHighlight = findMatchHighlight

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -48,6 +48,18 @@ public struct MarkdownEditorTheme: Sendable {
     /// Foreground color for heading marker glyphs (`#`, `##`, …).
     public var headingMarker: NSColor
 
+    // MARK: Blockquotes
+
+    /// Fill of the painted vertical quote bar(s). `nil` (the default) keeps
+    /// the historical half-transparent ``mutedText``. A configured color is
+    /// used exactly as given — no alpha is layered on top.
+    public var blockquoteBar: NSColor?
+    /// Foreground color of blockquote content. `nil` (the default) keeps the
+    /// historical behavior of muting quotes in ``mutedText``. The `>` marker
+    /// glyphs revealed on the active line stay on ``mutedText`` either way,
+    /// and inline constructs keep their own colors as usual.
+    public var blockquoteText: NSColor?
+
     // MARK: Links
 
     /// Foreground color for hyperlinks that resolve to an URL.
@@ -96,6 +108,8 @@ public struct MarkdownEditorTheme: Sendable {
         disabledText: NSColor = .tertiaryLabelColor,
         headingText: NSColor? = nil,
         headingMarker: NSColor = .gray,
+        blockquoteBar: NSColor? = nil,
+        blockquoteText: NSColor? = nil,
         link: NSColor = .linkColor,
         incompleteLink: NSColor = .systemBlue,
         findMatchHighlight: NSColor = .systemYellow,
@@ -110,6 +124,8 @@ public struct MarkdownEditorTheme: Sendable {
         self.disabledText = disabledText
         self.headingText = headingText
         self.headingMarker = headingMarker
+        self.blockquoteBar = blockquoteBar
+        self.blockquoteText = blockquoteText
         self.link = link
         self.incompleteLink = incompleteLink
         self.findMatchHighlight = findMatchHighlight

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -547,7 +547,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             let isSelected = selectionRanges.contains(where: { NSIntersectionRange($0, attrRange).length > 0 })
             let raw = storageString.substring(with: attrRange)
             let glyph = (isSelected ? raw : "•") as NSString
-            let glyphAttrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.bodyText]
+            let glyphAttrs: [NSAttributedString.Key: Any] = [
+                .font: font, .foregroundColor: theme.listMarker ?? theme.bodyText,
+            ]
 
             let markerWidth = (raw as NSString).size(withAttributes: [.font: font]).width
             let glyphWidth = glyph.size(withAttributes: glyphAttrs).width
@@ -589,7 +591,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             let isSelected = selectionRanges.contains(where: { NSIntersectionRange($0, attrRange).length > 0 })
             let raw = storageString.substring(with: attrRange)
             let glyph = (isSelected ? raw : number) as NSString
-            let glyphAttrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.bodyText]
+            let glyphAttrs: [NSAttributedString.Key: Any] = [
+                .font: font, .foregroundColor: theme.listMarker ?? theme.bodyText,
+            ]
             let topY = pos.baselineY - font.ascender
             glyph.draw(at: CGPoint(x: pos.x, y: topY), withAttributes: glyphAttrs)
         }

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -624,10 +624,14 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             // char's font (0.1pt in a heading-first doc → 1px boxes).
             let font = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.baseFont
                 ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
+            let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
+                ?? .default
             let ascent = max(0, font.ascender)
             let descent = max(0, -font.descender)
             let size = TaskCheckboxGeometry.size(for: font)
-            let boxX = TaskCheckboxGeometry.boxX(contentX: pos.x, size: size)
+            let boxX = TaskCheckboxGeometry.boxX(
+                contentX: pos.x, size: size, markerTextGap: configuration.lists.markerTextGap
+            )
             let centerY = pos.baselineY + (descent - ascent) / 2
             let boxY = centerY - size / 2
 
@@ -641,8 +645,6 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
             let iconInset = max(0.0, size * 0.01)
             let iconRect = boxRect.insetBy(dx: iconInset, dy: iconInset)
-            let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
-                ?? .default
             let style = configuration.taskCheckbox
             let symbolName = isChecked ? style.checkedSymbolName : style.uncheckedSymbolName
             let fallbackName = isChecked

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -37,11 +37,6 @@ extension NSAttributedString.Key {
 
 final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
-    /// Horizontal space (points) each blockquote nesting level occupies —
-    /// shared so the styler's text indent and the painted bars line up.
-    static let blockquoteIndentPerLevel: CGFloat = 18
-    static let blockquoteBarWidth: CGFloat = 3
-
     /// Strip below an overlay block for the legacy-small scroller (~11pt) + buffer.
     static let scrollableBlockScrollerStrip: CGFloat = 14
 
@@ -474,16 +469,19 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         }
         guard anyLevel else { return }
 
-        let theme = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
-            .configuration.theme ?? .default
-        let indentPerLevel = Self.blockquoteIndentPerLevel
-        let barWidth = Self.blockquoteBarWidth
+        let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
+            .configuration ?? .default
+        let theme = configuration.theme
+        // textIndent is shared with the styler's paragraph indent so the
+        // painted bars and the hanging text line up at every level.
+        let indentPerLevel = configuration.blockquote.textIndent
+        let barWidth = configuration.blockquote.barWidth
 
         NSGraphicsContext.saveGraphicsState()
         defer { NSGraphicsContext.restoreGraphicsState() }
         let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
         NSGraphicsContext.current = nsContext
-        theme.mutedText.withAlphaComponent(0.5).setFill()
+        (theme.blockquoteBar ?? theme.mutedText.withAlphaComponent(0.5)).setFill()
 
         let fragLocation = fragmentNSRange?.location ?? 0
         let leftEdge = point.x - layoutFragmentFrame.origin.x

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -639,10 +639,23 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             let boxRect = CGRect(x: alignToPixel(boxX), y: alignToPixel(boxY), width: size, height: size)
             guard !boxRect.isEmpty, !boxRect.isNull else { return }
 
-            let iconInset = max(0.0, size * 0.01)
-            let iconRect = boxRect.insetBy(dx: iconInset, dy: iconInset)
             let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?.configuration
                 ?? .default
+
+            // A service-supplied checkbox image replaces the stock SF-symbol
+            // box entirely; geometry and hit-testing stay engine-owned either
+            // way, so a custom renderer only changes the pixels in boxRect.
+            if let custom = configuration.services.taskCheckboxes.image(
+                checked: isChecked,
+                size: boxRect.width,
+                appearance: textLayoutManager?.textContainer?.textView?.effectiveAppearance
+            ) {
+                custom.draw(in: boxRect)
+                return
+            }
+
+            let iconInset = max(0.0, size * 0.01)
+            let iconRect = boxRect.insetBy(dx: iconInset, dy: iconInset)
             let style = configuration.taskCheckbox
             let symbolName = isChecked ? style.checkedSymbolName : style.uncheckedSymbolName
             let fallbackName = isChecked

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -651,7 +651,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             if let baseSymbol = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
                 ?? NSImage(systemSymbolName: fallbackName, accessibilityDescription: nil) {
                 let sizeConfig = NSImage.SymbolConfiguration(pointSize: iconRect.height, weight: .regular)
-                let tint = isChecked ? configuration.theme.bodyText : configuration.theme.mutedText
+                let tint = isChecked
+                    ? (configuration.theme.taskCheckboxChecked ?? configuration.theme.bodyText)
+                    : (configuration.theme.taskCheckboxUnchecked ?? configuration.theme.mutedText)
                 let colorConfig = NSImage.SymbolConfiguration(hierarchicalColor: tint)
                 let symbolConfig = sizeConfig.applying(colorConfig)
                 let symbol = baseSymbol.withSymbolConfiguration(symbolConfig) ?? baseSymbol

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -553,7 +553,18 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
             let markerWidth = (raw as NSString).size(withAttributes: [.font: font]).width
             let glyphWidth = glyph.size(withAttributes: glyphAttrs).width
-            let xOffset = max(0, (markerWidth - glyphWidth) / 2)
+            // Fixed marker column (lists.markerSlotWidth on the grid): center
+            // the `•` in the column so bullets share the checkbox/number
+            // alignment grid. Raw reveal (selection) keeps the source
+            // position. Otherwise center on the source char's own advance.
+            let slotWidth = (self.textLayoutManager?.textContainer?.textView as? NativeTextView)?
+                .configuration.lists.effectiveMarkerSlotWidth
+            let xOffset: CGFloat
+            if let slotWidth, !isSelected {
+                xOffset = (slotWidth - glyphWidth) / 2
+            } else {
+                xOffset = max(0, (markerWidth - glyphWidth) / 2)
+            }
             // Flipped context: text origin is its top edge, baseline sits one
             // ascent below — so top = baseline − ascent aligns the glyph.
             let topY = pos.baselineY - font.ascender
@@ -594,8 +605,18 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             let glyphAttrs: [NSAttributedString.Key: Any] = [
                 .font: font, .foregroundColor: theme.listMarker ?? theme.bodyText,
             ]
+            // Fixed marker column (lists.markerSlotWidth on the grid): center
+            // the painted marker in the column, matching bullets and the task
+            // checkbox. Raw reveal (selection) keeps the source position.
+            let slotWidth = (self.textLayoutManager?.textContainer?.textView as? NativeTextView)?
+                .configuration.lists.effectiveMarkerSlotWidth
+            let xOffset: CGFloat = {
+                guard let slotWidth, !isSelected else { return 0 }
+                let glyphWidth = glyph.size(withAttributes: glyphAttrs).width
+                return (slotWidth - glyphWidth) / 2
+            }()
             let topY = pos.baselineY - font.ascender
-            glyph.draw(at: CGPoint(x: pos.x, y: topY), withAttributes: glyphAttrs)
+            glyph.draw(at: CGPoint(x: pos.x + xOffset, y: topY), withAttributes: glyphAttrs)
         }
     }
 
@@ -632,7 +653,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
                 ?? .default
             let ascent = max(0, font.ascender)
             let descent = max(0, -font.descender)
-            let size = TaskCheckboxGeometry.size(for: font)
+            let size = TaskCheckboxGeometry.size(
+                for: font, slotWidth: configuration.lists.effectiveMarkerSlotWidth
+            )
             let boxX = TaskCheckboxGeometry.boxX(
                 contentX: pos.x, size: size, markerTextGap: configuration.lists.markerTextGap
             )

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -33,6 +33,14 @@ extension NSAttributedString.Key {
     static let scrollableBlockTotalHeight = NSAttributedString.Key("ScrollableBlockTotalHeight")
     /// NSValue(range:) — full multi-line range of the wide-table source, used to scope width-change restyles.
     static let scrollableBlockFullRange = NSAttributedString.Key("ScrollableBlockFullRange")
+    /// NSValue(range:) — whole fenced-block range (fences included). Marks the
+    /// block as card-rendered (`CodeBlockStyle.cornerRadius` set); each
+    /// fragment uses the range to decide whether it draws the card's top
+    /// and/or bottom rounded corners.
+    static let codeBlockCard = NSAttributedString.Key("CodeBlockCard")
+    /// Marks an inline `code` span rendered as a rounded chip
+    /// (`InlineCodeStyle.chipCornerRadius` set). Set to `true`.
+    static let inlineCodeChip = NSAttributedString.Key("InlineCodeChip")
 }
 
 final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
@@ -59,7 +67,7 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
         var bounds = super.renderingSurfaceBounds
         // Task checkboxes too: the box draws left of the first glyph (marker
         // slot), outside the default text surface — TextKit would clip it.
-        if hasCodeBlockBackground || hasThematicBreak || hasBlockquote || hasTaskCheckbox {
+        if hasCodeBlockBackground || hasThematicBreak || hasBlockquote || hasTaskCheckbox || hasInlineCodeChip {
             let containerWidth = textLayoutManager?.textContainer?.size.width ?? bounds.width
             // Extend left to container edge
             bounds.origin.x = -layoutFragmentFrame.origin.x
@@ -78,6 +86,9 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
     override func draw(at point: CGPoint, in context: CGContext) {
         // 1. Code-block backgrounds (behind text)
         drawCodeBlockBackground(at: point, in: context)
+
+        // 1b. Inline-code chips (behind text; selection cut out like 1)
+        drawInlineCodeChips(at: point, in: context)
 
         // 2. LaTeX images (behind text — hidden markers are invisible anyway)
         drawLatexImages(at: point, in: context)
@@ -160,9 +171,22 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
     private var hasCodeBlockBackground: Bool {
         guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return false }
+        if ts.attribute(.codeBlockCard, at: range.location, effectiveRange: nil) != nil { return true }
         let bgColor = ts.attribute(.backgroundColor, at: range.location, effectiveRange: nil) as? NSColor
         guard let bgColor else { return false }
         return isCodeBlockBackgroundColor(bgColor)
+    }
+
+    private var hasInlineCodeChip: Bool {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return false }
+        var found = false
+        ts.enumerateAttribute(.inlineCodeChip, in: range, options: []) { value, _, stop in
+            if value as? Bool == true {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
     }
 
     private var hasThematicBreak: Bool {
@@ -203,6 +227,14 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
 
     private func drawCodeBlockBackground(at point: CGPoint, in context: CGContext) {
         guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+
+        // Card mode: the styler tags the block with `.codeBlockCard` instead
+        // of a `.backgroundColor`, and each fragment paints its slice of one
+        // continuous rounded card.
+        if let cardValue = ts.attribute(.codeBlockCard, at: range.location, effectiveRange: nil) as? NSValue {
+            drawCodeBlockCardSlice(blockRange: cardValue.rangeValue, at: point, in: context)
+            return
+        }
 
         // Only fenced code-block fragments get the full-width fill (first char must carry the code background).
         guard let color = ts.attribute(.backgroundColor, at: range.location, effectiveRange: nil) as? NSColor,
@@ -251,6 +283,161 @@ final class MarkdownTextLayoutFragment: NSTextLayoutFragment {
             }
             path.fill()
         }
+    }
+
+    /// One fragment's slice of the code-block CARD: a full-width fill whose
+    /// corners round only on the fragments holding the block's first and last
+    /// characters, so the whole fenced block (wrapped lines included) reads
+    /// as ONE continuous rounded card. Rounding is achieved by extending the
+    /// rounded rect past the slice on the sides that must stay square and
+    /// clipping back to the slice — every fragment still draws strictly
+    /// inside its own strip, so invalidation and scrolling stay per-fragment.
+    private func drawCodeBlockCardSlice(blockRange: NSRange, at point: CGPoint, in context: CGContext) {
+        guard let range = fragmentNSRange else { return }
+        let configuration = (textLayoutManager?.textContainer?.textView as? NativeTextView)?
+            .configuration ?? .default
+        guard let radius = configuration.codeBlock.cornerRadius else { return }
+        let color = configuration.theme.codeBackground
+            ?? configuration.services.syntaxHighlighter.backgroundColor()
+
+        let containerWidth = textLayoutManager?.textContainer?.size.width ?? layoutFragmentFrame.width
+
+        var effectiveHeight = layoutFragmentFrame.height
+        if textLineFragments.count > 1,
+           let lastLF = textLineFragments.last,
+           lastLF.characterRange.length == 0 {
+            effectiveHeight -= lastLF.typographicBounds.height
+        }
+
+        let scale = textLayoutManager?.textContainer?.textView?.window?.backingScaleFactor
+            ?? NSScreen.main?.backingScaleFactor ?? 2.0
+        let snappedY = floor(point.y * scale) / scale
+        let snappedMaxY = ceil((point.y + effectiveHeight) * scale) / scale
+
+        let bgRect = CGRect(
+            x: point.x - layoutFragmentFrame.origin.x,
+            y: snappedY,
+            width: containerWidth,
+            height: snappedMaxY - snappedY
+        )
+
+        let isTop = NSLocationInRange(blockRange.location, range)
+        let isBottom = blockRange.length > 0 && NSLocationInRange(NSMaxRange(blockRange) - 1, range)
+        var cardRect = bgRect
+        if !isTop {
+            cardRect.origin.y -= radius
+            cardRect.size.height += radius
+        }
+        if !isBottom {
+            cardRect.size.height += radius
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+
+        NSBezierPath(rect: bgRect).setClip()
+        let path = NSBezierPath(roundedRect: cardRect, xRadius: radius, yRadius: radius)
+        path.windingRule = .evenOdd
+        // Selection stays visible inside the card, same as the legacy fill.
+        for r in selectionRectsInDrawCoordinates(drawPoint: point, snappedY: snappedY, snappedMaxY: snappedMaxY) {
+            let cut = r.intersection(bgRect)
+            if !cut.isEmpty { path.appendRect(cut) }
+        }
+        color.setFill()
+        path.fill()
+    }
+
+    // MARK: - Inline Code Chips
+
+    /// Rounded chip behind each inline `code` span (`.inlineCodeChip`): a
+    /// small background hugging the code text's own height with a little
+    /// horizontal breathing room, drawn per wrapped line. Selection is cut
+    /// out even-odd so the system highlight stays visible above the chip.
+    private func drawInlineCodeChips(at point: CGPoint, in context: CGContext) {
+        guard let ts = textStorage, let range = fragmentNSRange, range.length > 0 else { return }
+        guard let textView = textLayoutManager?.textContainer?.textView as? NativeTextView else { return }
+        let configuration = textView.configuration
+        guard let radius = configuration.inlineCode.chipCornerRadius else { return }
+
+        var chipRects: [CGRect] = []
+        let pad = configuration.inlineCode.chipHorizontalPadding
+        ts.enumerateAttribute(.inlineCodeChip, in: range, options: []) { [weak self] value, attrRange, _ in
+            guard let self, (value as? Bool) == true else { return }
+            let font = (ts.attribute(.font, at: attrRange.location, effectiveRange: nil) as? NSFont)
+                ?? textView.baseFont
+            let ascent = max(0, font.ascender)
+            let descent = max(0, -font.descender)
+            for lineFragment in self.textLineFragments {
+                let lr = lineFragment.characterRange
+                let lineDocRange = NSRange(location: range.location + lr.location, length: lr.length)
+                let inter = NSIntersectionRange(lineDocRange, attrRange)
+                guard inter.length > 0 else { continue }
+                let tb = lineFragment.typographicBounds
+                let startPos = lineFragment.locationForCharacter(at: inter.location - range.location)
+                let endPos = lineFragment.locationForCharacter(at: NSMaxRange(inter) - range.location)
+                let x0 = point.x + tb.origin.x + startPos.x
+                let x1 = point.x + tb.origin.x + endPos.x
+                guard x1 > x0 else { continue }
+                let baselineY = point.y + tb.origin.y + startPos.y
+                chipRects.append(CGRect(
+                    x: x0 - pad,
+                    y: baselineY - ascent - 1,
+                    width: (x1 - x0) + pad * 2,
+                    height: ascent + descent + 2
+                ))
+            }
+        }
+        guard !chipRects.isEmpty else { return }
+
+        NSGraphicsContext.saveGraphicsState()
+        defer { NSGraphicsContext.restoreGraphicsState() }
+        NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: true)
+
+        let selectionRects = selectionSegmentRects(drawPoint: point)
+        let color = configuration.theme.inlineCodeBackground
+            ?? configuration.theme.codeBackground
+            ?? configuration.services.syntaxHighlighter.backgroundColor()
+        color.setFill()
+        let path = NSBezierPath()
+        path.windingRule = .evenOdd
+        for chip in chipRects {
+            path.appendRoundedRect(chip, xRadius: radius, yRadius: radius)
+            for r in selectionRects {
+                let cut = r.intersection(chip)
+                if !cut.isEmpty { path.appendRect(cut) }
+            }
+        }
+        path.fill()
+    }
+
+    /// Active text-selection segment rectangles intersecting this fragment,
+    /// in draw-relative coordinates, with their natural segment heights
+    /// (unlike `selectionRectsInDrawCoordinates`, which expands to a snapped
+    /// vertical span for the code-block fill's cut-out).
+    private func selectionSegmentRects(drawPoint: CGPoint) -> [CGRect] {
+        guard let tlm = textLayoutManager else { return [] }
+        var rects: [CGRect] = []
+        let dx = drawPoint.x - layoutFragmentFrame.origin.x
+        let dy = drawPoint.y - layoutFragmentFrame.origin.y
+        let myRange = self.rangeInElement
+
+        for selection in tlm.textSelections {
+            for textRange in selection.textRanges {
+                let interStart = textRange.location.compare(myRange.location) == .orderedAscending
+                    ? myRange.location : textRange.location
+                let interEnd = textRange.endLocation.compare(myRange.endLocation) == .orderedDescending
+                    ? myRange.endLocation : textRange.endLocation
+                guard interStart.compare(interEnd) == .orderedAscending,
+                      let intersection = NSTextRange(location: interStart, end: interEnd) else { continue }
+
+                tlm.enumerateTextSegments(in: intersection, type: .selection, options: []) { _, segFrame, _, _ in
+                    rects.append(segFrame.offsetBy(dx: dx, dy: dy))
+                    return true
+                }
+            }
+        }
+        return rects
     }
 
     /// Returns active text-selection rectangles intersecting this fragment, in

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -28,8 +28,17 @@ enum TaskCheckboxGeometry {
         return max(1.0, min(floor(fontHeight * 1.2), floor(markerWidth * 1.2)))
     }
 
-    /// Left edge of the square: right-aligned to the content start x with `gap`.
-    static func boxX(contentX: CGFloat, size: CGFloat) -> CGFloat {
-        contentX - size - gap
+    /// Left edge of the square.
+    ///
+    /// Legacy layout right-aligns the box to the content start x with `gap`.
+    /// In the indent grid (``ListStyle/markerTextGap`` set) the box is
+    /// LEFT-aligned to the marker slot's origin instead, matching where a
+    /// bullet or number would start — clamped so a slot narrower than the
+    /// box itself falls back to the right-aligned position.
+    static func boxX(contentX: CGFloat, size: CGFloat, markerTextGap: CGFloat? = nil) -> CGFloat {
+        if let markerTextGap {
+            return contentX - max(markerTextGap, size + gap)
+        }
+        return contentX - size - gap
     }
 }

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -19,8 +19,12 @@ enum TaskCheckboxGeometry {
     /// Gap between the box's right edge and the task content's left edge.
     static let gap: CGFloat = 2.0
 
-    /// Side length of the square for the given (body) font.
-    static func size(for font: NSFont) -> CGFloat {
+    /// Side length of the square for the given (body) font. A fixed marker
+    /// column (``ListStyle/markerSlotWidth`` on the indent grid) overrides
+    /// the font-derived size: the box fills the column exactly, so checkbox,
+    /// bullet, and number markers share one alignment grid.
+    static func size(for font: NSFont, slotWidth: CGFloat? = nil) -> CGFloat {
+        if let slotWidth { return max(1.0, slotWidth) }
         let ascent = max(0, font.ascender)
         let descent = max(0, -font.descender)
         let fontHeight = max(1, ceil(ascent + descent))

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -30,14 +30,17 @@ enum TaskCheckboxGeometry {
 
     /// Left edge of the square.
     ///
-    /// Legacy layout right-aligns the box to the content start x with `gap`.
-    /// In the indent grid (``ListStyle/markerTextGap`` set) the box is
-    /// LEFT-aligned to the marker slot's origin instead, matching where a
-    /// bullet or number would start — clamped so a slot narrower than the
-    /// box itself falls back to the right-aligned position.
+    /// Legacy layout right-aligns the box to the content start x with `gap`
+    /// (the hidden `[ ] ` sits at the content edge because `- ` keeps full
+    /// advance). In the indent grid (``ListStyle/markerTextGap`` set) the
+    /// styler collapses the WHOLE `- [ ] `, so the box range's own position is
+    /// the marker-slot origin — the square is LEFT-aligned there, matching
+    /// where a bullet or number glyph would start. Gaps narrower than
+    /// `size + gap` let the square run into the content; configure
+    /// ``ListStyle/markerTextGap`` at least that wide.
     static func boxX(contentX: CGFloat, size: CGFloat, markerTextGap: CGFloat? = nil) -> CGFloat {
-        if let markerTextGap {
-            return contentX - max(markerTextGap, size + gap)
+        if markerTextGap != nil {
+            return contentX
         }
         return contentX - size - gap
     }

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -184,6 +184,36 @@ public struct NoOpLatexRenderer: LatexRenderer {
     public func render(latex: String, fontSize: CGFloat, theme: MarkdownEditorTheme) -> LatexRenderResult? { nil }
 }
 
+// MARK: - Task Checkboxes
+
+/// Supplies the image drawn for task-list checkboxes (`- [ ]` / `- [x]`).
+///
+/// The engine's stock rendering is an SF-symbol square tinted from the theme.
+/// Embedders whose design system has its own checkbox glyph implement this
+/// protocol and return a ready-to-draw image; the engine keeps ownership of
+/// the box's geometry (position, size) and of hit-testing, so a custom image
+/// changes only the pixels inside the box rect.
+public protocol TaskCheckboxRenderer: Sendable {
+    /// Return the image for one checkbox state, or `nil` to fall back to the
+    /// engine's stock SF-symbol rendering for this call.
+    ///
+    /// - Parameters:
+    ///   - checked: Whether the box renders the checked state.
+    ///   - size: Side length of the square box rect, in points.
+    ///   - appearance: The text view's effective appearance at draw time, so
+    ///     implementations can resolve light/dark variants.
+    ///
+    /// Called synchronously on the main thread during fragment drawing;
+    /// implementations should cache per (checked, size, appearance).
+    func image(checked: Bool, size: CGFloat, appearance: NSAppearance?) -> NSImage?
+}
+
+/// Default renderer that always defers to the engine's stock SF-symbol box.
+public struct SystemTaskCheckboxRenderer: TaskCheckboxRenderer {
+    public init() {}
+    public func image(checked: Bool, size: CGFloat, appearance: NSAppearance?) -> NSImage? { nil }
+}
+
 // MARK: - Event Bus
 
 /// Optional notification-name bridge that lets the editor communicate with
@@ -319,6 +349,7 @@ public struct MarkdownEditorServices: Sendable {
     public var images: any EmbeddedImageProvider
     public var syntaxHighlighter: any SyntaxHighlighter
     public var latex: any LatexRenderer
+    public var taskCheckboxes: any TaskCheckboxRenderer
     public var bus: MarkdownEditorBus
 
     public init(
@@ -326,12 +357,14 @@ public struct MarkdownEditorServices: Sendable {
         images: any EmbeddedImageProvider = NoOpEmbeddedImageProvider(),
         syntaxHighlighter: any SyntaxHighlighter = PlainTextSyntaxHighlighter(),
         latex: any LatexRenderer = NoOpLatexRenderer(),
+        taskCheckboxes: any TaskCheckboxRenderer = SystemTaskCheckboxRenderer(),
         bus: MarkdownEditorBus = .default
     ) {
         self.wikiLinks = wikiLinks
         self.images = images
         self.syntaxHighlighter = syntaxHighlighter
         self.latex = latex
+        self.taskCheckboxes = taskCheckboxes
         self.bus = bus
     }
 

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -557,12 +557,13 @@ enum MarkdownASTStyler {
                 .flatMap { NSFont(name: $0, size: headingSize) }
                 ?? adding(.bold, to: NSFont(name: ctx.fontName, size: headingSize)
                     ?? .systemFont(ofSize: headingSize))
-            let lineHeight = ceil(headingFont.ascender - headingFont.descender + headingFont.leading) + 1
+            let lineHeight = ctx.config.headings.lineHeight(for: level)
+                ?? ceil(headingFont.ascender - headingFont.descender + headingFont.leading) + 1
             let headingPara = NSMutableParagraphStyle()
             headingPara.minimumLineHeight = lineHeight
             headingPara.maximumLineHeight = lineHeight
             headingPara.paragraphSpacingBefore = headingFont.pointSize * ctx.config.headings.topSpacingEm(for: level)
-            headingPara.paragraphSpacing = ctx.baseParagraphSpacing
+            headingPara.paragraphSpacing = ctx.config.headings.paragraphSpacing ?? ctx.baseParagraphSpacing
             attrs.append((ctx.ns.paragraphRange(for: range), [.paragraphStyle: headingPara]))
             // theme.headingText paints the whole heading line; the marker loop
             // and the inline descent below both append LATER, so `#` glyphs

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -377,15 +377,48 @@ enum MarkdownASTStyler {
         ps.paragraphSpacing = ctx.baseParagraphSpacing
         ps.paragraphSpacingBefore = 0
         ps.tabStops = []
-        ps.defaultTabInterval = ctx.config.lists.indentPerLevel
-        ps.firstLineHeadIndent = ctx.config.lists.indentPerLevel
-        // Wrapped lines hang under the first line's content (indent + marker
-        // width). No checkbox-specific extra: the box is a drawn overlay that
-        // doesn't change text advance, so adding it here (and only here, not to
-        // firstLineHeadIndent) shifted an unchecked task's wrapped lines right
-        // of its first line.
-        ps.headIndent = ctx.config.lists.indentPerLevel + depthIndent + markerWidth
-        attrs.append((line, [.paragraphStyle: ps]))
+        if let gap = ctx.config.lists.markerTextGap,
+           item.contentRange.location - 1 >= NSMaxRange(item.marker) {
+            // Indent GRID (opt-in, see ListStyle.markerTextGap): the marker
+            // starts at depth × indentPerLevel — level 1 on the body origin —
+            // and content hangs a fixed slot after it. The raw source
+            // whitespace is neutralized below, so tabs must stop advancing to
+            // indentPerLevel stops; a sub-point interval reduces each tab to
+            // layout noise instead.
+            ps.defaultTabInterval = 0.25
+            ps.firstLineHeadIndent = depthIndent
+            // The slot can widen freely but only narrow until the final spacer
+            // char would reach a negative advance (content folding back over
+            // the marker glyphs).
+            let spacerRange = NSRange(location: item.contentRange.location - 1, length: 1)
+            let spacerWidth = HeadingHelpers.textWidth(ctx.ns.substring(with: spacerRange), font: ctx.baseFont)
+            let slot = max(gap, markerWidth - spacerWidth + 0.5)
+            ps.headIndent = depthIndent + slot
+            attrs.append((line, [.paragraphStyle: ps]))
+            // Collapse the leading whitespace so the SOURCE indent stops being
+            // the visual indent — the paragraph indent above owns it now.
+            // (Tabs keep their sub-point interval advance; spaces take the
+            // hidden-marker font like every other collapsed syntax char.)
+            if wsRange.length > 0 {
+                attrs.append((wsRange, [.font: ctx.inlineMarkerFont]))
+            }
+            // Land the content exactly on the slot edge by kerning the final
+            // spacer char. markerWidth already measures the DISPLAY marker
+            // while the ordered overlay is active and the raw marker in every
+            // reveal state, so the same correction holds for every marker kind
+            // — content doesn't jump when the caret enters/leaves the syntax.
+            attrs.append((spacerRange, [.kern: slot - markerWidth]))
+        } else {
+            ps.defaultTabInterval = ctx.config.lists.indentPerLevel
+            ps.firstLineHeadIndent = ctx.config.lists.indentPerLevel
+            // Wrapped lines hang under the first line's content (indent + marker
+            // width). No checkbox-specific extra: the box is a drawn overlay that
+            // doesn't change text advance, so adding it here (and only here, not to
+            // firstLineHeadIndent) shifted an unchecked task's wrapped lines right
+            // of its first line.
+            ps.headIndent = ctx.config.lists.indentPerLevel + depthIndent + markerWidth
+            attrs.append((line, [.paragraphStyle: ps]))
+        }
 
         // 2. Marker decoration (suppressed while the caret edits the syntax).
         if let box = item.checkbox {

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -71,7 +71,8 @@ enum MarkdownASTStyler {
             extensionsByID: configuration.extensionsByID,
             wikiLinkID: wikiLinkIDProvider,
             scopedRanges: scopedRanges,
-            orderedDisplayNumbers: computeOrderedDisplayNumbers(blocks: blocks, ns: ns)
+            orderedDisplayNumbers: computeOrderedDisplayNumbers(blocks: blocks, ns: ns),
+            listDepths: computeListDepths(blocks: blocks, ns: ns)
         )
         var attrs: [StyledRange] = []
         for block in blocks where ctx.inScope(block.range) {
@@ -209,12 +210,13 @@ enum MarkdownASTStyler {
     /// hole between two scoped blocks" without materializing the substring.
     private static let nonWhitespace = CharacterSet.whitespacesAndNewlines.inverted
 
-    /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
-    /// in the full source: same-indent items counted, blank lines skipped, real
-    /// content stops it) and returns the next number per indent. Lets a scoped
-    /// restyle that only sees a local window continue the document's numbering.
-    private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
-        guard loc > 0, loc <= ns.length else { return [:] }
+    /// The list-item lines of the run that continues ABOVE `loc`, bottom-to-top
+    /// (scanning backward in the full source: list lines collected, blank lines
+    /// skipped, real content stops the scan). `number` is nil for bullets/tasks.
+    /// Shared by the ordered-counter and indent-stack seeds so a scoped restyle
+    /// that only sees a local window can rebuild the document-level run state.
+    private static func scanListRunLines(above loc: Int, in ns: NSString) -> [(indent: Int, number: Int?)] {
+        guard loc > 0, loc <= ns.length else { return [] }
         var runLines: [(indent: Int, number: Int?)] = []   // bottom-to-top; nil = bullet/other list
         // From the START of loc's line: callers pass a MARKER offset, which for
         // an indented item still sits inside its own line — scanning up from
@@ -240,8 +242,16 @@ enum MarkdownASTStyler {
             runLines.append(((ws as NSString).length, number))
             scan = lineRange.location
         }
+        return runLines
+    }
+
+    /// Replays the ordered-list run that continues ABOVE `loc` (scanning backward
+    /// in the full source: same-indent items counted, blank lines skipped, real
+    /// content stops it) and returns the next number per indent. Lets a scoped
+    /// restyle that only sees a local window continue the document's numbering.
+    private static func seedOrderedCounters(above loc: Int, in ns: NSString) -> [Int: Int] {
         var counters: [Int: Int] = [:]
-        for item in runLines.reversed() {                    // replay top-to-bottom
+        for item in scanListRunLines(above: loc, in: ns).reversed() {   // replay top-to-bottom
             if let number = item.number {
                 counters[item.indent] = (counters[item.indent] ?? number) + 1
             } else {
@@ -250,6 +260,63 @@ enum MarkdownASTStyler {
             for key in counters.keys where key > item.indent { counters[key] = nil }
         }
         return counters
+    }
+
+    /// Replays the list run that continues ABOVE `loc` and returns the stack of
+    /// open ancestor indent columns (outermost first) — the state
+    /// `computeListDepths` needs to keep a nested item's depth stable when a
+    /// scoped restyle starts mid-list.
+    private static func seedIndentStack(above loc: Int, in ns: NSString) -> [Int] {
+        var stack: [Int] = []
+        for item in scanListRunLines(above: loc, in: ns).reversed() {   // replay top-to-bottom
+            while let top = stack.last, top >= item.indent { stack.removeLast() }
+            stack.append(item.indent)
+        }
+        return stack
+    }
+
+    /// Structural nesting depth (0-based) per list item, keyed by marker
+    /// location. Derived from the ORDER of indent columns in the run — an item
+    /// is one level deeper than the nearest earlier item with a smaller indent
+    /// — instead of a fixed spaces-per-level divisor, so ordered nesting (3+
+    /// columns per level, marker-width driven) and bullet nesting (2 columns)
+    /// land on the same ladder. Mirrors `computeOrderedDisplayNumbers`'
+    /// gap/seed handling so scoped restyles see document-level depth.
+    private static func computeListDepths(blocks: [BlockNode], ns: NSString) -> [Int: Int] {
+        var result: [Int: Int] = [:]
+        var stack: [Int] = []          // open ancestor indent columns
+        var needsSeed = true
+        var contiguousEnd: Int?
+        for block in blocks {
+            if let contiguousEnd, block.range.location > contiguousEnd,
+               ns.rangeOfCharacter(from: Self.nonWhitespace, options: [],
+                                   range: NSRange(location: contiguousEnd,
+                                                  length: block.range.location - contiguousEnd)).location != NSNotFound {
+                stack = []
+                needsSeed = true
+            }
+            contiguousEnd = NSMaxRange(block.range)
+            switch block {
+            case .list(_, let items):
+                for item in items {
+                    if needsSeed {
+                        stack = seedIndentStack(above: item.marker.location, in: ns)
+                        needsSeed = false
+                    }
+                    while let top = stack.last, top >= item.indent { stack.removeLast() }
+                    result[item.marker.location] = stack.count
+                    stack.append(item.indent)
+                }
+            case .blank:
+                break                     // blank lines keep the run (spacing, not a reset)
+            case .paragraph(_, let inlines) where inlines.isEmpty:
+                break                     // an empty paragraph line is spacing too
+            default:
+                stack = []                // real text/content ends the run
+                needsSeed = false         // a seed scan would stop on this line anyway
+            }
+        }
+        return result
     }
 
     private static func computeOrderedDisplayNumbers(blocks: [BlockNode], ns: NSString) -> [Int: Int] {
@@ -359,6 +426,10 @@ enum MarkdownASTStyler {
         // Keep the source punctuation (`.` or `)`) when overlaying, so a paren list stays a paren list.
         let orderedPunct = orderedOverlayActive && item.marker.length > 0
             ? ctx.ns.substring(with: NSRange(location: NSMaxRange(item.marker) - 1, length: 1)) : "."
+        // A hidden task in the indent grid collapses its `- ` too (the drawn box
+        // replaces the whole marker slot, LEFT-aligned at the slot origin), so
+        // the slot kern below must measure the marker at its collapsed advance.
+        let gridHiddenTask = ctx.config.lists.markerTextGap != nil && item.checkbox != nil && !taskRevealed
         // Via the memoized measure — list markers are a tiny repeated set (`- `, `1. `).
         let markerWidth: CGFloat = {
             if orderedOverlayActive, let displayNumber {
@@ -366,9 +437,16 @@ enum MarkdownASTStyler {
                                                          length: item.contentRange.location - NSMaxRange(item.marker)))
                 return HeadingHelpers.textWidth("\(displayNumber)\(orderedPunct)" + gap, font: ctx.baseFont)
             }
-            return HeadingHelpers.textWidth(ctx.ns.substring(with: markerGroup), font: ctx.baseFont)
+            return HeadingHelpers.textWidth(ctx.ns.substring(with: markerGroup),
+                                            font: gridHiddenTask ? ctx.inlineMarkerFont : ctx.baseFont)
         }()
+        // Legacy layout derives depth from a fixed 2-columns-per-level divisor;
+        // the grid uses the STRUCTURAL depth (position of this item's indent in
+        // the run's indent ladder) so 3-column ordered nesting steps one level
+        // per parent, not one per two source columns.
         let depthIndent = CGFloat(MarkdownLists.indentLevel(from: ws)) * ctx.config.lists.indentPerLevel
+        let structuralDepth = ctx.listDepths[item.marker.location] ?? MarkdownLists.indentLevel(from: ws)
+        let gridDepthIndent = CGFloat(structuralDepth) * ctx.config.lists.indentPerLevel
         let ps = NSMutableParagraphStyle()
         let lineHeight = ctx.baseLineHeight + ctx.config.lists.extraLineHeight
         ps.minimumLineHeight = lineHeight
@@ -386,14 +464,14 @@ enum MarkdownASTStyler {
             // indentPerLevel stops; a sub-point interval reduces each tab to
             // layout noise instead.
             ps.defaultTabInterval = 0.25
-            ps.firstLineHeadIndent = depthIndent
+            ps.firstLineHeadIndent = gridDepthIndent
             // The slot can widen freely but only narrow until the final spacer
             // char would reach a negative advance (content folding back over
             // the marker glyphs).
             let spacerRange = NSRange(location: item.contentRange.location - 1, length: 1)
             let spacerWidth = HeadingHelpers.textWidth(ctx.ns.substring(with: spacerRange), font: ctx.baseFont)
             let slot = max(gap, markerWidth - spacerWidth + 0.5)
-            ps.headIndent = depthIndent + slot
+            ps.headIndent = gridDepthIndent + slot
             attrs.append((line, [.paragraphStyle: ps]))
             // Collapse the leading whitespace so the SOURCE indent stops being
             // the visual indent — the paragraph indent above owns it now.
@@ -424,11 +502,22 @@ enum MarkdownASTStyler {
         if let box = item.checkbox {
             if taskRevealed { return }
             let spacer = NSRange(location: NSMaxRange(item.marker), length: box.location - NSMaxRange(item.marker))
-            // `- ` keeps full advance (the box's slot, like the bullet `•`);
-            // `[ ]` + trailing space collapse to the hidden-marker font so the
-            // content starts at the bullet-content x.
-            attrs.append((item.marker, [.foregroundColor: NSColor.clear]))
-            if spacer.length > 0 { attrs.append((spacer, [.foregroundColor: NSColor.clear])) }
+            if gridHiddenTask {
+                // Indent grid: the WHOLE `- [ ] ` collapses so the box range's
+                // position IS the marker-slot origin — the drawn square sits
+                // LEFT-aligned there (where a bullet glyph would start) and the
+                // slot kern above already measures the collapsed marker.
+                attrs.append((item.marker, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
+                if spacer.length > 0 {
+                    attrs.append((spacer, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
+                }
+            } else {
+                // `- ` keeps full advance (the box's slot, like the bullet `•`);
+                // `[ ]` + trailing space collapse to the hidden-marker font so the
+                // content starts at the bullet-content x.
+                attrs.append((item.marker, [.foregroundColor: NSColor.clear]))
+                if spacer.length > 0 { attrs.append((spacer, [.foregroundColor: NSColor.clear])) }
+            }
             attrs.append((box, [.taskCheckbox: item.checked, .foregroundColor: NSColor.clear,
                                 .font: ctx.inlineMarkerFont]))
             let postGap = NSRange(location: NSMaxRange(box),
@@ -545,6 +634,9 @@ enum MarkdownASTStyler {
         let wikiLinkID: (NSRange) -> String?
         let scopedRanges: [NSRange]?
         let orderedDisplayNumbers: [Int: Int]
+        /// Structural nesting depth (0-based) per list item, keyed by marker
+        /// location — see `computeListDepths`.
+        let listDepths: [Int: Int]
 
         /// True when a non-empty selection overlaps `range` — the selection
         /// counterpart of `isActive` for elements that reveal on select.

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -404,10 +404,20 @@ enum MarkdownASTStyler {
                 attrs.append((postGap, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
             }
             if item.checked, NSMaxRange(item.range) > NSMaxRange(box) {
-                attrs.append((NSRange(location: NSMaxRange(box), length: NSMaxRange(item.range) - NSMaxRange(box)), [
-                    .strikethroughStyle: NSUnderlineStyle.single.rawValue,
-                    .strikethroughColor: ctx.theme.strikethroughColor,
-                ]))
+                let label = NSRange(location: NSMaxRange(box), length: NSMaxRange(item.range) - NSMaxRange(box))
+                // theme.completedTaskText paints the whole label; inline
+                // constructs (links, code, extension spans) append LATER via
+                // styleInlines, so they keep their own ink — the same
+                // later-range-wins layering the bodyText default relies on.
+                if let completedInk = ctx.theme.completedTaskText {
+                    attrs.append((label, [.foregroundColor: completedInk]))
+                }
+                if ctx.config.taskCheckbox.strikethroughCompletedTasks {
+                    attrs.append((label, [
+                        .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                        .strikethroughColor: ctx.theme.strikethroughColor,
+                    ]))
+                }
             }
         } else if !item.ordered {
             let syntax = NSRange(location: item.marker.location,

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -699,9 +699,23 @@ enum MarkdownASTStyler {
 
     private static func styleCodeBlock(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
         let parts = codeBlockParts(range, ctx.ns)
-        attrs.append((parts.codeRange, [
-            .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: ctx.codeParagraphStyle,
-        ]))
+        let cardMode = ctx.config.codeBlock.cornerRadius != nil
+        if cardMode {
+            // Card mode (CodeBlockStyle.cornerRadius): the fragment paints ONE
+            // continuous rounded card over the whole block, keyed off
+            // `.codeBlockCard` (which carries the block range so each
+            // fragment knows whether it holds the block's first/last line).
+            // No `.backgroundColor` — the square glyph-run fill would sit on
+            // top of the card.
+            attrs.append((parts.codeRange, [
+                .font: ctx.codeFont, .paragraphStyle: ctx.codeParagraphStyle,
+                .codeBlockCard: NSValue(range: parts.codeRange),
+            ]))
+        } else {
+            attrs.append((parts.codeRange, [
+                .font: ctx.codeFont, .backgroundColor: ctx.codeBackground, .paragraphStyle: ctx.codeParagraphStyle,
+            ]))
+        }
         // Suppress spell-check underlines on the whole fenced block — code is not prose.
         attrs.append((parts.codeRange, [.spellingState: 0]))
         let codeContent = ctx.ns.substring(with: parts.content)
@@ -718,6 +732,20 @@ enum MarkdownASTStyler {
             : [.foregroundColor: NSColor.clear, .font: ctx.codeFont]   // hiddenMarkerFont == codeFont
         attrs.append((parts.openFence, markerAttrs))
         attrs.append((parts.closeFence, markerAttrs))
+
+        // Card interior padding: pin the HIDDEN fence lines' height so the
+        // fence rows read as the card's vertical padding above the first and
+        // below the last code line. While the caret reveals the fences they
+        // keep the natural code line height for comfortable editing.
+        if cardMode, let pad = ctx.config.codeBlock.cardVerticalPadding, !ctx.isActive(range) {
+            guard let fencePara = ctx.codeParagraphStyle.mutableCopy() as? NSMutableParagraphStyle else { return }
+            fencePara.minimumLineHeight = pad
+            fencePara.maximumLineHeight = pad
+            attrs.append((ctx.ns.paragraphRange(for: parts.openFence), [.paragraphStyle: fencePara]))
+            if parts.closeFence.length > 0 {
+                attrs.append((ctx.ns.paragraphRange(for: parts.closeFence), [.paragraphStyle: fencePara]))
+            }
+        }
     }
 
     /// Split a fenced-code range into open fence (+language), content, close fence, and language.
@@ -775,7 +803,15 @@ enum MarkdownASTStyler {
                 styleInlines(node.children, font: font, ctx: ctx, into: &attrs)
 
             case .code(let range, let contentRange):
-                attrs.append((contentRange, [.font: ctx.inlineCodeFont, .backgroundColor: ctx.codeBackground]))
+                if ctx.config.inlineCode.chipCornerRadius != nil {
+                    // Chip mode (InlineCodeStyle.chipCornerRadius): the
+                    // fragment paints a rounded chip hugging the span; the
+                    // square glyph-run fill would fight it, so no
+                    // `.backgroundColor` here.
+                    attrs.append((contentRange, [.font: ctx.inlineCodeFont, .inlineCodeChip: true]))
+                } else {
+                    attrs.append((contentRange, [.font: ctx.inlineCodeFont, .backgroundColor: ctx.codeBackground]))
+                }
                 // Suppress spell-check underlines on inline `code` spans (markers + content).
                 attrs.append((range, [.spellingState: 0]))
                 let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(range)

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -39,7 +39,15 @@ enum MarkdownASTStyler {
         let codeFontSize = round(fontSize * configuration.codeBlock.fontSizeScale)
         let hiddenSize = configuration.markers.hiddenMarkerFontSize
         let ns = text as NSString
-        let codeFont = configuration.services.syntaxHighlighter.codeFont(size: codeFontSize)
+        // A configured code face is honored exactly; a name that doesn't
+        // resolve degrades to the syntax-highlighter service's font, so a
+        // typo changes nothing (mirrors HeadingStyle.fontName's fallback).
+        let codeFont = configuration.codeBlock.fontName
+            .flatMap { NSFont(name: $0, size: codeFontSize) }
+            ?? configuration.services.syntaxHighlighter.codeFont(size: codeFontSize)
+        let inlineCodeFont = configuration.inlineCode.fontName
+            .flatMap { NSFont(name: $0, size: codeFontSize) }
+            ?? codeFont
         let codeLineHeight = ceil(codeFont.ascender - codeFont.descender + codeFont.leading)
         let codePara = NSMutableParagraphStyle()
         codePara.lineBreakMode = .byCharWrapping
@@ -62,7 +70,9 @@ enum MarkdownASTStyler {
             baseLineHeight: baseLineHeight,
             baseParagraphSpacing: baseParagraphSpacing,
             codeFont: codeFont,
-            codeBackground: configuration.services.syntaxHighlighter.backgroundColor(),
+            inlineCodeFont: inlineCodeFont,
+            codeBackground: configuration.theme.codeBackground
+                ?? configuration.services.syntaxHighlighter.backgroundColor(),
             codeParagraphStyle: codePara,
             inlineMarkerFont: NSFont(name: fontName, size: hiddenSize) ?? .systemFont(ofSize: hiddenSize),
             caret: caretLocation,
@@ -496,6 +506,7 @@ enum MarkdownASTStyler {
         let baseLineHeight: CGFloat
         let baseParagraphSpacing: CGFloat
         let codeFont: NSFont
+        let inlineCodeFont: NSFont
         let codeBackground: NSColor
         let codeParagraphStyle: NSParagraphStyle
         let inlineMarkerFont: NSFont
@@ -764,11 +775,11 @@ enum MarkdownASTStyler {
                 styleInlines(node.children, font: font, ctx: ctx, into: &attrs)
 
             case .code(let range, let contentRange):
-                attrs.append((contentRange, [.font: ctx.codeFont, .backgroundColor: ctx.codeBackground]))
+                attrs.append((contentRange, [.font: ctx.inlineCodeFont, .backgroundColor: ctx.codeBackground]))
                 // Suppress spell-check underlines on inline `code` spans (markers + content).
                 attrs.append((range, [.spellingState: 0]))
                 let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(range)
-                    ? [.foregroundColor: ctx.theme.mutedText, .font: ctx.codeFont]
+                    ? [.foregroundColor: ctx.theme.mutedText, .font: ctx.inlineCodeFont]
                     : [.foregroundColor: ctx.theme.mutedText.withAlphaComponent(ctx.config.markers.inlineCodeMarkerAlpha),
                        .font: ctx.inlineMarkerFont]
                 for marker in markers(of: range, content: contentRange) { attrs.append((marker, markerAttrs)) }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -548,9 +548,15 @@ enum MarkdownASTStyler {
 
         case .heading(let level, let range, let markers, let inlines):
             let multiplier = ctx.config.headings.fontMultiplier(for: level)
-            let headingBase = NSFont(name: ctx.fontName, size: ctx.baseFont.pointSize * multiplier)
-                ?? .systemFont(ofSize: ctx.baseFont.pointSize * multiplier)
-            let headingFont = adding(.bold, to: headingBase)
+            let headingSize = ctx.baseFont.pointSize * multiplier
+            // A configured heading face is honored exactly — its weight is the
+            // embedder's choice, so no synthetic bold on top. A name that
+            // doesn't resolve degrades to the stock heading font (base family,
+            // bold trait), mirroring TaskCheckboxStyle's symbol fallback.
+            let headingFont = ctx.config.headings.fontName
+                .flatMap { NSFont(name: $0, size: headingSize) }
+                ?? adding(.bold, to: NSFont(name: ctx.fontName, size: headingSize)
+                    ?? .systemFont(ofSize: headingSize))
             let lineHeight = ceil(headingFont.ascender - headingFont.descender + headingFont.leading) + 1
             let headingPara = NSMutableParagraphStyle()
             headingPara.minimumLineHeight = lineHeight
@@ -558,7 +564,15 @@ enum MarkdownASTStyler {
             headingPara.paragraphSpacingBefore = headingFont.pointSize * ctx.config.headings.topSpacingEm(for: level)
             headingPara.paragraphSpacing = ctx.baseParagraphSpacing
             attrs.append((ctx.ns.paragraphRange(for: range), [.paragraphStyle: headingPara]))
-            attrs.append((range, [.font: headingFont]))
+            // theme.headingText paints the whole heading line; the marker loop
+            // and the inline descent below both append LATER, so `#` glyphs
+            // keep headingMarker and links / code keep their own ink — the
+            // same later-range-wins layering the bodyText default relies on.
+            var headingAttrs: [NSAttributedString.Key: Any] = [.font: headingFont]
+            if let headingText = ctx.theme.headingText {
+                headingAttrs[.foregroundColor] = headingText
+            }
+            attrs.append((range, headingAttrs))
             for marker in markers {
                 attrs.append((marker, [.foregroundColor: ctx.theme.headingMarker]))
             }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -631,7 +631,7 @@ enum MarkdownASTStyler {
 
     /// Per-line blockquote: indent, mute content, hide/show `>` markers, tag first char with bar level.
     private static func styleBlockquote(range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]) {
-        let indentPerLevel = MarkdownTextLayoutFragment.blockquoteIndentPerLevel
+        let indentPerLevel = ctx.config.blockquote.textIndent
         var lineStart = range.location
         let end = NSMaxRange(range)
         while lineStart < end {
@@ -674,7 +674,9 @@ enum MarkdownASTStyler {
             attrs.append((ctx.ns.paragraphRange(for: tokenRange), [.paragraphStyle: para]))
 
             if contentRange.length > 0 {
-                attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
+                // theme.blockquoteText lifts the historical muting; inline
+                // constructs append later and keep their own ink either way.
+                attrs.append((contentRange, [.foregroundColor: ctx.theme.blockquoteText ?? ctx.theme.mutedText]))
             }
             if ctx.isActive(tokenRange) {
                 attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -349,11 +349,17 @@ enum MarkdownASTStyler {
         // tasks (the checkbox branch owns those).
         let orderedSyntax = NSRange(location: item.marker.location,
                                     length: item.contentRange.location - item.marker.location)
+        // The per-depth marker style (1. / a. / i. — .numeric everywhere by
+        // default). Only the painted overlay changes; the source stays digits.
+        let markerStyle = ctx.config.lists.orderedMarkerStyle(forDepth: MarkdownLists.indentLevel(from: ws))
         // Also off while the marker is inside a selection: the painter reveals the
         // raw source digits there, so the slot must revert to raw width (else a
         // kerned slot leaves a gap/overlap over the raw digits).
+        // A non-numeric style keeps the overlay on even when the computed number
+        // MATCHES the source digits — `1.` still has to display as `a.`.
         let orderedOverlayActive = item.ordered && item.checkbox == nil && item.number != nil
-            && displayNumber != nil && displayNumber != item.number
+            && displayNumber != nil
+            && (displayNumber != item.number || markerStyle != .numeric)
             && !MarkdownStyler.caretRevealsOrderedMarker(caret: ctx.caret, syntax: orderedSyntax)
             && !ctx.selectionIntersects(orderedSyntax)
         // Keep the source punctuation (`.` or `)`) when overlaying, so a paren list stays a paren list.
@@ -364,7 +370,7 @@ enum MarkdownASTStyler {
             if orderedOverlayActive, let displayNumber {
                 let gap = ctx.ns.substring(with: NSRange(location: NSMaxRange(item.marker),
                                                          length: item.contentRange.location - NSMaxRange(item.marker)))
-                return HeadingHelpers.textWidth("\(displayNumber)\(orderedPunct)" + gap, font: ctx.baseFont)
+                return HeadingHelpers.textWidth(markerStyle.label(for: displayNumber) + orderedPunct + gap, font: ctx.baseFont)
             }
             return HeadingHelpers.textWidth(ctx.ns.substring(with: markerGroup), font: ctx.baseFont)
         }()
@@ -422,12 +428,13 @@ enum MarkdownASTStyler {
             // content baseline down under the pinned line height); spread across
             // all marker chars so every glyph advance stays positive even when
             // the number shrinks (10 → 9).
+            let display = markerStyle.label(for: displayNumber) + orderedPunct
             let sourceW = (ctx.ns.substring(with: item.marker) as NSString)
                 .size(withAttributes: [.font: ctx.baseFont]).width
-            let displayW = ("\(displayNumber)\(orderedPunct)" as NSString)
+            let displayW = (display as NSString)
                 .size(withAttributes: [.font: ctx.baseFont]).width
             var markerAttrs: [NSAttributedString.Key: Any] = [
-                .orderedMarker: "\(displayNumber)\(orderedPunct)", .foregroundColor: NSColor.clear,
+                .orderedMarker: display, .foregroundColor: NSColor.clear,
             ]
             if abs(displayW - sourceW) > 0.01 {
                 markerAttrs[.kern] = (displayW - sourceW) / CGFloat(max(1, item.marker.length))

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -427,9 +427,13 @@ enum MarkdownASTStyler {
         // kerned slot leaves a gap/overlap over the raw digits).
         // A non-numeric style keeps the overlay on even when the computed number
         // MATCHES the source digits — `1.` still has to display as `a.`.
+        // A fixed marker slot (markerSlotWidth on the grid) forces the overlay
+        // too: the painted marker is CENTERED in the slot, and only the
+        // overlay path can place the glyphs off the source position.
+        let slotCentered = ctx.config.lists.effectiveMarkerSlotWidth != nil
         let orderedOverlayActive = item.ordered && item.checkbox == nil && item.number != nil
             && displayNumber != nil
-            && (displayNumber != item.number || markerStyle != .numeric)
+            && (displayNumber != item.number || markerStyle != .numeric || slotCentered)
             && !MarkdownStyler.caretRevealsOrderedMarker(caret: ctx.caret, syntax: orderedSyntax)
             && !ctx.selectionIntersects(orderedSyntax)
         // Keep the source punctuation (`.` or `)`) when overlaying, so a paren list stays a paren list.
@@ -476,10 +480,13 @@ enum MarkdownASTStyler {
             ps.firstLineHeadIndent = gridDepthIndent
             // The slot can widen freely but only narrow until the final spacer
             // char would reach a negative advance (content folding back over
-            // the marker glyphs).
+            // the marker glyphs). With a fixed marker COLUMN configured
+            // (markerSlotWidth), content hangs column + gap after the marker
+            // origin instead of the bare gap.
             let spacerRange = NSRange(location: item.contentRange.location - 1, length: 1)
             let spacerWidth = HeadingHelpers.textWidth(ctx.ns.substring(with: spacerRange), font: ctx.baseFont)
-            let slot = max(gap, markerWidth - spacerWidth + 0.5)
+            let contentOffset = gap + (ctx.config.lists.effectiveMarkerSlotWidth ?? 0)
+            let slot = max(contentOffset, markerWidth - spacerWidth + 0.5)
             ps.headIndent = gridDepthIndent + slot
             attrs.append((line, [.paragraphStyle: ps]))
             // Collapse the leading whitespace so the SOURCE indent stops being

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -61,10 +61,14 @@ extension MarkdownStyler {
 
     private static func themeKeyPrefix(ctx: StylingContext, appearance: NSAppearance) -> String {
         let theme = ctx.configuration.theme
+        func optionalIdentity(_ color: NSColor?) -> String {
+            color.map { "\(ObjectIdentifier($0))" } ?? "nil"
+        }
         let identity = "\(ctx.baseFont.fontName)|\(ctx.baseFont.pointSize)|\(appearance.name.rawValue)|"
             + "\(ObjectIdentifier(theme.bodyText))|\(ObjectIdentifier(theme.mutedText))|"
             + "\(ObjectIdentifier(theme.highlightColor))|\(ObjectIdentifier(ctx.codeBackgroundColor))|"
             + "\(ObjectIdentifier(theme.latexLightModeText))|\(ObjectIdentifier(theme.latexDarkModeText))|"
+            + "\(optionalIdentity(theme.tableHeaderBackground))|\(optionalIdentity(theme.tableRule))|"
             + "\(ObjectIdentifier(type(of: ctx.services.latex)))"
 
         themeKeyLock.lock()
@@ -87,6 +91,8 @@ extension MarkdownStyler {
             colorKey(ctx.codeBackgroundColor, under: appearance),
             colorKey(theme.latexLightModeText, under: appearance),
             colorKey(theme.latexDarkModeText, under: appearance),
+            theme.tableHeaderBackground.map { colorKey($0, under: appearance) } ?? "nil",
+            theme.tableRule.map { colorKey($0, under: appearance) } ?? "nil",
             "\(ObjectIdentifier(type(of: ctx.services.latex)))",
         ].joined(separator: "|")
 
@@ -460,14 +466,17 @@ extension MarkdownStyler {
         let cellVPadding: CGFloat = 6
         let borderWidth: CGFloat = 1
         // Resolve under the real appearance: `.withAlphaComponent()` freezes a dynamic color otherwise.
-        func mutedColor(alpha: CGFloat) -> NSColor {
-            var resolved: NSColor = theme.mutedText
+        func resolved(_ color: NSColor) -> NSColor {
+            var result = color
             appearance.performAsCurrentDrawingAppearance {
-                resolved = theme.mutedText.usingColorSpace(.sRGB) ?? theme.mutedText
+                result = color.usingColorSpace(.sRGB) ?? color
             }
-            return resolved.withAlphaComponent(alpha)
+            return result
         }
-        let borderColor = mutedColor(alpha: 0.5)
+        func mutedColor(alpha: CGFloat) -> NSColor {
+            resolved(theme.mutedText).withAlphaComponent(alpha)
+        }
+        let borderColor = theme.tableRule.map(resolved) ?? mutedColor(alpha: 0.5)
         let baseLineHeight: CGFloat = ceil(baseFont.ascender - baseFont.descender + baseFont.leading)
         let minColumnContentWidth: CGFloat = 16
 
@@ -598,7 +607,7 @@ extension MarkdownStyler {
         }
 
         let alignments = table.alignments
-        let headerFill = mutedColor(alpha: 0.08)
+        let headerFill = theme.tableHeaderBackground.map(resolved) ?? mutedColor(alpha: 0.08)
 
         // Flipped image so AppKit handles the y-flip; a manual transform mirror would flip glyphs too.
         return NSImage(size: size, flipped: true) { _ in

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -152,7 +152,11 @@ extension MarkdownStyler {
         // highlighted under one config and literal under another — those must
         // never share a cached image.
         let extensionKey = ctx.configuration.extensionRegistry.fingerprint
-        let key = (themeKeyPrefix(ctx: ctx, appearance: appearance) + "|x\(extensionKey)|w\(widthKey)|" + source) as NSString
+        // The wrapper radius changes the rendered pixels, so it is part of
+        // the cache identity like every other rendering input.
+        let radiusKey = ctx.configuration.table.cornerRadius
+        let key = (themeKeyPrefix(ctx: ctx, appearance: appearance)
+            + "|x\(extensionKey)|w\(widthKey)|r\(radiusKey)|" + source) as NSString
         if let cached = tableImageCache.object(forKey: key) {
             return (cached, false)
         }
@@ -164,7 +168,8 @@ extension MarkdownStyler {
             latex: ctx.services.latex,
             appearance: appearance,
             availableWidth: availableWidth,
-            extensions: ctx.configuration.extensions
+            extensions: ctx.configuration.extensions,
+            cornerRadius: ctx.configuration.table.cornerRadius
         )
         tableImageCache.setObject(image, forKey: key)
         return (image, true)
@@ -459,7 +464,8 @@ extension MarkdownStyler {
         latex: any LatexRenderer,
         appearance: NSAppearance,
         availableWidth: CGFloat,
-        extensions: [any MarkdownExtension] = []
+        extensions: [any MarkdownExtension] = [],
+        cornerRadius: CGFloat = 0
     ) -> NSImage {
         let columnCount = table.alignments.count
         let cellHPadding: CGFloat = 12
@@ -609,8 +615,29 @@ extension MarkdownStyler {
         let alignments = table.alignments
         let headerFill = theme.tableHeaderBackground.map(resolved) ?? mutedColor(alpha: 0.08)
 
+        // Clamp so tiny tables can't invert the rounded path.
+        let radius = max(0, min(cornerRadius, min(size.width, size.height) / 2 - borderWidth))
+        let outerRect = NSRect(
+            x: borderWidth / 2,
+            y: borderWidth / 2,
+            width: size.width - borderWidth,
+            height: size.height - borderWidth
+        )
+
         // Flipped image so AppKit handles the y-flip; a manual transform mirror would flip glyphs too.
         return NSImage(size: size, flipped: true) { _ in
+            // Rounded wrapper: the outer border stroke runs along the rounded
+            // path, and the interior painting (header fill, separator rule
+            // ends) is clipped to it so nothing pokes out of the corners.
+            let outer = radius > 0
+                ? NSBezierPath(roundedRect: outerRect, xRadius: radius, yRadius: radius)
+                : NSBezierPath(rect: outerRect)
+
+            if radius > 0 {
+                NSGraphicsContext.saveGraphicsState()
+                outer.addClip()
+            }
+
             // Header row fill
             headerFill.setFill()
             NSBezierPath(rect: NSRect(
@@ -619,17 +646,6 @@ extension MarkdownStyler {
                 width: size.width - 2 * borderWidth,
                 height: rowContentHeights[0] + 2 * cellVPadding
             )).fill()
-
-            // Outer border
-            borderColor.setStroke()
-            let outer = NSBezierPath(rect: NSRect(
-                x: borderWidth / 2,
-                y: borderWidth / 2,
-                width: size.width - borderWidth,
-                height: size.height - borderWidth
-            ))
-            outer.lineWidth = borderWidth
-            outer.stroke()
 
             // Internal separators
             let separators = NSBezierPath()
@@ -645,6 +661,14 @@ extension MarkdownStyler {
                 separators.line(to: NSPoint(x: size.width, y: y))
             }
             separators.stroke()
+
+            if radius > 0 { NSGraphicsContext.restoreGraphicsState() }
+
+            // Outer border — stroked unclipped so the rule stays crisp at
+            // the rounded corners.
+            borderColor.setStroke()
+            outer.lineWidth = borderWidth
+            outer.stroke()
 
             func drawCell(_ s: NSAttributedString, col: Int, row: Int) {
                 guard col < columnCount else { return }

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -152,11 +152,13 @@ extension MarkdownStyler {
         // highlighted under one config and literal under another — those must
         // never share a cached image.
         let extensionKey = ctx.configuration.extensionRegistry.fingerprint
-        // The wrapper radius changes the rendered pixels, so it is part of
-        // the cache identity like every other rendering input.
+        // The wrapper radius and rule orientation change the rendered pixels,
+        // so they are part of the cache identity like every other rendering
+        // input.
         let radiusKey = ctx.configuration.table.cornerRadius
+        let verticalRulesKey = ctx.configuration.table.verticalRules ? 1 : 0
         let key = (themeKeyPrefix(ctx: ctx, appearance: appearance)
-            + "|x\(extensionKey)|w\(widthKey)|r\(radiusKey)|" + source) as NSString
+            + "|x\(extensionKey)|w\(widthKey)|r\(radiusKey)|v\(verticalRulesKey)|" + source) as NSString
         if let cached = tableImageCache.object(forKey: key) {
             return (cached, false)
         }
@@ -169,7 +171,8 @@ extension MarkdownStyler {
             appearance: appearance,
             availableWidth: availableWidth,
             extensions: ctx.configuration.extensions,
-            cornerRadius: ctx.configuration.table.cornerRadius
+            cornerRadius: ctx.configuration.table.cornerRadius,
+            verticalRules: ctx.configuration.table.verticalRules
         )
         tableImageCache.setObject(image, forKey: key)
         return (image, true)
@@ -465,7 +468,8 @@ extension MarkdownStyler {
         appearance: NSAppearance,
         availableWidth: CGFloat,
         extensions: [any MarkdownExtension] = [],
-        cornerRadius: CGFloat = 0
+        cornerRadius: CGFloat = 0,
+        verticalRules: Bool = true
     ) -> NSImage {
         let columnCount = table.alignments.count
         let cellHPadding: CGFloat = 12
@@ -647,13 +651,20 @@ extension MarkdownStyler {
                 height: rowContentHeights[0] + 2 * cellVPadding
             )).fill()
 
-            // Internal separators
+            // Internal separators. Stroked in the border color explicitly:
+            // the context's default stroke is black, and the outer border's
+            // setStroke happens later (it moved below the clip restore when
+            // the rounded wrapper landed). Row rules always span the full
+            // inner width; column rules only exist in the full-grid look.
+            borderColor.setStroke()
             let separators = NSBezierPath()
             separators.lineWidth = borderWidth
-            for i in 1..<columnCount {
-                let x = columnLeft[i] - borderWidth / 2
-                separators.move(to: NSPoint(x: x, y: 0))
-                separators.line(to: NSPoint(x: x, y: size.height))
+            if verticalRules {
+                for i in 1..<columnCount {
+                    let x = columnLeft[i] - borderWidth / 2
+                    separators.move(to: NSPoint(x: x, y: 0))
+                    separators.line(to: NSPoint(x: x, y: size.height))
+                }
             }
             for i in 1..<rowCount {
                 let y = rowTop[i] - borderWidth / 2

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CaretWorkarounds.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CaretWorkarounds.swift
@@ -13,6 +13,7 @@ extension NativeTextView {
     override func updateInsertionPointStateAndRestartTimer(_ restartFlag: Bool) {
         super.updateInsertionPointStateAndRestartTimer(restartFlag)
         applyBlockImageCaretPolicy()
+        fixMarkerOnlyLineCaret()
         DispatchQueue.main.async { [weak self] in self?.fixPhantomTrailingCaret() }
     }
 
@@ -74,6 +75,7 @@ extension NativeTextView {
             caretIndicatorObservation = indicator.observe(\.frame, options: [.new]) { [weak self] _, _ in
                 guard let self, !self.isApplyingCaretShift else { return }
                 self.applyBlockImageCaretPolicy()
+                self.fixMarkerOnlyLineCaret()
                 self.fixPhantomTrailingCaret()
             }
         }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
@@ -19,6 +19,7 @@ extension NativeTextView {
            handler(.confirmAndOpen) {
             return true
         }
+        if handleFormattingShortcut(event) { return true }
         return super.performKeyEquivalent(with: event)
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -19,10 +19,11 @@ extension NativeTextView {
             // any set here fights the overlay's cursor (flicker).
             if isEditable { NSCursor.arrow.set() }
         } else if isEditable, isOverTaskCheckboxBox(event) {
-            // The box is a clickable control, not text. super sets the I-beam
-            // on every move, so setting the arrow after it flickers — skip
-            // super entirely, like the exclusion-zone branch.
-            NSCursor.arrow.set()
+            // The box is a clickable control, not text — a click toggles it,
+            // so it reads as a button: pointing hand, like links. super sets
+            // the I-beam on every move, so setting a cursor after it flickers
+            // — skip super entirely, like the exclusion-zone branch.
+            NSCursor.pointingHand.set()
         } else if isEditable, isOverWideTableOverlay(event) {
             // Same treatment for wide-table scroll overlays: the overlay is a
             // control surface (rendered image + horizontal scroller), not
@@ -40,7 +41,7 @@ extension NativeTextView {
         if isInCursorExclusionZone(event) {
             if isEditable { NSCursor.arrow.set() }
         } else if isEditable, isOverTaskCheckboxBox(event) {
-            NSCursor.arrow.set()
+            NSCursor.pointingHand.set()
         } else if isEditable, isOverWideTableOverlay(event) {
             NSCursor.arrow.set()
         } else {
@@ -48,6 +49,27 @@ extension NativeTextView {
             applyReadOnlyCursor(for: event)
             applyInvertedIBeamIfNeeded(for: event)
         }
+    }
+
+    /// NSTextView's own cursor tracking goes quiet while the window isn't
+    /// key, so the checkbox hand (and the read-only link hand) froze on
+    /// whatever cursor was last set when hovering an inactive editor panel.
+    /// One extra `.activeInActiveApp` area keeps `mouseMoved`/`mouseEntered`
+    /// flowing app-wide; the handlers above are idempotent, so overlapping
+    /// with the system areas while the window IS key is harmless.
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let area = inactiveWindowCursorTrackingArea {
+            removeTrackingArea(area)
+        }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInActiveApp, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        inactiveWindowCursorTrackingArea = area
     }
 
     /// True when the pointer is over a wide-table overlay's HORIZONTAL

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FormattingShortcuts.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FormattingShortcuts.swift
@@ -1,0 +1,51 @@
+//
+//  NativeTextView+FormattingShortcuts.swift
+//  MarkdownEngine
+//
+//  Inline-formatting key equivalents, wired to the coordinator's existing
+//  toggleable formatting actions (the same wrap/unwrap logic the context
+//  menu drives):
+//
+//    ⌘B  bold          (`**` wrap/unwrap; ***both*** → *italic*)
+//    ⌘I  italic        (`*` wrap/unwrap)
+//    ⌘E  inline code   (`` ` `` wrap/unwrap)
+//    ⌘⇧K link scaffold (`[text](url)`; plain ⌘K is left untouched — it is
+//                       a common embedder binding, e.g. command palettes)
+//
+//  Gated by `MarkdownEditorConfiguration.formattingShortcutsEnabled`
+//  (default on, like the list helpers). Only exact modifier matches are
+//  consumed, so every other ⌘-combination keeps flowing to menus and the
+//  responder chain.
+//
+
+import AppKit
+
+extension NativeTextView {
+
+    /// Handles an inline-formatting key equivalent. Returns true when the
+    /// event was consumed.
+    func handleFormattingShortcut(_ event: NSEvent) -> Bool {
+        guard configuration.formattingShortcutsEnabled,
+              isEditable,
+              let coordinator = delegate as? NativeTextViewCoordinator,
+              let characters = event.charactersIgnoringModifiers?.lowercased()
+        else { return false }
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        switch (modifiers, characters) {
+        case (.command, "b"):
+            coordinator.didMarkdownBold(nil)
+            return true
+        case (.command, "i"):
+            coordinator.didMarkdownItalic(nil)
+            return true
+        case (.command, "e"):
+            coordinator.didMarkdownInlineCode(nil)
+            return true
+        case ([.command, .shift], "k"):
+            coordinator.didMarkdownLink(nil)
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -319,11 +319,15 @@ extension NativeTextView {
             propagateCaretRevealToEnclosingScroller(range: range)
             return
         }
-        // Only the reading column needs manual reveal; default keeps AppKit's native implementation.
-        guard configuration.readingWidth != nil else {
-            super.scrollRangeToVisible(range)
-            return
-        }
+        // Manual reveal for EVERY .scrolls editor, not only the reading
+        // column: AppKit's native scrollRangeToVisible is unreliable for
+        // off-screen content in a TextKit 2 text view (it routes through the
+        // absent TextKit 1 layout manager — see the find-reveal path, which
+        // learned this first), so typing at the bottom of a small viewport
+        // simply never scrolled. The fragment math below already serves both
+        // layouts: with no reading column the text view fills the container
+        // and `frame.origin.y` is just the header-band offset.
+        //
         // Explicit reveal: native scrollRangeToVisible can't position the container's centered subview.
         // A caret at the document end has no fragment at its location; step back one
         // char there so the last line's fragment is found (else nothing reveals).
@@ -390,9 +394,30 @@ extension NativeTextView {
             } else {
                 return false   // already visible (or a spurious verdict, corrected)
             }
-            cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
-            scrollView.reflectScrolledClipView(cv)
-            (scrollView as? ClampedScrollView)?.clampToInsets()
+            // Clamp the target BEFORE moving so an animated reveal can't fly
+            // past the content and get yanked back by a post-hoc clamp.
+            let container = scrollView.documentView as? NativeTextViewContainer
+            let realHeight = container?.scrollableContentHeight ?? scrollView.documentView?.bounds.height ?? 0
+            let minY = -scrollView.contentInsets.top
+            let maxY = max(minY, realHeight - cv.bounds.height)
+            let clampedTarget = NSPoint(x: cv.bounds.origin.x, y: min(max(targetY, minY), maxY))
+            let duration = self.configuration.caretFollowAnimationDuration
+            if duration > 0, self.window != nil {
+                // Smooth-but-quick caret follow. Interrupting a running
+                // animation with a new animator target is safe: AppKit
+                // retargets from the current presentation value.
+                NSAnimationContext.runAnimationGroup { context in
+                    context.duration = duration
+                    context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                    context.allowsImplicitAnimation = true
+                    cv.animator().setBoundsOrigin(clampedTarget)
+                }
+                scrollView.reflectScrolledClipView(cv)
+            } else {
+                cv.scroll(to: clampedTarget)
+                scrollView.reflectScrolledClipView(cv)
+                (scrollView as? ClampedScrollView)?.clampToInsets()
+            }
             return false
         }
     }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+MarkerOnlyCaret.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+MarkerOnlyCaret.swift
@@ -1,0 +1,74 @@
+//
+//  NativeTextView+MarkerOnlyCaret.swift
+//  MarkdownEngine
+//
+//  Caret x on marker-only list lines in the indent grid.
+//
+//  A fresh list continuation (`- `, `1. `, `- [ ] ` with no content yet)
+//  carries its content offset as a kern on the final spacer character
+//  (see the grid branch of `styleListItem`). Core Text drops the kern on
+//  the last glyph of a line, so while the item is still empty the caret
+//  rect collapses back to the raw marker advance — the insertion point
+//  blinks at the line's left edge while the drawn marker sits in its slot
+//  and the first typed character will land a full slot away. Snap the
+//  insertion indicator to the paragraph's `headIndent`, which in grid
+//  geometry IS the content origin (depth indent + marker slot).
+//
+//  Legacy (nil `markerTextGap`) geometry is untouched: content advance
+//  there comes from real glyph advances, not an end-of-line kern, and the
+//  caret already lands on the content origin.
+//
+
+import AppKit
+
+extension NativeTextView {
+
+    /// The corrected caret x (view coordinates) when the caret sits at the
+    /// end of a marker-only list line in the indent grid, or nil when no
+    /// correction applies.
+    func markerOnlyListCaretX() -> CGFloat? {
+        guard configuration.lists.helpersEnabled,
+              configuration.lists.markerTextGap != nil,
+              let ts = textStorage, ts.length > 0 else { return nil }
+        let sel = selectedRange()
+        guard sel.length == 0, sel.location <= ts.length else { return nil }
+        let ns = ts.string as NSString
+        let paragraph = ns.paragraphRange(for: NSRange(location: min(sel.location, ns.length), length: 0))
+        var line = paragraph
+        while line.length > 0 {
+            let last = ns.character(at: NSMaxRange(line) - 1)
+            guard last == 0x0A || last == 0x0D else { break }
+            line.length -= 1
+        }
+        // Only an end-of-line caret on a non-empty line can be affected —
+        // mid-syntax carets sit before the kerned spacer and are laid out
+        // with real advances.
+        guard line.length > 0, sel.location == NSMaxRange(line) else { return nil }
+        // Marker-only line: the list-marker prefix (the same recognizer the
+        // Enter-continuation logic uses) consumes the whole line.
+        let text = ns.substring(with: line)
+        let textRange = NSRange(location: 0, length: (text as NSString).length)
+        guard let match = MarkdownLists.listRegex.firstMatch(in: text, options: [], range: textRange),
+              match.range(at: 1).length > 0,
+              match.range.location == 0,
+              NSMaxRange(match.range(at: 1)) == textRange.length else { return nil }
+        // In grid geometry the paragraph's headIndent is the content origin
+        // (depth × indentPerLevel + marker slot) — exactly where the first
+        // typed character lands once the spacer kern stops being line-final.
+        guard let style = ts.attribute(.paragraphStyle, at: line.location, effectiveRange: nil) as? NSParagraphStyle,
+              style.headIndent > 0 else { return nil }
+        return textContainerOrigin.x + style.headIndent
+    }
+
+    /// Snap the insertion indicator to the marker-only content origin
+    /// (companion to the caret workarounds' Y-snap; this one fixes X).
+    func fixMarkerOnlyLineCaret() {
+        guard let desiredX = markerOnlyListCaretX(),
+              let indicator = subviews.first(where: { type(of: $0) == NSTextInsertionIndicator.self }),
+              !indicator.isHidden,
+              abs(indicator.frame.origin.x - desiredX) >= 0.5 else { return }
+        isApplyingCaretShift = true
+        indicator.frame.origin.x = desiredX
+        isApplyingCaretShift = false
+    }
+}

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -24,7 +24,9 @@ extension NativeTextView {
         guard let textContainer = textContainer,
               let bridge = layoutBridge,
               let storage = textStorage, storage.length > 0 else { return nil }
-        let boxSize = TaskCheckboxGeometry.size(for: baseFont)
+        let boxSize = TaskCheckboxGeometry.size(
+            for: baseFont, slotWidth: configuration.lists.effectiveMarkerSlotWidth
+        )
         let scan = searchRange ?? NSRange(location: 0, length: storage.length)
         var hit: (range: NSRange, isChecked: Bool)?
         storage.enumerateAttribute(.taskCheckbox, in: scan, options: []) { value, attrRange, stop in

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -31,7 +31,10 @@ extension NativeTextView {
             guard let isChecked = value as? Bool else { return }
             let anchor = bridge.boundingRect(forCharacterRange: attrRange, in: textContainer)
             let rect = CGRect(
-                x: TaskCheckboxGeometry.boxX(contentX: anchor.minX, size: boxSize),
+                x: TaskCheckboxGeometry.boxX(
+                    contentX: anchor.minX, size: boxSize,
+                    markerTextGap: configuration.lists.markerTextGap
+                ),
                 y: anchor.minY,
                 width: boxSize,
                 height: max(anchor.height, boxSize)

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -54,6 +54,12 @@ final class NativeTextView: NSTextView {
     weak var observedCaretIndicator: NSView?
     var isApplyingCaretShift: Bool = false
 
+    // MARK: Cursor-tracking state
+    /// Keeps hover cursors (checkbox hand, read-only link hand) alive while
+    /// the window isn't key; installed by `updateTrackingAreas` in
+    /// `NativeTextView+CursorRects.swift`.
+    var inactiveWindowCursorTrackingArea: NSTrackingArea?
+
     // MARK: Drag-select state
     var dragStartMouseScreenLoc: NSPoint?
 

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -244,6 +244,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.minOverscrollPoints = configuration.overscroll.minPoints
         context.coordinator.configuration = configuration
         textView.insertionPointColor = configuration.theme.bodyText
+        textView.linkTextAttributes = configuration.theme.linkTextAttributes
         textView.isEditable = isEditable
         textView.isSelectable = true
         textView.isRichText = true
@@ -530,6 +531,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.insertionPointColor = isEditable
             ? (context.coordinator.resolvedCaretColor ?? context.coordinator.configuration.theme.bodyText)
             : .clear
+        // Keep the display-time link ink in sync with the theme handed in on
+        // this pass (mirrors the insertionPointColor refresh above).
+        textView.linkTextAttributes = configuration.theme.linkTextAttributes
         let fontChanged = (context.coordinator.fontName != fontName) || (context.coordinator.fontSize != fontSize)
         if let pendingInlineReplacement {
             if pendingInlineReplacement.documentId == documentId,

--- a/Tests/MarkdownEngineTests/BlockquoteStylingTests.swift
+++ b/Tests/MarkdownEngineTests/BlockquoteStylingTests.swift
@@ -1,0 +1,106 @@
+//
+//  BlockquoteStylingTests.swift
+//  MarkdownEngineTests
+//
+//  Blockquote styling knobs: the bar/indent metrics
+//  (`BlockquoteStyle.barWidth` / `textIndent`) and the theme slots
+//  (`blockquoteBar`, `blockquoteText`). Defaults must reproduce the previous
+//  hard-coded constants (3pt bar, 18pt indent, muted content) exactly.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Blockquote styling knobs")
+struct BlockquoteStylingTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private func style(
+        _ text: String,
+        theme: MarkdownEditorTheme = .default,
+        blockquote: BlockquoteStyle = .default,
+        caret: Int = -1
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: caret,
+            configuration: MarkdownEditorConfiguration(theme: theme, blockquote: blockquote)
+        )
+    }
+
+    private func paragraphStyle(in attrs: [StyledRange], at pos: Int) -> NSParagraphStyle? {
+        var result: NSParagraphStyle?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+        }
+        return result
+    }
+
+    private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.foregroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    // MARK: - Metrics
+
+    @Test("defaults reproduce the previous hard-coded constants")
+    func defaultsMatchHistoricalConstants() {
+        #expect(BlockquoteStyle.default.barWidth == 3)
+        #expect(BlockquoteStyle.default.textIndent == 18)
+
+        // Level 1 text hangs at 1 × 18 + 9 = 27pt, exactly as before.
+        let attrs = style("> quoted line\n")
+        let ps = paragraphStyle(in: attrs, at: 2)
+        #expect(abs((ps?.firstLineHeadIndent ?? 0) - 27) < 0.01)
+        #expect(abs((ps?.headIndent ?? 0) - 27) < 0.01)
+    }
+
+    @Test("textIndent drives the hanging indent per nesting level")
+    func textIndentDrivesHangingIndent() {
+        let narrow = BlockquoteStyle(textIndent: 12)
+        let single = style("> quoted line\n", blockquote: narrow)
+        let ps1 = paragraphStyle(in: single, at: 2)
+        #expect(abs((ps1?.firstLineHeadIndent ?? 0) - (12 + 6)) < 0.01)
+
+        let nested = style(">> deep quote\n", blockquote: narrow)
+        let ps2 = paragraphStyle(in: nested, at: 3)
+        #expect(abs((ps2?.firstLineHeadIndent ?? 0) - (24 + 6)) < 0.01)
+    }
+
+    // MARK: - Theme slots
+
+    @Test("blockquoteText lifts the historical muting; nil keeps it")
+    func blockquoteTextSlot() {
+        let text = "> quoted line\n"
+        let contentPos = (text as NSString).range(of: "quoted").location
+
+        let muted = style(text)
+        #expect(color(in: muted, at: contentPos) == MarkdownEditorTheme.default.mutedText)
+
+        let bodyInk = NSColor(calibratedWhite: 0.9, alpha: 1)
+        let restyled = style(text, theme: MarkdownEditorTheme(blockquoteText: bodyInk))
+        #expect(color(in: restyled, at: contentPos) == bodyInk)
+    }
+
+    @Test("the revealed > marker stays muted even with a custom content ink")
+    func revealedMarkerStaysMuted() {
+        let text = "> quoted line\n"
+        let bodyInk = NSColor(calibratedWhite: 0.9, alpha: 1)
+        // Caret on the line reveals the marker.
+        let attrs = style(text, theme: MarkdownEditorTheme(blockquoteText: bodyInk), caret: 3)
+        #expect(color(in: attrs, at: 0) == MarkdownEditorTheme.default.mutedText)
+    }
+
+    @Test("bar theme slot defaults to nil and carries a custom ink")
+    func blockquoteBarSlot() {
+        #expect(MarkdownEditorTheme.default.blockquoteBar == nil)
+        let brand = NSColor(calibratedRed: 1, green: 0.8, blue: 0.81, alpha: 1)
+        #expect(MarkdownEditorTheme(blockquoteBar: brand).blockquoteBar == brand)
+    }
+}

--- a/Tests/MarkdownEngineTests/CaretFollowScrollTests.swift
+++ b/Tests/MarkdownEngineTests/CaretFollowScrollTests.swift
@@ -1,0 +1,124 @@
+//
+//  CaretFollowScrollTests.swift
+//  MarkdownEngineTests
+//
+//  Caret-follow in `.scrolls` mode: `scrollRangeToVisible` must reveal an
+//  off-screen caret through the engine's manual TextKit-2 fragment reveal —
+//  AppKit's native implementation routes through the absent TextKit 1 layout
+//  manager and silently no-ops for off-screen content, so typing at the
+//  bottom of a small viewport never scrolled. Also pins the
+//  `caretFollowAnimationDuration` knob's default (0 = instant, the
+//  historical behavior).
+//
+//  Headless: no window, so the animated branch (which requires a window) is
+//  never taken and reveals apply instantly — deterministic assertions.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Caret follow in .scrolls mode")
+struct CaretFollowScrollTests {
+
+    private func makeStack(
+        lines: Int = 30,
+        viewport: NSSize = NSSize(width: 360, height: 300)
+    ) -> HeightBehaviorStack {
+        _ = NSApplication.shared
+        let stack = HeightBehaviorStack(viewport: viewport, heightBehavior: .scrolls)
+        let tv = stack.textView
+        tv.string = (1...lines).map { "line number \($0)" }.joined(separator: "\n")
+        if let tlm = tv.textLayoutManager {
+            tv.layoutBridge = LayoutBridge(tlm)
+        }
+        tv.recalcOverscroll(for: stack.scrollView)
+        stack.scrollView.layoutSubtreeIfNeeded()
+        return stack
+    }
+
+    @Test("the animation knob defaults to instant")
+    func animationDefaultsToZero() {
+        #expect(MarkdownEditorConfiguration.default.caretFollowAnimationDuration == 0)
+        // Negative durations clamp to instant rather than trapping later.
+        let config = MarkdownEditorConfiguration(caretFollowAnimationDuration: -1)
+        #expect(config.caretFollowAnimationDuration == 0)
+    }
+
+    @Test("revealing an off-screen caret scrolls it into the viewport")
+    func revealAtBottomScrolls() {
+        let stack = makeStack()
+        let tv = stack.textView
+        let cv = stack.scrollView.contentView
+        #expect(cv.bounds.origin.y == 0)
+
+        let end = (tv.string as NSString).length
+        tv.setSelectedRange(NSRange(location: end, length: 0))
+        tv.scrollRangeToVisible(NSRange(location: end, length: 0))
+
+        // The clip view moved down, and the last line's rect now sits inside
+        // the visible band.
+        let y = cv.bounds.origin.y
+        #expect(y > 0)
+        guard let tlm = tv.textLayoutManager,
+              let loc = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: end - 1)
+        else {
+            Issue.record("no layout manager")
+            return
+        }
+        var lineRect = CGRect.zero
+        tlm.enumerateTextSegments(in: NSTextRange(location: loc), type: .standard, options: []) { _, rect, _, _ in
+            lineRect = rect
+            return false
+        }
+        let lineInDoc = lineRect.offsetBy(dx: 0, dy: tv.frame.origin.y)
+        #expect(lineInDoc.maxY <= cv.bounds.origin.y + cv.bounds.height + 0.5)
+        #expect(lineInDoc.minY >= cv.bounds.origin.y - 0.5)
+    }
+
+    @Test("an already-visible caret does not move the viewport")
+    func visibleCaretDoesNotScroll() {
+        let stack = makeStack()
+        let tv = stack.textView
+        let cv = stack.scrollView.contentView
+
+        tv.setSelectedRange(NSRange(location: 0, length: 0))
+        tv.scrollRangeToVisible(NSRange(location: 0, length: 0))
+        #expect(cv.bounds.origin.y == 0)
+    }
+
+    @Test("revealing an off-screen caret above the viewport scrolls back up")
+    func revealAboveScrollsUp() {
+        let stack = makeStack()
+        let tv = stack.textView
+        let cv = stack.scrollView.contentView
+
+        // Park the viewport at the bottom first.
+        let end = (tv.string as NSString).length
+        tv.scrollRangeToVisible(NSRange(location: end, length: 0))
+        let bottomY = cv.bounds.origin.y
+        #expect(bottomY > 0)
+
+        tv.scrollRangeToVisible(NSRange(location: 0, length: 0))
+        #expect(cv.bounds.origin.y < bottomY)
+        // The first line is at the document top: the reveal target clamps to
+        // the inset origin instead of overshooting negative.
+        #expect(cv.bounds.origin.y <= 0)
+    }
+
+    @Test("the reveal target clamps to the scrollable content")
+    func revealClampsToContent() {
+        let stack = makeStack()
+        let tv = stack.textView
+        let cv = stack.scrollView.contentView
+        let container = stack.scrollView.documentView as? NativeTextViewContainer
+
+        let end = (tv.string as NSString).length
+        tv.scrollRangeToVisible(NSRange(location: end, length: 0))
+
+        let realHeight = container?.scrollableContentHeight ?? 0
+        let maxY = max(-stack.scrollView.contentInsets.top, realHeight - cv.bounds.height)
+        #expect(cv.bounds.origin.y <= maxY + 0.5)
+    }
+}

--- a/Tests/MarkdownEngineTests/CheckboxCursorTrackingTests.swift
+++ b/Tests/MarkdownEngineTests/CheckboxCursorTrackingTests.swift
@@ -1,0 +1,47 @@
+//
+//  CheckboxCursorTrackingTests.swift
+//  MarkdownEngineTests
+//
+//  The app-wide cursor tracking area that keeps the checkbox pointing hand
+//  (and the read-only link hand) alive while the editor's window isn't key.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Checkbox cursor tracking")
+struct CheckboxCursorTrackingTests {
+
+    @Test("updateTrackingAreas installs one app-active mouse-moved area")
+    func trackingAreaInstalled() {
+        let view = NativeTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        view.updateTrackingAreas()
+        let area = view.inactiveWindowCursorTrackingArea
+        #expect(area != nil)
+        if let area {
+            #expect(view.trackingAreas.contains(area))
+            #expect(area.options.contains(.mouseMoved))
+            #expect(area.options.contains(.mouseEnteredAndExited))
+            #expect(area.options.contains(.activeInActiveApp))
+            #expect(area.options.contains(.inVisibleRect))
+        }
+    }
+
+    @Test("repeated updates replace the area instead of stacking")
+    func trackingAreaReplaced() {
+        let view = NativeTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        view.updateTrackingAreas()
+        let first = view.inactiveWindowCursorTrackingArea
+        view.updateTrackingAreas()
+        let second = view.inactiveWindowCursorTrackingArea
+        #expect(second != nil)
+        #expect(first !== second)
+        if let first {
+            #expect(!view.trackingAreas.contains(first))
+        }
+        let ours = view.trackingAreas.filter { $0.options.contains(.activeInActiveApp) }
+        #expect(ours.count == 1)
+    }
+}

--- a/Tests/MarkdownEngineTests/CodeBlockCardTests.swift
+++ b/Tests/MarkdownEngineTests/CodeBlockCardTests.swift
@@ -1,0 +1,143 @@
+//
+//  CodeBlockCardTests.swift
+//  MarkdownEngineTests
+//
+//  Card rendering for fenced code blocks (`CodeBlockStyle.cornerRadius` +
+//  `cardVerticalPadding`) and chip rendering for inline code spans
+//  (`InlineCodeStyle.chipCornerRadius`). Both are opt-in; the defaults must
+//  keep the historical `.backgroundColor` glyph-run fills exactly.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Code block card and inline code chips")
+struct CodeBlockCardTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private func style(_ text: String, _ config: MarkdownEditorConfiguration = .default,
+                       caret: Int = -1) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            caretLocation: caret, configuration: config
+        )
+    }
+
+    private var cardConfig: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(
+            codeBlock: CodeBlockStyle(cornerRadius: 8, cardVerticalPadding: 16)
+        )
+    }
+
+    private var chipConfig: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(
+            inlineCode: InlineCodeStyle(chipCornerRadius: 4, chipHorizontalPadding: 3)
+        )
+    }
+
+    private let fenced = "```swift\nlet x = 1\n```\n"
+
+    // MARK: - Defaults preserved
+
+    @Test("nil cornerRadius keeps the historical background attribute and no card tag")
+    func defaultKeepsBackgroundColor() {
+        let attrs = style(fenced)
+        let codePos = (fenced as NSString).range(of: "let x").location
+        let hasBackground = attrs.contains { range, a in
+            NSLocationInRange(codePos, range) && a[.backgroundColor] != nil
+        }
+        let hasCard = attrs.contains { _, a in a[.codeBlockCard] != nil }
+        #expect(hasBackground)
+        #expect(!hasCard)
+    }
+
+    @Test("nil chipCornerRadius keeps the historical inline-code background and no chip tag")
+    func defaultKeepsInlineBackground() {
+        let text = "some `code` here\n"
+        let attrs = style(text)
+        let codePos = (text as NSString).range(of: "code").location
+        let hasBackground = attrs.contains { range, a in
+            NSLocationInRange(codePos, range) && a[.backgroundColor] != nil
+        }
+        let hasChip = attrs.contains { _, a in a[.inlineCodeChip] != nil }
+        #expect(hasBackground)
+        #expect(!hasChip)
+    }
+
+    // MARK: - Card mode
+
+    @Test("card mode tags the whole block and drops the square background fill")
+    func cardModeTagsBlock() {
+        let attrs = style(fenced, cardConfig)
+        let ns = fenced as NSString
+        let codePos = ns.range(of: "let x").location
+
+        var cardRange: NSRange?
+        for (range, a) in attrs where a[.codeBlockCard] != nil {
+            cardRange = (a[.codeBlockCard] as? NSValue)?.rangeValue
+            #expect(NSLocationInRange(codePos, range))
+        }
+        // The tag carries the block range: opening fence through closing fence.
+        #expect(cardRange?.location == 0)
+        #expect(cardRange.map { NSMaxRange($0) } == ns.range(of: "```", options: .backwards).length + ns.range(of: "```", options: .backwards).location)
+
+        let hasBackground = attrs.contains { range, a in
+            NSLocationInRange(codePos, range) && a[.backgroundColor] != nil
+        }
+        #expect(!hasBackground)
+    }
+
+    @Test("card padding pins the hidden fence lines' height and lifts while the caret reveals them")
+    func cardPaddingPinsFenceLines() {
+        let ns = fenced as NSString
+
+        // Effective paragraph style on the opening fence (last range wins).
+        func fenceStyle(_ attrs: [StyledRange]) -> NSParagraphStyle? {
+            var result: NSParagraphStyle?
+            for (range, a) in attrs where NSLocationInRange(0, range) {
+                if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+            }
+            return result
+        }
+
+        // Hidden fences: pinned to the padding.
+        let hidden = fenceStyle(style(fenced, cardConfig))
+        #expect(hidden?.minimumLineHeight == 16)
+        #expect(hidden?.maximumLineHeight == 16)
+
+        // Caret inside the block: fences reveal at their natural code height.
+        let active = fenceStyle(style(fenced, cardConfig, caret: ns.range(of: "let x").location))
+        #expect(active != nil)
+        #expect(active?.minimumLineHeight != 16)
+    }
+
+    // MARK: - Chip mode
+
+    @Test("chip mode tags the span content and drops the square background fill")
+    func chipModeTagsSpan() {
+        let text = "some `code` here\n"
+        let attrs = style(text, chipConfig)
+        let ns = text as NSString
+        let contentRange = ns.range(of: "code")
+
+        let chip = attrs.first { _, a in (a[.inlineCodeChip] as? Bool) == true }
+        #expect(chip?.0 == contentRange)
+        let hasBackground = attrs.contains { range, a in
+            NSLocationInRange(contentRange.location, range) && a[.backgroundColor] != nil
+        }
+        #expect(!hasBackground)
+    }
+
+    // MARK: - Theme slot
+
+    @Test("inlineCodeBackground defaults to nil and is carried by the theme")
+    func inlineCodeBackgroundSlot() {
+        #expect(MarkdownEditorTheme.default.inlineCodeBackground == nil)
+        let themed = MarkdownEditorTheme(inlineCodeBackground: .systemTeal)
+        #expect(themed.inlineCodeBackground == .systemTeal)
+    }
+}

--- a/Tests/MarkdownEngineTests/CodeFontThemingTests.swift
+++ b/Tests/MarkdownEngineTests/CodeFontThemingTests.swift
@@ -1,0 +1,131 @@
+//
+//  CodeFontThemingTests.swift
+//  MarkdownEngineTests
+//
+//  Code typography and background knobs: `CodeBlockStyle.fontName`,
+//  `InlineCodeStyle.fontName`, and the `MarkdownEditorTheme.codeBackground`
+//  slot. Defaults must keep the syntax-highlighter service's font and
+//  background exactly as before.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Code font and background knobs")
+struct CodeFontThemingTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+    /// A face that ships with macOS and is not the mono default.
+    private let customFace = "Menlo-Regular"
+
+    private func style(
+        _ text: String, configuration: MarkdownEditorConfiguration = .default
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: configuration
+        )
+    }
+
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    private func background(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.backgroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    // MARK: - Fonts
+
+    @Test("nil fontName keeps the service's code font in blocks and inline")
+    func defaultsKeepServiceFont() {
+        let expected = MarkdownEditorServices.default.syntaxHighlighter
+            .codeFont(size: round(base * 0.85))
+
+        let block = style("```\nlet x = 1\n```\n")
+        #expect(font(in: block, at: 6)?.fontName == expected.fontName)
+
+        let text = "some `code` here\n"
+        let inline = style(text)
+        let pos = (text as NSString).range(of: "code").location
+        #expect(font(in: inline, at: pos)?.fontName == expected.fontName)
+    }
+
+    @Test("codeBlock.fontName swaps the block face; inline follows by default")
+    func codeBlockFontNameAppliesToBoth() {
+        let config = MarkdownEditorConfiguration(codeBlock: CodeBlockStyle(fontName: customFace))
+
+        let block = style("```\nlet x = 1\n```\n", configuration: config)
+        #expect(font(in: block, at: 6)?.fontName == customFace)
+
+        let text = "some `code` here\n"
+        let inline = style(text, configuration: config)
+        let pos = (text as NSString).range(of: "code").location
+        #expect(font(in: inline, at: pos)?.fontName == customFace)
+    }
+
+    @Test("inlineCode.fontName overrides inline spans independently")
+    func inlineCodeFontNameOverridesInline() {
+        let config = MarkdownEditorConfiguration(
+            inlineCode: InlineCodeStyle(fontName: customFace)
+        )
+        let serviceFont = MarkdownEditorServices.default.syntaxHighlighter
+            .codeFont(size: round(base * 0.85))
+
+        let text = "some `code` here\n"
+        let inline = style(text, configuration: config)
+        let pos = (text as NSString).range(of: "code").location
+        #expect(font(in: inline, at: pos)?.fontName == customFace)
+
+        // Blocks stay on the service font.
+        let block = style("```\nlet x = 1\n```\n", configuration: config)
+        #expect(font(in: block, at: 6)?.fontName == serviceFont.fontName)
+    }
+
+    @Test("an unresolvable name degrades to the service font")
+    func unresolvableNameFallsBack() {
+        let config = MarkdownEditorConfiguration(
+            codeBlock: CodeBlockStyle(fontName: "NoSuchFace-Regular")
+        )
+        let expected = MarkdownEditorServices.default.syntaxHighlighter
+            .codeFont(size: round(base * 0.85))
+        let block = style("```\nlet x = 1\n```\n", configuration: config)
+        #expect(font(in: block, at: 6)?.fontName == expected.fontName)
+    }
+
+    // MARK: - Background
+
+    @Test("codeBackground slot replaces the service background; nil keeps it")
+    func codeBackgroundSlot() {
+        #expect(MarkdownEditorTheme.default.codeBackground == nil)
+
+        let serviceBackground = MarkdownEditorServices.default.syntaxHighlighter.backgroundColor()
+        let stock = style("```\nlet x = 1\n```\n")
+        #expect(background(in: stock, at: 6) == serviceBackground)
+
+        let card = NSColor(calibratedWhite: 0.15, alpha: 1)
+        let themed = style(
+            "```\nlet x = 1\n```\n",
+            configuration: MarkdownEditorConfiguration(theme: MarkdownEditorTheme(codeBackground: card))
+        )
+        #expect(background(in: themed, at: 6) == card)
+
+        let text = "some `code` here\n"
+        let inline = style(
+            text,
+            configuration: MarkdownEditorConfiguration(theme: MarkdownEditorTheme(codeBackground: card))
+        )
+        let pos = (text as NSString).range(of: "code").location
+        #expect(background(in: inline, at: pos) == card)
+    }
+}

--- a/Tests/MarkdownEngineTests/FormattingShortcutTests.swift
+++ b/Tests/MarkdownEngineTests/FormattingShortcutTests.swift
@@ -1,0 +1,140 @@
+//
+//  FormattingShortcutTests.swift
+//  MarkdownEngineTests
+//
+//  Inline-formatting key equivalents (⌘B/⌘I/⌘E/⌘⇧K) dispatching to the
+//  coordinator's toggleable formatting actions, and the
+//  `formattingShortcutsEnabled` gate. The wrap/unwrap semantics themselves
+//  are covered by FormattingActionTests.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Formatting shortcuts")
+struct FormattingShortcutTests {
+
+    private func makeEditor(
+        _ text: String,
+        selection: NSRange,
+        configure: (inout MarkdownEditorConfiguration) -> Void = { _ in }
+    ) -> (NativeTextView, NativeTextViewCoordinator) {
+        // The coordinator's selection-change delegate reads NSApp.currentEvent;
+        // headless test bundles must materialize the shared app first.
+        _ = NSApplication.shared
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        textView.isEditable = true
+        var config = MarkdownEditorConfiguration.default
+        configure(&config)
+        textView.configuration = config
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(""),
+            fontName: "SF Pro Text",
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        coordinator.textView = textView
+        coordinator.configuration = config
+        textView.delegate = coordinator
+        textView.string = text
+        textView.setSelectedRange(selection)
+        return (textView, coordinator)
+    }
+
+    private func keyEvent(_ character: String, modifiers: NSEvent.ModifierFlags) -> NSEvent {
+        NSEvent.keyEvent(
+            with: .keyDown, location: .zero, modifierFlags: modifiers,
+            timestamp: 0, windowNumber: 0, context: nil,
+            characters: character, charactersIgnoringModifiers: character,
+            isARepeat: false, keyCode: 0
+        )!
+    }
+
+    // MARK: - Dispatch
+
+    @Test("⌘B wraps the selection in bold markers")
+    func commandBWraps() {
+        let (tv, _) = makeEditor("hello world", selection: NSRange(location: 0, length: 5))
+        #expect(tv.handleFormattingShortcut(keyEvent("b", modifiers: .command)))
+        #expect(tv.string == "**hello** world")
+        #expect(tv.selectedRange() == NSRange(location: 2, length: 5))
+    }
+
+    @Test("⌘B unwraps an already-bold target (toggle)")
+    func commandBToggles() {
+        let (tv, _) = makeEditor("aa **bb** cc", selection: NSRange(location: 5, length: 2))
+        #expect(tv.handleFormattingShortcut(keyEvent("b", modifiers: .command)))
+        #expect(tv.string == "aa bb cc")
+    }
+
+    @Test("⌘I wraps and unwraps italics")
+    func commandIToggles() {
+        let (tv, _) = makeEditor("hello world", selection: NSRange(location: 0, length: 5))
+        #expect(tv.handleFormattingShortcut(keyEvent("i", modifiers: .command)))
+        #expect(tv.string == "*hello* world")
+        tv.setSelectedRange(NSRange(location: 1, length: 5))
+        #expect(tv.handleFormattingShortcut(keyEvent("i", modifiers: .command)))
+        #expect(tv.string == "hello world")
+    }
+
+    @Test("⌘E wraps the selection in inline code")
+    func commandEWrapsCode() {
+        let (tv, _) = makeEditor("run this now", selection: NSRange(location: 4, length: 4))
+        #expect(tv.handleFormattingShortcut(keyEvent("e", modifiers: .command)))
+        #expect(tv.string == "run `this` now")
+    }
+
+    @Test("⌘⇧K inserts the link scaffold around the selection")
+    func commandShiftKLinks() {
+        let (tv, _) = makeEditor("visit here today", selection: NSRange(location: 6, length: 4))
+        #expect(tv.handleFormattingShortcut(keyEvent("k", modifiers: [.command, .shift])))
+        #expect(tv.string.contains("[here]("))
+    }
+
+    // MARK: - Events that must keep flowing
+
+    @Test("plain ⌘K is never consumed (embedder binding)")
+    func plainCommandKPassesThrough() {
+        let (tv, _) = makeEditor("visit here today", selection: NSRange(location: 6, length: 4))
+        #expect(!tv.handleFormattingShortcut(keyEvent("k", modifiers: .command)))
+        #expect(tv.string == "visit here today")
+    }
+
+    @Test("extra modifiers pass through")
+    func extraModifiersPassThrough() {
+        let (tv, _) = makeEditor("hello", selection: NSRange(location: 0, length: 5))
+        #expect(!tv.handleFormattingShortcut(keyEvent("b", modifiers: [.command, .option])))
+        #expect(!tv.handleFormattingShortcut(keyEvent("b", modifiers: [.command, .shift])))
+        #expect(tv.string == "hello")
+    }
+
+    @Test("the gate turns every shortcut off")
+    func gateDisablesShortcuts() {
+        let (tv, _) = makeEditor("hello", selection: NSRange(location: 0, length: 5)) {
+            $0.formattingShortcutsEnabled = false
+        }
+        #expect(!tv.handleFormattingShortcut(keyEvent("b", modifiers: .command)))
+        #expect(!tv.handleFormattingShortcut(keyEvent("i", modifiers: .command)))
+        #expect(!tv.handleFormattingShortcut(keyEvent("e", modifiers: .command)))
+        #expect(!tv.handleFormattingShortcut(keyEvent("k", modifiers: [.command, .shift])))
+        #expect(tv.string == "hello")
+    }
+
+    @Test("read-only editors don't consume the keys")
+    func readOnlyPassesThrough() {
+        let (tv, _) = makeEditor("hello", selection: NSRange(location: 0, length: 5))
+        tv.isEditable = false
+        #expect(!tv.handleFormattingShortcut(keyEvent("b", modifiers: .command)))
+        #expect(tv.string == "hello")
+    }
+
+    @Test("shortcuts default on")
+    func defaultsOn() {
+        #expect(MarkdownEditorConfiguration.default.formattingShortcutsEnabled)
+    }
+}

--- a/Tests/MarkdownEngineTests/HeadingFontAndColorTests.swift
+++ b/Tests/MarkdownEngineTests/HeadingFontAndColorTests.swift
@@ -1,0 +1,179 @@
+//
+//  HeadingFontAndColorTests.swift
+//  MarkdownEngineTests
+//
+//  The two opt-in heading knobs: `HeadingStyle.fontName` (a dedicated heading
+//  typeface) and `MarkdownEditorTheme.headingText` (a dedicated heading text
+//  color). Both default to nil, which must keep the stock styling unchanged —
+//  headings derive from the base font with the bold trait and inherit the
+//  view-level bodyText foreground.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Heading font & color knobs")
+struct HeadingFontAndColorTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// A real, always-installed face that differs from the system font in both
+    /// family and weight, so assertions can see it was used verbatim.
+    private let headingFace = "Menlo-Regular"
+
+    /// Effective font at `pos`: the last styled range covering it that sets `.font`.
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
+    private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.foregroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    private func style(
+        _ text: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, configuration: configuration
+        )
+    }
+
+    // MARK: - HeadingStyle.fontName
+
+    @Test("headings.fontName renders headings in that face at the multiplied size")
+    func headingFontNameUsedVerbatimAtMultipliedSize() {
+        let config = MarkdownEditorConfiguration(headings: HeadingStyle(fontName: headingFace))
+        // "# One\n\nbody\n\n## Two": O=2, b=7, T=16
+        let attrs = style("# One\n\nbody\n\n## Two", configuration: config)
+
+        let h1 = font(in: attrs, at: 2)
+        #expect(h1?.fontName == headingFace)
+        #expect(h1?.pointSize == base * 2.0)
+        // The face is honored exactly: no synthetic bold on the chosen weight.
+        #expect(h1?.fontDescriptor.symbolicTraits.contains(.bold) == false)
+
+        // Per-level multipliers still apply to the custom face.
+        let h2 = font(in: attrs, at: 16)
+        #expect(h2?.fontName == headingFace)
+        #expect(h2?.pointSize == base * 1.5)
+
+        // Body text never takes the heading face (no .font range at all).
+        #expect(font(in: attrs, at: 7) == nil)
+    }
+
+    @Test("emphasis inside a custom-face heading keeps family and size, adds traits")
+    func emphasisComposesOnTheCustomHeadingFace() {
+        let config = MarkdownEditorConfiguration(headings: HeadingStyle(fontName: headingFace))
+        // "# **n*o*des**": n=4, o=6, d=8
+        let attrs = style("# **n*o*des**", configuration: config)
+        let n = font(in: attrs, at: 4)
+        let o = font(in: attrs, at: 6)
+        let d = font(in: attrs, at: 8)
+
+        #expect(n?.familyName == "Menlo")
+        #expect(o?.familyName == "Menlo")
+        #expect(d?.familyName == "Menlo")
+        #expect(n?.pointSize == base * 2.0)
+        #expect(o?.pointSize == base * 2.0)
+        #expect(d?.pointSize == base * 2.0)
+        #expect(n?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+        #expect(o?.fontDescriptor.symbolicTraits.contains([.bold, .italic]) == true)
+        #expect(d?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test("an unresolvable fontName falls back to the stock heading font")
+    func unresolvableFontNameFallsBack() {
+        let config = MarkdownEditorConfiguration(
+            headings: HeadingStyle(fontName: "Not-A-Real-Font-Face")
+        )
+        let stock = font(in: style("# Title"), at: 2)
+        let fallback = font(in: style("# Title", configuration: config), at: 2)
+        #expect(fallback == stock)
+        #expect(fallback?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    // MARK: - MarkdownEditorTheme.headingText
+
+    @Test("theme.headingText colors heading text; # markers and body keep their own ink")
+    func headingTextColorsContentOnly() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# Title\n\nbody": marker=0..1, T=2, b=8
+        let attrs = style("# Title\n\nbody", configuration: config)
+
+        #expect(color(in: attrs, at: 2) == .systemPink)
+        // The `#` marker glyphs stay on headingMarker (the separate knob).
+        #expect(color(in: attrs, at: 0) == theme.headingMarker)
+        // Body text still inherits the view-level bodyText (no styled foreground).
+        #expect(color(in: attrs, at: 8) == nil)
+    }
+
+    @Test("a link inside a colored heading keeps the link ink")
+    func linkInsideColoredHeadingKeepsLinkColor() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# [x](https://e.com)": x=3
+        let attrs = style("# [x](https://e.com)", configuration: config)
+        #expect(color(in: attrs, at: 3) == theme.link)
+    }
+
+    @Test("emphasis inside a colored heading keeps the heading color")
+    func emphasisInsideColoredHeadingKeepsHeadingColor() {
+        var theme = MarkdownEditorTheme.default
+        theme.headingText = .systemPink
+        let config = MarkdownEditorConfiguration(theme: theme)
+        // "# **bold**": b=4 — emphasis composes fonts only, so the ink survives.
+        let attrs = style("# **bold**", configuration: config)
+        #expect(color(in: attrs, at: 4) == .systemPink)
+    }
+
+    // MARK: - Defaults stay byte-identical
+
+    @Test("nil knobs: heading content carries the stock font and no foreground")
+    func nilKnobsKeepStockHeadingAttributes() {
+        // "# Title": T=2
+        let attrs = style("# Title")
+        let heading = font(in: attrs, at: 2)
+        let stock = NSFont(name: fontName, size: base * 2.0) ?? .systemFont(ofSize: base * 2.0)
+        let stockBold = NSFont(
+            descriptor: stock.fontDescriptor.withSymbolicTraits(
+                stock.fontDescriptor.symbolicTraits.union(.bold)),
+            size: stock.pointSize
+        ) ?? stock
+        #expect(heading == stockBold)
+        // No styled range sets a heading foreground — bodyText inheritance.
+        #expect(color(in: attrs, at: 2) == nil)
+    }
+
+    @Test("explicit-nil knobs produce value-identical styling to .default")
+    func nilKnobsMatchDefaultsExactly() {
+        let doc = "# One **bold** *i*\n\nbody `code`\n\n## Two\n\n- item\n\n> quote\n"
+        let expected = style(doc)
+        let explicitNil = MarkdownEditorConfiguration(
+            theme: MarkdownEditorTheme(headingText: nil),
+            headings: HeadingStyle(fontName: nil)
+        )
+        let actual = style(doc, configuration: explicitNil)
+
+        #expect(actual.count == expected.count)
+        for (a, e) in zip(actual, expected) {
+            #expect(a.range == e.range)
+            #expect((a.attributes as NSDictionary).isEqual(to: e.attributes))
+        }
+    }
+}

--- a/Tests/MarkdownEngineTests/HeadingMetricsTests.swift
+++ b/Tests/MarkdownEngineTests/HeadingMetricsTests.swift
@@ -1,0 +1,78 @@
+//
+//  HeadingMetricsTests.swift
+//  MarkdownEngineTests
+//
+//  Heading metric knobs: `HeadingStyle.lineHeights` (fixed per-level line
+//  heights, empty = derived from font metrics as before) and
+//  `HeadingStyle.paragraphSpacing` (below-heading spacing, nil = the base
+//  paragraph spacing as before).
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Heading metric knobs")
+struct HeadingMetricsTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private func headingParagraphStyle(
+        _ text: String, headings: HeadingStyle = .default
+    ) -> NSParagraphStyle? {
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: MarkdownEditorConfiguration(headings: headings)
+        )
+        var result: NSParagraphStyle?
+        for (range, a) in attrs where NSLocationInRange(0, range) {
+            if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+        }
+        return result
+    }
+
+    @Test("empty lineHeights keeps the metric-derived height")
+    func defaultsDeriveFromFontMetrics() {
+        #expect(HeadingStyle.default.lineHeights.isEmpty)
+        #expect(HeadingStyle.default.paragraphSpacing == nil)
+
+        // Reproduce the styler's stock heading font: base face + bold trait.
+        let plain = NSFont(name: fontName, size: base * 2) ?? .systemFont(ofSize: base * 2)
+        let merged = plain.fontDescriptor.symbolicTraits.union(.bold)
+        let font = NSFont(descriptor: plain.fontDescriptor.withSymbolicTraits(merged), size: base * 2) ?? plain
+        let derived = ceil(font.ascender - font.descender + font.leading) + 1
+        let ps = headingParagraphStyle("# Title\n")
+        #expect(abs((ps?.minimumLineHeight ?? 0) - derived) < 0.01)
+        #expect(ps?.minimumLineHeight == ps?.maximumLineHeight)
+    }
+
+    @Test("lineHeights pins a fixed grid per level, reusing the last entry")
+    func lineHeightsPinAFixedGrid() {
+        let grid = HeadingStyle(lineHeights: [48, 44, 40])
+        let h1 = headingParagraphStyle("# Title\n", headings: grid)
+        #expect(h1?.minimumLineHeight == 48)
+        #expect(h1?.maximumLineHeight == 48)
+
+        let h2 = headingParagraphStyle("## Title\n", headings: grid)
+        #expect(h2?.minimumLineHeight == 44)
+
+        // Levels past the array reuse the last entry (fontMultipliers pattern).
+        let h5 = headingParagraphStyle("##### Title\n", headings: grid)
+        #expect(h5?.minimumLineHeight == 40)
+    }
+
+    @Test("paragraphSpacing overrides the below-heading gap; nil keeps base")
+    func paragraphSpacingOverridesBelowHeadingGap() {
+        // Default: base paragraph spacing = ceil(baseLineHeight × 0.3).
+        let baseFont = NSFont(name: fontName, size: base) ?? .systemFont(ofSize: base)
+        let baseLineHeight = ceil(baseFont.ascender - baseFont.descender + baseFont.leading)
+        let expectedBase = ceil(baseLineHeight * ParagraphStyle.default.spacingFactor)
+        let stock = headingParagraphStyle("# Title\n")
+        #expect(abs((stock?.paragraphSpacing ?? 0) - expectedBase) < 0.01)
+
+        let tight = headingParagraphStyle("# Title\n", headings: HeadingStyle(paragraphSpacing: 4))
+        #expect(tight?.paragraphSpacing == 4)
+    }
+}

--- a/Tests/MarkdownEngineTests/LinkTextAttributesTests.swift
+++ b/Tests/MarkdownEngineTests/LinkTextAttributesTests.swift
@@ -1,0 +1,39 @@
+//
+//  LinkTextAttributesTests.swift
+//  MarkdownEngineTests
+//
+//  The display-time link attributes derived from the theme. AppKit's
+//  `NSTextView.linkTextAttributes` default paints every `.link` range
+//  `.linkColor` blue regardless of the foreground the styler set, so the
+//  editor re-declares the theme's link ink there (see NativeTextViewWrapper's
+//  makeNSView/updateNSView). These tests pin the derivation.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Link text attributes")
+struct LinkTextAttributesTests {
+
+    @Test("linkTextAttributes carry the theme's link ink, underline, and pointing hand")
+    func attributesFollowThemeLinkInk() {
+        let brand = NSColor(calibratedRed: 0.4, green: 0.05, blue: 0.13, alpha: 1)
+        let theme = MarkdownEditorTheme(link: brand)
+        let attrs = theme.linkTextAttributes
+        #expect(attrs[.foregroundColor] as? NSColor == brand)
+        #expect(attrs[.underlineStyle] as? Int == NSUnderlineStyle.single.rawValue)
+        #expect(attrs[.cursor] as? NSCursor == NSCursor.pointingHand)
+    }
+
+    @Test("the default theme reproduces AppKit's stock link look")
+    func defaultThemeMatchesStockAppKitLook() {
+        // `.linkColor` + single underline is exactly what AppKit's own
+        // `linkTextAttributes` default renders, so installing these
+        // attributes changes nothing for embedders on the default theme.
+        let attrs = MarkdownEditorTheme.default.linkTextAttributes
+        #expect(attrs[.foregroundColor] as? NSColor == NSColor.linkColor)
+        #expect(attrs[.underlineStyle] as? Int == NSUnderlineStyle.single.rawValue)
+    }
+}

--- a/Tests/MarkdownEngineTests/ListIndentGridTests.swift
+++ b/Tests/MarkdownEngineTests/ListIndentGridTests.swift
@@ -1,0 +1,182 @@
+//
+//  ListIndentGridTests.swift
+//  MarkdownEngineTests
+//
+//  The opt-in list indent grid (`ListStyle.markerTextGap`): markers on a
+//  deterministic depth × indentPerLevel grid with level 1 on the body origin,
+//  the raw source whitespace neutralized, and content hanging a fixed slot
+//  after the marker. `nil` (the default) must keep the historical geometry
+//  bit-for-bit.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("List indent grid (ListStyle.markerTextGap)")
+struct ListIndentGridTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+    private var baseFont: NSFont { NSFont.systemFont(ofSize: 16) }
+
+    private func gridConfig(gap: CGFloat = 36, indent: CGFloat = 24) -> MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(lists: ListStyle(indentPerLevel: indent, markerTextGap: gap))
+    }
+
+    private func style(_ text: String, _ config: MarkdownEditorConfiguration = .default) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base, configuration: config)
+    }
+
+    /// Effective paragraph style at `pos` (last styled range wins).
+    private func paragraphStyle(in attrs: [StyledRange], at pos: Int) -> NSParagraphStyle? {
+        var result: NSParagraphStyle?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+        }
+        return result
+    }
+
+    /// Effective kern at `pos`, if any styled range sets one.
+    private func kern(in attrs: [StyledRange], at pos: Int) -> CGFloat? {
+        var result: CGFloat?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let k = a[.kern] as? CGFloat { result = k }
+        }
+        return result
+    }
+
+    /// Effective font at `pos` (last styled range wins).
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    // MARK: - Default preserved
+
+    @Test("nil markerTextGap keeps the historical flat first-line indent and raw-whitespace nesting")
+    func nilGapKeepsLegacyGeometry() {
+        let text = "- top\n  - nested\n"
+        let attrs = style(text)
+        let perLevel = MarkdownEditorConfiguration.default.lists.indentPerLevel
+
+        let top = paragraphStyle(in: attrs, at: 0)
+        #expect(top?.firstLineHeadIndent == perLevel)
+        #expect(top?.defaultTabInterval == perLevel)
+        let markerWidth = HeadingHelpers.textWidth("- ", font: baseFont)
+        #expect(abs((top?.headIndent ?? 0) - (perLevel + markerWidth)) < 0.01)
+
+        // Nested: first line stays FLAT (raw whitespace is the visual indent),
+        // only the wrapped-line hang includes the depth.
+        let nested = paragraphStyle(in: attrs, at: 8)
+        #expect(nested?.firstLineHeadIndent == perLevel)
+        #expect(abs((nested?.headIndent ?? 0) - (perLevel + perLevel + markerWidth)) < 0.01)
+
+        // No kern correction and no whitespace collapse in legacy mode.
+        #expect(kern(in: attrs, at: 1) == nil)
+        #expect(font(in: attrs, at: 6)?.pointSize == nil || font(in: attrs, at: 6)?.pointSize == base)
+    }
+
+    // MARK: - Grid geometry
+
+    @Test("level 1 marker sits on the body origin; content hangs at the gap")
+    func levelOneOnBodyOrigin() {
+        let text = "- alpha beta\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+
+        // The final spacer char (before "alpha") is kerned so the marker→content
+        // advance lands exactly on the slot.
+        let markerWidth = HeadingHelpers.textWidth("- ", font: baseFont)
+        let k = kern(in: attrs, at: 1)
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
+    }
+
+    @Test("nesting steps by indentPerLevel and collapses the source whitespace")
+    func nestedStepsByIndentPerLevel() {
+        let text = "- top\n  - two\n    - three\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+
+        let two = paragraphStyle(in: attrs, at: ns.range(of: "- two").location)
+        #expect(two?.firstLineHeadIndent == 24)
+        #expect(abs((two?.headIndent ?? 0) - (24 + 36)) < 0.01)
+
+        let three = paragraphStyle(in: attrs, at: ns.range(of: "- three").location)
+        #expect(three?.firstLineHeadIndent == 48)
+        #expect(abs((three?.headIndent ?? 0) - (48 + 36)) < 0.01)
+
+        // The two leading spaces collapse to the hidden-marker font so the
+        // source indent stops shifting the line.
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        #expect(font(in: attrs, at: 6)?.pointSize == hidden)
+    }
+
+    @Test("tab-indented items land on the same grid; tabs advance by a sub-point interval")
+    func tabIndentedItemsUseGrid() {
+        let text = "- top\n\t- nested\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+        let nested = paragraphStyle(in: attrs, at: ns.range(of: "- nested").location)
+        #expect(nested?.firstLineHeadIndent == 24)
+        #expect(nested?.defaultTabInterval == 0.25)
+    }
+
+    @Test("ordered markers share the same slot so bullet and numbered content align")
+    func orderedMarkersShareTheSlot() {
+        let text = "1. first\n2. second\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+
+        let markerWidth = HeadingHelpers.textWidth("1. ", font: baseFont)
+        let k = kern(in: attrs, at: 2)   // the space between "1." and "first"
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
+    }
+
+    @Test("task items keep the grid geometry")
+    func taskItemsKeepGridGeometry() {
+        let text = "- [ ] task content\n"
+        let attrs = style(text, gridConfig())
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == 0)
+        #expect(ps?.headIndent == 36)
+    }
+
+    @Test("a slot narrower than the marker widens just enough to keep the spacer advance positive")
+    func narrowSlotClamps() {
+        let text = "10. wide marker\n"
+        let attrs = style(text, gridConfig(gap: 4))
+        let markerWidth = HeadingHelpers.textWidth("10. ", font: baseFont)
+        let spacerWidth = HeadingHelpers.textWidth(" ", font: baseFont)
+        let expectedSlot = markerWidth - spacerWidth + 0.5
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(abs((ps?.headIndent ?? 0) - expectedSlot) < 0.01)
+        let k = kern(in: attrs, at: 3)
+        #expect(abs((k ?? 0) - (expectedSlot - markerWidth)) < 0.01)
+    }
+
+    // MARK: - Checkbox slot
+
+    @Test("the drawn checkbox left-aligns to the marker slot in grid mode and right-aligns otherwise")
+    func checkboxAlignmentPerMode() {
+        // Legacy: right-aligned to the content edge with the fixed gap.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17) == 100 - 17 - TaskCheckboxGeometry.gap)
+        // Grid: left-aligned to the slot origin.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 36) == 64)
+        // A slot narrower than the box falls back to the right-aligned position.
+        #expect(
+            TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 10)
+                == 100 - 17 - TaskCheckboxGeometry.gap
+        )
+    }
+}

--- a/Tests/MarkdownEngineTests/ListIndentGridTests.swift
+++ b/Tests/MarkdownEngineTests/ListIndentGridTests.swift
@@ -143,13 +143,42 @@ struct ListIndentGridTests {
         #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
     }
 
-    @Test("task items keep the grid geometry")
+    @Test("task items keep the grid geometry and collapse the whole `- [ ] ` marker")
     func taskItemsKeepGridGeometry() {
         let text = "- [ ] task content\n"
         let attrs = style(text, gridConfig())
         let ps = paragraphStyle(in: attrs, at: 0)
         #expect(ps?.firstLineHeadIndent == 0)
         #expect(ps?.headIndent == 36)
+
+        // The `- ` collapses too (the drawn box owns the slot, left-aligned at
+        // its origin), so the slot kern measures the collapsed marker and the
+        // content still lands on the slot edge.
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        #expect(font(in: attrs, at: 0)?.pointSize == hidden)   // "-"
+        #expect(font(in: attrs, at: 1)?.pointSize == hidden)   // " "
+        let collapsedFont = font(in: attrs, at: 0) ?? baseFont
+        let collapsedWidth = HeadingHelpers.textWidth("- ", font: collapsedFont)
+        let k = kern(in: attrs, at: 5)   // the space between "]" and "task"
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - collapsedWidth)) < 0.01)
+    }
+
+    @Test("ordered nesting steps one level per parent, not one per two source columns")
+    func orderedNestingUsesStructuralDepth() {
+        // CommonMark ordered nesting indents by the parent MARKER width — three
+        // columns here. The naive spaces/2 divisor would put "three" on level 3
+        // (72pt); the structural ladder keeps it on level 2 (48pt).
+        let text = "1. one\n   1. two\n      1. three\n"
+        let attrs = style(text, gridConfig())
+        let ns = text as NSString
+
+        let two = paragraphStyle(in: attrs, at: ns.range(of: "1. two").location)
+        #expect(two?.firstLineHeadIndent == 24)
+
+        let three = paragraphStyle(in: attrs, at: ns.range(of: "1. three").location)
+        #expect(three?.firstLineHeadIndent == 48)
+        #expect(abs((three?.headIndent ?? 0) - (48 + 36)) < 0.01)
     }
 
     @Test("a slot narrower than the marker widens just enough to keep the spacer advance positive")
@@ -169,14 +198,11 @@ struct ListIndentGridTests {
 
     @Test("the drawn checkbox left-aligns to the marker slot in grid mode and right-aligns otherwise")
     func checkboxAlignmentPerMode() {
-        // Legacy: right-aligned to the content edge with the fixed gap.
+        // Legacy: the hidden `[ ] ` sits at the content edge (the `- ` keeps
+        // full advance), so the square right-aligns to it with the fixed gap.
         #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17) == 100 - 17 - TaskCheckboxGeometry.gap)
-        // Grid: left-aligned to the slot origin.
-        #expect(TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 36) == 64)
-        // A slot narrower than the box falls back to the right-aligned position.
-        #expect(
-            TaskCheckboxGeometry.boxX(contentX: 100, size: 17, markerTextGap: 10)
-                == 100 - 17 - TaskCheckboxGeometry.gap
-        )
+        // Grid: the whole `- [ ] ` collapses, so the box range's own position
+        // IS the marker-slot origin — the square draws right there.
+        #expect(TaskCheckboxGeometry.boxX(contentX: 24, size: 17, markerTextGap: 36) == 24)
     }
 }

--- a/Tests/MarkdownEngineTests/ListMarkerSlotTests.swift
+++ b/Tests/MarkdownEngineTests/ListMarkerSlotTests.swift
@@ -1,0 +1,126 @@
+//
+//  ListMarkerSlotTests.swift
+//  MarkdownEngineTests
+//
+//  The fixed marker column on the indent grid (`ListStyle.markerSlotWidth`):
+//  every marker kind occupies an invisible fixed-width slot at the depth
+//  indent — bullets and painted ordered markers center in it, the task
+//  checkbox fills it exactly — and content hangs `slot + gap` after the
+//  marker origin so all three list kinds share one alignment grid.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("List marker slot (ListStyle.markerSlotWidth)")
+struct ListMarkerSlotTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+    private var baseFont: NSFont { NSFont.systemFont(ofSize: 16) }
+
+    private func slotConfig(slot: CGFloat = 20, gap: CGFloat = 16, indent: CGFloat = 24) -> MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(
+            lists: ListStyle(indentPerLevel: indent, markerTextGap: gap, markerSlotWidth: slot)
+        )
+    }
+
+    private func style(_ text: String, _ config: MarkdownEditorConfiguration) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(text: text, fontName: fontName, fontSize: base, configuration: config)
+    }
+
+    private func paragraphStyle(in attrs: [StyledRange], at pos: Int) -> NSParagraphStyle? {
+        var result: NSParagraphStyle?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let p = a[.paragraphStyle] as? NSParagraphStyle { result = p }
+        }
+        return result
+    }
+
+    private func kern(in attrs: [StyledRange], at pos: Int) -> CGFloat? {
+        var result: CGFloat?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let k = a[.kern] as? CGFloat { result = k }
+        }
+        return result
+    }
+
+    // MARK: - Gating
+
+    @Test("markerSlotWidth without markerTextGap is inert")
+    func slotRequiresGrid() {
+        let lists = ListStyle(markerSlotWidth: 20)
+        #expect(lists.effectiveMarkerSlotWidth == nil)
+        // Layout stays the historical geometry bit-for-bit.
+        let config = MarkdownEditorConfiguration(lists: lists)
+        let attrs = style("- alpha\n", config)
+        let ps = paragraphStyle(in: attrs, at: 0)
+        #expect(ps?.firstLineHeadIndent == lists.indentPerLevel)
+    }
+
+    @Test("markerSlotWidth on the grid is in effect")
+    func slotActiveOnGrid() {
+        #expect(ListStyle(markerTextGap: 16, markerSlotWidth: 20).effectiveMarkerSlotWidth == 20)
+    }
+
+    // MARK: - Content offset = slot + gap
+
+    @Test("bullet, ordered, and task content all hang slot + gap after the marker origin")
+    func allMarkerKindsShareTheContentEdge() {
+        let config = slotConfig()   // 20 + 16 = 36
+        for text in ["- bullet item\n", "1. ordered item\n", "- [ ] task item\n"] {
+            let attrs = style(text, config)
+            let ps = paragraphStyle(in: attrs, at: 0)
+            #expect(ps?.firstLineHeadIndent == 0, "first line origin for \(text)")
+            #expect(abs((ps?.headIndent ?? 0) - 36) < 0.01, "content edge for \(text)")
+        }
+    }
+
+    @Test("nested items step by indentPerLevel and keep the slot + gap hang")
+    func nestedSlotGeometry() {
+        let text = "- top\n  - nested\n"
+        let attrs = style(text, slotConfig())
+        let ns = text as NSString
+        let nested = paragraphStyle(in: attrs, at: ns.range(of: "- nested").location)
+        #expect(nested?.firstLineHeadIndent == 24)
+        #expect(abs((nested?.headIndent ?? 0) - (24 + 36)) < 0.01)
+    }
+
+    @Test("the spacer kern lands content exactly on the slot edge")
+    func spacerKernTargetsSlotEdge() {
+        let attrs = style("- alpha\n", slotConfig())
+        let markerWidth = HeadingHelpers.textWidth("- ", font: baseFont)
+        let k = kern(in: attrs, at: 1)
+        #expect(k != nil)
+        #expect(abs((k ?? 0) - (36 - markerWidth)) < 0.01)
+    }
+
+    // MARK: - Ordered overlay forced
+
+    @Test("slot mode paints ordered markers even when the display number matches the source digits")
+    func slotModeForcesOrderedOverlay() {
+        // Numeric style + matching digits normally skips the overlay (the raw
+        // digits already read right); the slot's centering requires painting.
+        let attrs = style("1. first\n", slotConfig())
+        let hasOverlay = attrs.contains { _, a in a[.orderedMarker] != nil }
+        #expect(hasOverlay)
+
+        // Without a slot the historical skip stays.
+        let gridOnly = MarkdownEditorConfiguration(lists: ListStyle(indentPerLevel: 24, markerTextGap: 36))
+        let plain = style("1. first\n", gridOnly)
+        let hasPlainOverlay = plain.contains { _, a in a[.orderedMarker] != nil }
+        #expect(!hasPlainOverlay)
+    }
+
+    // MARK: - Checkbox geometry
+
+    @Test("the checkbox square fills the slot exactly; nil slot keeps the font-derived size")
+    func checkboxFillsSlot() {
+        #expect(TaskCheckboxGeometry.size(for: baseFont, slotWidth: 20) == 20)
+        let legacy = TaskCheckboxGeometry.size(for: baseFont)
+        #expect(legacy == TaskCheckboxGeometry.size(for: baseFont, slotWidth: nil))
+        #expect(legacy > 0)
+    }
+}

--- a/Tests/MarkdownEngineTests/ListMarkerStylingTests.swift
+++ b/Tests/MarkdownEngineTests/ListMarkerStylingTests.swift
@@ -1,0 +1,136 @@
+//
+//  ListMarkerStylingTests.swift
+//  MarkdownEngineTests
+//
+//  Per-depth ordered marker styles (`ListStyle.orderedMarkerStyles`) and the
+//  `MarkdownEditorTheme.listMarker` ink slot. Lettering only changes the
+//  painted overlay — the source digits stay untouched — and the default
+//  (single `.numeric`) must keep today's rendering exactly.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("List marker styling")
+struct ListMarkerStylingTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private func style(
+        _ text: String,
+        styles: [OrderedMarkerStyle] = [.numeric],
+        caret: Int = -1
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base, caretLocation: caret,
+            configuration: MarkdownEditorConfiguration(lists: ListStyle(orderedMarkerStyles: styles))
+        )
+    }
+
+    /// The painted overlay marker covering `pos`, if the overlay is active.
+    private func overlayMarker(in attrs: [StyledRange], at pos: Int) -> String? {
+        var result: String?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let m = a[.orderedMarker] as? String { result = m }
+        }
+        return result
+    }
+
+    // MARK: - Label formatting
+
+    @Test("alpha labels count bijective base-26")
+    func alphaLabels() {
+        let style = OrderedMarkerStyle.lowerAlpha
+        #expect(style.label(for: 1) == "a")
+        #expect(style.label(for: 2) == "b")
+        #expect(style.label(for: 26) == "z")
+        #expect(style.label(for: 27) == "aa")
+        #expect(style.label(for: 28) == "ab")
+        #expect(style.label(for: 53) == "ba")
+        #expect(OrderedMarkerStyle.upperAlpha.label(for: 27) == "AA")
+    }
+
+    @Test("roman labels use subtractive notation")
+    func romanLabels() {
+        let style = OrderedMarkerStyle.lowerRoman
+        #expect(style.label(for: 1) == "i")
+        #expect(style.label(for: 3) == "iii")
+        #expect(style.label(for: 4) == "iv")
+        #expect(style.label(for: 9) == "ix")
+        #expect(style.label(for: 14) == "xiv")
+        #expect(style.label(for: 40) == "xl")
+        #expect(OrderedMarkerStyle.upperRoman.label(for: 4) == "IV")
+    }
+
+    @Test("numeric labels are the digits; non-positive numbers fall back to digits")
+    func numericAndFallbackLabels() {
+        #expect(OrderedMarkerStyle.numeric.label(for: 7) == "7")
+        #expect(OrderedMarkerStyle.lowerAlpha.label(for: 0) == "0")
+    }
+
+    @Test("styles cycle per depth; an empty array reads as numeric")
+    func stylesCyclePerDepth() {
+        let lists = ListStyle(orderedMarkerStyles: [.numeric, .lowerAlpha, .lowerRoman])
+        #expect(lists.orderedMarkerStyle(forDepth: 0) == .numeric)
+        #expect(lists.orderedMarkerStyle(forDepth: 1) == .lowerAlpha)
+        #expect(lists.orderedMarkerStyle(forDepth: 2) == .lowerRoman)
+        #expect(lists.orderedMarkerStyle(forDepth: 3) == .numeric)
+        #expect(ListStyle(orderedMarkerStyles: []).orderedMarkerStyle(forDepth: 2) == .numeric)
+    }
+
+    // MARK: - Overlay behavior
+
+    @Test("the default stays numeric: a matching source number paints no overlay")
+    func defaultNumericPaintsNoOverlayForMatchingSource() {
+        // "1." and "2." already display what the source says — the overlay
+        // stays off, exactly as before this knob existed.
+        let text = "1. one\n2. two\n"
+        let attrs = style(text)
+        #expect(overlayMarker(in: attrs, at: 0) == nil)
+        #expect(overlayMarker(in: attrs, at: 7) == nil)
+
+        // A repeated literal still renumbers by position (existing behavior).
+        let repeated = style("1. one\n1. two\n")
+        #expect(overlayMarker(in: repeated, at: 7) == "2.")
+    }
+
+    @Test("a non-numeric depth letters the marker even when the number matches the source")
+    func letteringActivatesOverlayAtNestedDepth() {
+        let text = "1. top\n   1. child\n"
+        let attrs = style(text, styles: [.numeric, .lowerAlpha])
+        let ns = text as NSString
+        let childMarker = ns.range(of: "1. child").location
+        #expect(overlayMarker(in: attrs, at: 0) == nil, "top level stays numeric with no overlay")
+        #expect(overlayMarker(in: attrs, at: childMarker) == "a.")
+    }
+
+    @Test("lettering keeps the source punctuation — a paren list stays a paren list")
+    func letteringKeepsParenPunctuation() {
+        let text = "1) top\n   1) child\n"
+        let attrs = style(text, styles: [.numeric, .lowerAlpha])
+        let ns = text as NSString
+        let childMarker = ns.range(of: "1) child").location
+        #expect(overlayMarker(in: attrs, at: childMarker) == "a)")
+    }
+
+    @Test("the caret inside the marker reveals the raw digits (overlay off)")
+    func caretRevealsRawDigits() {
+        let text = "1. top\n   1. child\n"
+        let ns = text as NSString
+        let childMarker = ns.range(of: "1. child").location
+        let attrs = style(text, styles: [.numeric, .lowerAlpha], caret: childMarker + 1)
+        #expect(overlayMarker(in: attrs, at: childMarker) == nil)
+    }
+
+    // MARK: - Theme slot
+
+    @Test("theme.listMarker defaults to nil and carries a custom ink")
+    func listMarkerThemeSlot() {
+        #expect(MarkdownEditorTheme.default.listMarker == nil)
+        let muted = NSColor(calibratedWhite: 0.5, alpha: 1)
+        #expect(MarkdownEditorTheme(listMarker: muted).listMarker == muted)
+    }
+}

--- a/Tests/MarkdownEngineTests/MarkerOnlyCaretTests.swift
+++ b/Tests/MarkdownEngineTests/MarkerOnlyCaretTests.swift
@@ -1,0 +1,123 @@
+//
+//  MarkerOnlyCaretTests.swift
+//  MarkdownEngineTests
+//
+//  Caret x on marker-only list lines (fresh Enter continuations) in the
+//  indent grid: the insertion point must sit at the paragraph's content
+//  origin (headIndent), where the first typed character lands — not at the
+//  raw collapsed-marker advance that Core Text reports once the spacer
+//  kern falls at the end of the line.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Marker-only line caret")
+struct MarkerOnlyCaretTests {
+
+    private func makeView(_ text: String, caret: Int, _ config: MarkdownEditorConfiguration) -> NativeTextView {
+        let view = NativeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 400))
+        view.configuration = config
+        view.string = text
+        let font = NSFont.systemFont(ofSize: 16)
+        if let storage = view.textStorage {
+            storage.addAttribute(.font, value: font, range: NSRange(location: 0, length: storage.length))
+            let attrs = MarkdownASTStyler.styleAttributes(
+                text: text, fontName: font.fontName, fontSize: 16, configuration: config
+            )
+            for (range, a) in attrs {
+                storage.addAttributes(a, range: range)
+            }
+        }
+        view.setSelectedRange(NSRange(location: caret, length: 0))
+        return view
+    }
+
+    private var grid: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(
+            lists: ListStyle(indentPerLevel: 24, markerTextGap: 16, markerSlotWidth: 20)
+        )
+    }
+
+    // MARK: - Grid geometry: every marker kind snaps to the content origin
+
+    @Test("empty task, bullet, and ordered continuations snap to headIndent")
+    func markerOnlyLinesSnap() {
+        for text in ["- [ ] ", "- ", "1. ", "- [x] "] {
+            let caret = (text as NSString).length
+            let view = makeView(text, caret: caret, grid)
+            let x = view.markerOnlyListCaretX()
+            let style = view.textStorage?.attribute(
+                .paragraphStyle, at: 0, effectiveRange: nil
+            ) as? NSParagraphStyle
+            #expect(style != nil, "grid paragraph style missing for \(text)")
+            #expect(x != nil, "no caret correction for marker-only \(text)")
+            if let x, let style {
+                // Content origin: depth 0 × 24 + slot(20) + gap(16) = 36.
+                #expect(style.headIndent == 36)
+                #expect(x == view.textContainerOrigin.x + style.headIndent)
+            }
+        }
+    }
+
+    @Test("nested continuations step by indentPerLevel")
+    func nestedMarkerOnlyLine() {
+        let text = "- parent\n  - "
+        let caret = (text as NSString).length
+        let view = makeView(text, caret: caret, grid)
+        let x = view.markerOnlyListCaretX()
+        #expect(x != nil)
+        if let x {
+            // Depth 1: 24 + slot(20) + gap(16) = 60.
+            #expect(x == view.textContainerOrigin.x + 60)
+        }
+    }
+
+    // MARK: - No correction where the caret is already right
+
+    @Test("a line with content is untouched")
+    func contentLineUntouched() {
+        let text = "- [ ] task content"
+        let view = makeView(text, caret: (text as NSString).length, grid)
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+
+    @Test("a mid-syntax caret is untouched")
+    func midSyntaxCaretUntouched() {
+        let view = makeView("- [ ] ", caret: 3, grid)
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+
+    @Test("plain text is untouched")
+    func plainTextUntouched() {
+        let text = "hello"
+        let view = makeView(text, caret: 5, grid)
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+
+    @Test("legacy geometry is untouched")
+    func legacyUntouched() {
+        // Legacy content advance comes from real glyph advances, not an
+        // end-of-line kern — the caret is already at the content origin.
+        let view = makeView("- [ ] ", caret: 6, .default)
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+
+    @Test("a selection is untouched")
+    func selectionUntouched() {
+        let view = makeView("- [ ] ", caret: 6, grid)
+        view.setSelectedRange(NSRange(location: 2, length: 4))
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+
+    @Test("helpers off means no correction")
+    func helpersOffUntouched() {
+        var config = grid
+        config.lists.helpersEnabled = false
+        let view = makeView("- [ ] ", caret: 6, config)
+        #expect(view.markerOnlyListCaretX() == nil)
+    }
+}

--- a/Tests/MarkdownEngineTests/TableCornerRadiusTests.swift
+++ b/Tests/MarkdownEngineTests/TableCornerRadiusTests.swift
@@ -1,0 +1,120 @@
+//
+//  TableCornerRadiusTests.swift
+//  MarkdownEngineTests
+//
+//  `TableStyle.cornerRadius`: the rendered table wrapper is clipped to a
+//  rounded shape with the outer border rule stroked along the rounded path.
+//  The default (0) keeps the historical square-cornered rendering, and the
+//  radius participates in the render cache key.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Table corner radius")
+struct TableCornerRadiusTests {
+
+    private func makeContext(
+        for source: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> MarkdownStyler.StylingContext {
+        let font = NSFont.systemFont(ofSize: 15)
+        return MarkdownStyler.StylingContext(
+            nsText: source as NSString,
+            tokens: [],
+            codeTokens: [],
+            activeTokenIndices: [],
+            baseFont: font,
+            layoutBridge: nil,
+            baseDefaultLineHeight: 18,
+            codeBackgroundColor: .windowBackgroundColor,
+            latexMarkerFont: font,
+            configuration: configuration,
+            wikiLinkIDProvider: { _ in nil }
+        )
+    }
+
+    private func sample(_ image: NSImage, x: Int, y: Int) -> NSColor? {
+        let size = image.size
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: Int(size.width), pixelsHigh: Int(size.height),
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .calibratedRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmap)
+        image.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        return bitmap.colorAt(x: x, y: y)
+    }
+
+    @Test("default radius is zero and negatives clamp")
+    func defaults() {
+        #expect(TableStyle.default.cornerRadius == 0)
+        #expect(MarkdownEditorConfiguration.default.table.cornerRadius == 0)
+        #expect(TableStyle(cornerRadius: -3).cornerRadius == 0)
+    }
+
+    @Test("a radius empties the corner and keeps the mid-edge rule crisp")
+    func roundedCornerPixels() throws {
+        let source = "| head | col |\n|---|---|\n| a | b |"
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+
+        var square = MarkdownEditorConfiguration.default
+        square.theme.tableRule = .blue
+        var rounded = square
+        rounded.table.cornerRadius = 6
+
+        let (squareImage, _) = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: square),
+            appearance: aqua, availableWidth: 2000
+        )
+        let (roundedImage, _) = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: rounded),
+            appearance: aqua, availableWidth: 2000
+        )
+
+        // The square wrapper inks the very corner; the rounded wrapper leaves
+        // it empty.
+        let squareCorner = try #require(sample(squareImage, x: 0, y: 0))
+        let roundedCorner = try #require(sample(roundedImage, x: 0, y: 0))
+        #expect(squareCorner.alphaComponent > 0.4)
+        #expect(roundedCorner.alphaComponent < 0.1)
+
+        // Mid-edge border rule stays inked (crisp rule along the rounded path).
+        let midEdge = try #require(sample(roundedImage, x: 0, y: Int(roundedImage.size.height / 2)))
+        #expect(midEdge.alphaComponent > 0.4)
+        #expect(midEdge.blueComponent > 0.9)
+
+        // The corner curve reconnects with the border within the radius: a
+        // pixel just inside the corner diagonal is inked again.
+        let onCurve = try #require(sample(roundedImage, x: 2, y: 2))
+        #expect(onCurve.alphaComponent > 0.2)
+    }
+
+    @Test("changing the radius renders fresh instead of reusing the cache")
+    func radiusChangeRendersFresh() throws {
+        let source = "| rho | sigma |\n|---|---|\n| 21 | 22 |"
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+
+        _ = MarkdownStyler.tableImage(
+            for: source, parsed: parsed, ctx: makeContext(for: source),
+            appearance: aqua, availableWidth: 2000
+        )
+
+        var rounded = MarkdownEditorConfiguration.default
+        rounded.table.cornerRadius = 4
+        let repainted = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: rounded),
+            appearance: aqua, availableWidth: 2000
+        )
+        #expect(repainted.rendered)
+    }
+}

--- a/Tests/MarkdownEngineTests/TableRuleOrientationTests.swift
+++ b/Tests/MarkdownEngineTests/TableRuleOrientationTests.swift
@@ -1,0 +1,166 @@
+//
+//  TableRuleOrientationTests.swift
+//  MarkdownEngineTests
+//
+//  `TableStyle.verticalRules`: the full-grid look (default) draws interior
+//  column separators; turning it off keeps only the outer border and the
+//  horizontal rules between rows, spanning the full inner width. The knob
+//  participates in the render cache key, and interior rules stroke in the
+//  themed rule color.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Table rule orientation")
+struct TableRuleOrientationTests {
+
+    private func makeContext(
+        for source: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> MarkdownStyler.StylingContext {
+        let font = NSFont.systemFont(ofSize: 15)
+        return MarkdownStyler.StylingContext(
+            nsText: source as NSString,
+            tokens: [],
+            codeTokens: [],
+            activeTokenIndices: [],
+            baseFont: font,
+            layoutBridge: nil,
+            baseDefaultLineHeight: 18,
+            codeBackgroundColor: .windowBackgroundColor,
+            latexMarkerFont: font,
+            configuration: configuration,
+            wikiLinkIDProvider: { _ in nil }
+        )
+    }
+
+    private func bitmap(_ image: NSImage) -> NSBitmapImageRep? {
+        let size = image.size
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: Int(size.width), pixelsHigh: Int(size.height),
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .calibratedRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        image.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        return rep
+    }
+
+    private func isRuleBlue(_ color: NSColor?) -> Bool {
+        guard let color else { return false }
+        return color.alphaComponent > 0.4 && color.blueComponent > 0.8 && color.redComponent < 0.3
+    }
+
+    /// Renders the sample table with a blue rule color so rule pixels are
+    /// unambiguous against the fill and text inks.
+    private func render(source: String, verticalRules: Bool) throws -> NSBitmapImageRep {
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+        var config = MarkdownEditorConfiguration.default
+        config.theme.tableRule = .blue
+        config.table.verticalRules = verticalRules
+        let (image, _) = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: config),
+            appearance: aqua, availableWidth: 2000
+        )
+        return try #require(bitmap(image))
+    }
+
+    /// Interior horizontal-rule rows: y positions strictly inside the image
+    /// where the pixel at mid-x is rule-colored.
+    private func interiorRuleRows(_ rep: NSBitmapImageRep) -> [Int] {
+        let midX = rep.pixelsWide / 2
+        return (2..<(rep.pixelsHigh - 2)).filter { isRuleBlue(rep.colorAt(x: midX, y: $0)) }
+    }
+
+    private let source = "| head | col | third |\n|---|---|---|\n| a | b | c |\n| d | e | f |"
+
+    @Test("default keeps the full grid")
+    func defaults() {
+        #expect(TableStyle.default.verticalRules)
+        #expect(MarkdownEditorConfiguration.default.table.verticalRules)
+    }
+
+    @Test("grid off leaves no interior vertical-rule pixels")
+    func noVerticalRulePixels() throws {
+        let grid = try render(source: source, verticalRules: true)
+        let rows = try render(source: source, verticalRules: false)
+
+        // Probe a row strictly between two horizontal rules (mid body row):
+        // halfway between the first two interior rule rows, or below the last
+        // one when the header fill occupies the first band.
+        let gridRules = interiorRuleRows(grid)
+        let rowsRules = interiorRuleRows(rows)
+        #expect(!gridRules.isEmpty)
+        #expect(!rowsRules.isEmpty)
+        let probeY = try #require(zip(rowsRules.dropFirst(), rowsRules).map { ($0 + $1) / 2 }.first)
+
+        func interiorVerticalHits(_ rep: NSBitmapImageRep, y: Int) -> Int {
+            (2..<(rep.pixelsWide - 2)).filter { isRuleBlue(rep.colorAt(x: $0, y: y)) }.count
+        }
+        // The full grid inks column separators inside the row band; the
+        // rows-only look inks nothing between the borders there.
+        #expect(interiorVerticalHits(grid, y: probeY) >= 2)
+        #expect(interiorVerticalHits(rows, y: probeY) == 0)
+    }
+
+    @Test("horizontal rules stay and span the full inner width")
+    func horizontalRulesSpanFullWidth() throws {
+        let rows = try render(source: source, verticalRules: false)
+        let ruleRows = interiorRuleRows(rows)
+        // Header/body rule plus one rule between the two body rows.
+        #expect(ruleRows.count >= 2)
+        for y in ruleRows {
+            #expect(isRuleBlue(rows.colorAt(x: 2, y: y)))
+            #expect(isRuleBlue(rows.colorAt(x: rows.pixelsWide - 3, y: y)))
+        }
+    }
+
+    @Test("outer border still draws on all four sides")
+    func outerBorderIntact() throws {
+        let rows = try render(source: source, verticalRules: false)
+        let midX = rows.pixelsWide / 2
+        let midY = rows.pixelsHigh / 2
+        #expect(isRuleBlue(rows.colorAt(x: midX, y: 0)))
+        #expect(isRuleBlue(rows.colorAt(x: midX, y: rows.pixelsHigh - 1)))
+        #expect(isRuleBlue(rows.colorAt(x: 0, y: midY)))
+        #expect(isRuleBlue(rows.colorAt(x: rows.pixelsWide - 1, y: midY)))
+    }
+
+    @Test("interior rules stroke in the themed rule color, not black")
+    func interiorRulesUseThemeColor() throws {
+        // Regression guard: the rounded-wrapper change moved the outer
+        // border's setStroke below the separator pass, which left interior
+        // rules on the context's default black.
+        let grid = try render(source: source, verticalRules: true)
+        let ruleRows = interiorRuleRows(grid)
+        #expect(!ruleRows.isEmpty)
+    }
+
+    @Test("flipping the knob renders fresh instead of reusing the cache")
+    func knobChangeRendersFresh() throws {
+        let source = "| tau | ups |\n|---|---|\n| 31 | 32 |"
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+
+        _ = MarkdownStyler.tableImage(
+            for: source, parsed: parsed, ctx: makeContext(for: source),
+            appearance: aqua, availableWidth: 2000
+        )
+
+        var rowsOnly = MarkdownEditorConfiguration.default
+        rowsOnly.table.verticalRules = false
+        let repainted = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: rowsOnly),
+            appearance: aqua, availableWidth: 2000
+        )
+        #expect(repainted.rendered)
+    }
+}

--- a/Tests/MarkdownEngineTests/TableThemingTests.swift
+++ b/Tests/MarkdownEngineTests/TableThemingTests.swift
@@ -1,0 +1,120 @@
+//
+//  TableThemingTests.swift
+//  MarkdownEngineTests
+//
+//  Table theming slots: `MarkdownEditorTheme.tableHeaderBackground` and
+//  `MarkdownEditorTheme.tableRule`. Defaults (nil) must keep the historical
+//  mutedText-derived fills, and the slots must participate in the render
+//  cache key so themed and stock tables never share an image.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Table theming slots")
+struct TableThemingTests {
+
+    private func makeContext(
+        for source: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> MarkdownStyler.StylingContext {
+        let font = NSFont.systemFont(ofSize: 15)
+        return MarkdownStyler.StylingContext(
+            nsText: source as NSString,
+            tokens: [],
+            codeTokens: [],
+            activeTokenIndices: [],
+            baseFont: font,
+            layoutBridge: nil,
+            baseDefaultLineHeight: 18,
+            codeBackgroundColor: .windowBackgroundColor,
+            latexMarkerFont: font,
+            configuration: configuration,
+            wikiLinkIDProvider: { _ in nil }
+        )
+    }
+
+    private func sample(_ image: NSImage, x: Int, y: Int) -> NSColor? {
+        let size = image.size
+        guard let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil, pixelsWide: Int(size.width), pixelsHigh: Int(size.height),
+            bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+            colorSpaceName: .calibratedRGB, bytesPerRow: 0, bitsPerPixel: 0
+        ) else { return nil }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: bitmap)
+        image.draw(in: NSRect(origin: .zero, size: size))
+        NSGraphicsContext.restoreGraphicsState()
+        // NSImage draws bottom-up; convert the top-down y used by the table
+        // renderer into the bitmap's coordinate space.
+        return bitmap.colorAt(x: x, y: y)
+    }
+
+    @Test("slots default to nil")
+    func slotsDefaultToNil() {
+        #expect(MarkdownEditorTheme.default.tableHeaderBackground == nil)
+        #expect(MarkdownEditorTheme.default.tableRule == nil)
+    }
+
+    @Test("custom header fill and rule ink reach the rendered bitmap")
+    func customColorsReachTheBitmap() throws {
+        let source = "| head | col |\n|---|---|\n| a | b |"
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+
+        var themed = MarkdownEditorConfiguration.default
+        themed.theme.tableHeaderBackground = .red
+        themed.theme.tableRule = .blue
+
+        let (image, _) = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: themed),
+            appearance: aqua, availableWidth: 2000
+        )
+
+        // Top-left interior of the header row (inside the 1pt border, away
+        // from any glyph) carries the header fill.
+        let headerPixel = try #require(sample(image, x: 3, y: 3))
+        #expect(headerPixel.redComponent > 0.9)
+        #expect(headerPixel.blueComponent < 0.3)
+
+        // The outer border column carries the rule ink.
+        let rulePixel = try #require(sample(image, x: 0, y: Int(image.size.height / 2)))
+        #expect(rulePixel.blueComponent > 0.9)
+        #expect(rulePixel.redComponent < 0.3)
+    }
+
+    // The cache key must cover the new slots — a theme differing only in a
+    // table slot must be a miss, never the stock cached image.
+    @Test("changing a table slot renders fresh instead of reusing the cache")
+    func tableSlotChangeRendersFresh() throws {
+        let source = "| iota | kappa |\n|---|---|\n| 11 | 12 |"
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let aqua = try #require(NSAppearance(named: .aqua))
+
+        _ = MarkdownStyler.tableImage(
+            for: source, parsed: parsed, ctx: makeContext(for: source),
+            appearance: aqua, availableWidth: 2000
+        )
+
+        var ruled = MarkdownEditorConfiguration.default
+        ruled.theme.tableRule = .systemPink
+        let repainted = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: ruled),
+            appearance: aqua, availableWidth: 2000
+        )
+        #expect(repainted.rendered)
+
+        var filled = MarkdownEditorConfiguration.default
+        filled.theme.tableHeaderBackground = .systemTeal
+        let refilled = MarkdownStyler.tableImage(
+            for: source, parsed: parsed,
+            ctx: makeContext(for: source, configuration: filled),
+            appearance: aqua, availableWidth: 2000
+        )
+        #expect(refilled.rendered)
+    }
+}

--- a/Tests/MarkdownEngineTests/TaskCheckboxRendererTests.swift
+++ b/Tests/MarkdownEngineTests/TaskCheckboxRendererTests.swift
@@ -1,0 +1,56 @@
+//
+//  TaskCheckboxRendererTests.swift
+//  MarkdownEngineTests
+//
+//  The TaskCheckboxRenderer service: embedders can replace the pixels of the
+//  drawn task checkbox while the engine keeps geometry and hit-testing.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@Suite("TaskCheckboxRenderer service")
+struct TaskCheckboxRendererTests {
+
+    @Test("Default services carry the system renderer, which defers")
+    func defaultRendererDefers() {
+        let services = MarkdownEditorServices.default
+        #expect(services.taskCheckboxes is SystemTaskCheckboxRenderer)
+        #expect(services.taskCheckboxes.image(checked: false, size: 20, appearance: nil) == nil)
+        #expect(services.taskCheckboxes.image(checked: true, size: 20, appearance: NSAppearance(named: .darkAqua)) == nil)
+    }
+
+    struct RecordingRenderer: TaskCheckboxRenderer {
+        final class Log: @unchecked Sendable {
+            var calls: [(checked: Bool, size: CGFloat, appearanceName: NSAppearance.Name?)] = []
+        }
+        let log = Log()
+        func image(checked: Bool, size: CGFloat, appearance: NSAppearance?) -> NSImage? {
+            log.calls.append((checked, size, appearance?.name))
+            return NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+                (checked ? NSColor.systemRed : NSColor.systemGray).setFill()
+                rect.fill()
+                return true
+            }
+        }
+    }
+
+    @Test("A custom renderer is carried by the configuration and receives the box state")
+    func customRendererIsReachableThroughConfiguration() {
+        let renderer = RecordingRenderer()
+        var services = MarkdownEditorServices()
+        services.taskCheckboxes = renderer
+        let config = MarkdownEditorConfiguration(services: services)
+
+        let image = config.services.taskCheckboxes.image(
+            checked: true, size: 20, appearance: NSAppearance(named: .aqua)
+        )
+        #expect(image != nil)
+        #expect(image?.size == NSSize(width: 20, height: 20))
+        #expect(renderer.log.calls.count == 1)
+        #expect(renderer.log.calls.first?.checked == true)
+        #expect(renderer.log.calls.first?.size == 20)
+        #expect(renderer.log.calls.first?.appearanceName == .aqua)
+    }
+}

--- a/Tests/MarkdownEngineTests/TaskStylingTests.swift
+++ b/Tests/MarkdownEngineTests/TaskStylingTests.swift
@@ -1,0 +1,112 @@
+//
+//  TaskStylingTests.swift
+//  MarkdownEngineTests
+//
+//  Checked-task treatment knobs: the strikethrough gate
+//  (`TaskCheckboxStyle.strikethroughCompletedTasks`), the completed-label ink
+//  (`MarkdownEditorTheme.completedTaskText`), and the checkbox tint slots.
+//  Defaults must keep the historical rendering (strikethrough on, body ink).
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Task styling knobs")
+struct TaskStylingTests {
+
+    private let base: CGFloat = 16
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private func style(
+        _ text: String,
+        theme: MarkdownEditorTheme = .default,
+        strikethrough: Bool = true
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: MarkdownEditorConfiguration(
+                theme: theme,
+                taskCheckbox: TaskCheckboxStyle(strikethroughCompletedTasks: strikethrough)
+            )
+        )
+    }
+
+    /// Whether any styled range covering `pos` sets a strikethrough.
+    private func hasStrikethrough(in attrs: [StyledRange], at pos: Int) -> Bool {
+        attrs.contains { range, a in
+            NSLocationInRange(pos, range) && a[.strikethroughStyle] != nil
+        }
+    }
+
+    /// Effective foreground at `pos` (last styled range wins).
+    private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
+        var result: NSColor?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let c = a[.foregroundColor] as? NSColor { result = c }
+        }
+        return result
+    }
+
+    private let text = "- [x] done thing\n- [ ] open thing\n"
+    private var donePos: Int { (text as NSString).range(of: "done").location }
+    private var openPos: Int { (text as NSString).range(of: "open").location }
+
+    // MARK: - Strikethrough gate
+
+    @Test("the default keeps the historical strikethrough on checked labels")
+    func defaultKeepsStrikethrough() {
+        let attrs = style(text)
+        #expect(hasStrikethrough(in: attrs, at: donePos))
+        #expect(!hasStrikethrough(in: attrs, at: openPos))
+        // And the label keeps the document ink — no foreground override.
+        #expect(color(in: attrs, at: donePos) == nil)
+    }
+
+    @Test("strikethroughCompletedTasks = false drops the strikethrough")
+    func gateOffDropsStrikethrough() {
+        let attrs = style(text, strikethrough: false)
+        #expect(!hasStrikethrough(in: attrs, at: donePos))
+        #expect(!hasStrikethrough(in: attrs, at: openPos))
+    }
+
+    // MARK: - Completed label ink
+
+    @Test("completedTaskText colors only the checked label")
+    func completedInkColorsCheckedLabelOnly() {
+        let muted = NSColor(calibratedWhite: 0.45, alpha: 1)
+        let attrs = style(text, theme: MarkdownEditorTheme(completedTaskText: muted))
+        #expect(color(in: attrs, at: donePos) == muted)
+        #expect(color(in: attrs, at: openPos) == nil, "unchecked labels keep the document ink")
+    }
+
+    @Test("inline constructs inside a completed label keep their own ink")
+    func inlineInkWinsInsideCompletedLabel() {
+        let muted = NSColor(calibratedWhite: 0.45, alpha: 1)
+        let linked = "- [x] see [docs](https://example.com) now\n"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: linked, fontName: fontName, fontSize: base,
+            configuration: MarkdownEditorConfiguration(
+                theme: MarkdownEditorTheme(completedTaskText: muted)
+            )
+        )
+        let ns = linked as NSString
+        #expect(color(in: attrs, at: ns.range(of: "see").location) == muted)
+        // The link label appends after the task pass, so its ink wins.
+        let linkPos = ns.range(of: "docs").location
+        #expect(color(in: attrs, at: linkPos) == MarkdownEditorTheme.default.link)
+    }
+
+    // MARK: - Checkbox tint slots
+
+    @Test("checkbox tint slots default to nil and carry custom inks")
+    func checkboxTintSlots() {
+        #expect(MarkdownEditorTheme.default.taskCheckboxChecked == nil)
+        #expect(MarkdownEditorTheme.default.taskCheckboxUnchecked == nil)
+        let brand = NSColor(calibratedRed: 1, green: 0.8, blue: 0.81, alpha: 1)
+        let theme = MarkdownEditorTheme(taskCheckboxChecked: brand, taskCheckboxUnchecked: .gray)
+        #expect(theme.taskCheckboxChecked == brand)
+        #expect(theme.taskCheckboxUnchecked == .gray)
+    }
+}


### PR DESCRIPTION
## Summary

Two related changes to caret visibility in `.scrolls` mode:

1. **Bugfix — caret-follow never fired outside the reading column.** AppKit's native `scrollRangeToVisible` routes through the absent TextKit 1 layout manager in a TextKit 2 text view and silently no-ops for off-screen content (the find-reveal path documented this first and works around it). The `.scrolls` reveal path only used the manual TextKit-2 fragment reveal when `readingWidth != nil`, so any plain editor with a small viewport never scrolled the caret into view while typing at the bottom. The manual reveal now serves every `.scrolls` editor — with no reading column the text view fills the container, so the same math applies with a zero x-offset. The reveal target is clamped to the scrollable content before moving, so a reveal can't overshoot and get yanked back by the post-hoc clamp.
2. **Opt-in knob — `caretFollowAnimationDuration` (default `0`).** `0` keeps the historical instant jump; a short duration (0.1–0.2s) animates the follow with an ease-out curve and no bounce, via `NSAnimationContext` on the clip view's bounds origin. The animated branch requires a window and is skipped headlessly, keeping tests deterministic.

## Testing

New `CaretFollowScrollTests` suite (5 tests): knob default + negative clamping, off-screen caret reveals into the viewport (the regression), already-visible caret doesn't move the viewport, upward reveal, and target clamping to the scrollable content. Full package suite green.

Made with [Cursor](https://cursor.com)