### PR TITLE
Let an embedder keep the scroll offset when the editor is unmounted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `onPersistScrollOffset` / `restoreScrollOffset` on `NativeTextViewWrapper` —
+  scroll memory an embedder can keep somewhere that outlives the editor. The
+  engine's own per-document offsets live on the coordinator, so an embedder that
+  routes to a different screen and back lost them: nothing recorded the offset on
+  the way out (there was no `dismantleNSView` at all), and the restore was gated
+  on a document switch, which a remount is not — `makeCoordinator` seeds
+  `documentId`, so the first update pass never looks like one. Teardown now hands
+  the offset over, and the restore is latched instead of gated, retrying for a
+  bounded few passes because the first pass after a remount still carries the
+  embedder's empty buffer. Both closures are asked at call time, so the
+  embedder's own retention rules can see changes made on the way out. Passing
+  neither leaves behavior unchanged.
+
 - `NSAttributedString.Key.markdownBlockBackground` — a background painted
   across the whole line box by `MarkdownTextLayoutFragment` instead of the
   glyph box AppKit's `.backgroundColor` covers. Embedder extensions can use it

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -71,6 +71,8 @@ extension NativeTextViewCoordinator {
     public func textDidChange(_ notification: Notification) {
         guard let tv = notification.object as? NSTextView else { return }
         PerfTrace.checkpoint("didIn")
+        // Typing means the reader is here, so an unlanded restore must not fire.
+        pendingScrollRestoreDocumentId = nil
         // Before the early returns: the first keystroke must hide the placeholder.
         (tv as? NativeTextView)?.refreshPlaceholderVisibility()
         // Raw mode: display IS storage — sync the binding, skip the restyle.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -20,8 +20,20 @@ import SwiftUI
 public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var documentId: String?
     /// Remembered scroll offset (`bounds.origin.y`) per `documentId` — saved on
-    /// switch-away, restored on switch-back.
+    /// switch-away, restored on switch-back. Dies with the coordinator, so an
+    /// embedder that unmounts the editor supplies the two closures below instead.
     var scrollOffsets: [String: CGFloat] = [:]
+    /// Embedder-owned scroll memory that outlives this coordinator. `persist` is
+    /// also called from `dismantleNSView`; `restore` returning nil opens at top.
+    var onPersistScrollOffset: ((String, CGFloat) -> Void)?
+    var restoreScrollOffset: ((String) -> CGFloat?)?
+    /// documentId whose remembered offset still has to be applied, and how many
+    /// update passes it may keep trying. A remount is not a switch (SwiftUI seeds
+    /// `documentId` in `makeCoordinator`) and its first pass still carries the
+    /// embedder's empty buffer, so the offset can only land on a later pass. The
+    /// budget bounds it: a document that really got shorter must not keep yanking.
+    var pendingScrollRestoreDocumentId: String?
+    var pendingScrollRestoreAttempts = 0
     /// Per-`documentId` undo manager. AppKit reuses a single `NSTextView` across
     /// all open documents, so its built-in (view-wide) undo manager would mix
     /// files together. Keying a manager on the current document gives each file
@@ -403,6 +415,13 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
 
     // Find-in-document highlight handlers live in
     // `NativeTextViewCoordinator+Find.swift`.
+
+    /// Four passes: a remount needs two (empty buffer, then the real content) and
+    /// the header's hosting view can still resolve its height after that.
+    func armScrollRestore(for documentId: String) {
+        pendingScrollRestoreDocumentId = documentId
+        pendingScrollRestoreAttempts = 4
+    }
 
     func wikiLinkID(for range: NSRange) -> String? {
         wikiLinkMetadata[WikiLinkService.RangeKey(range)]?.id

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -646,7 +646,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                 nsView.reflectScrolledClipView(nsView.contentView)
                 (nsView as? ClampedScrollView)?.clampToInsets()
                 let landed = abs(nsView.contentView.bounds.origin.y - savedY) < 1
-                if landed || context.coordinator.pendingScrollRestoreAttempts <= 0 {
+                // Also give up once the real content has had its chance, landed or
+                // not: an armed latch outliving the document's arrival lets a much
+                // later unrelated pass — ⌘+/⌘−, the raw-source toggle, a buffer
+                // reload — scroll the reader away from wherever they went.
+                if landed || !text.isEmpty || context.coordinator.pendingScrollRestoreAttempts <= 0 {
                     context.coordinator.pendingScrollRestoreDocumentId = nil
                 }
             } else {
@@ -698,7 +702,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// different screen — and that is the only moment left to record where the
     /// reader was; the coordinator's own offsets die with it.
     public static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
-        guard let documentId = coordinator.documentId else { return }
+        // A restore still pending means the reader was never put back where they
+        // were — recording the current offset would overwrite the good one with
+        // the mid-load position.
+        guard let documentId = coordinator.documentId,
+              coordinator.pendingScrollRestoreDocumentId == nil else { return }
         coordinator.onPersistScrollOffset?(documentId, nsView.contentView.bounds.origin.y)
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -123,6 +123,15 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// documentIds whose scroll offset to keep; others are forgotten. `nil` keeps all.
     public var retainedScrollDocumentIds: Set<String>?
 
+    /// Scroll memory that outlives the editor. The engine's own offsets live on the
+    /// coordinator, so an embedder that unmounts the editor entirely — routing to a
+    /// different screen and back — loses them; these hand the offsets somewhere that
+    /// survives. `persist` is called on switch-away AND on teardown, `restore` when a
+    /// document becomes current (nil opens at the top). Both are asked at call time,
+    /// so the embedder's own retention rules can see changes made on the way out.
+    public var onPersistScrollOffset: ((String, CGFloat) -> Void)?
+    public var restoreScrollOffset: ((String) -> CGFloat?)?
+
     /// Embedder-supplied predicate that suppresses the I-beam cursor in edit mode.
     /// Called on mouse-move with the event location in window coordinates.
     /// Return `true` to show the arrow cursor instead of the I-beam.
@@ -150,6 +159,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         headerCollapsedHeight: CGFloat = 0,
         headerExpanded: Bool = true,
         retainedScrollDocumentIds: Set<String>? = nil,
+        onPersistScrollOffset: ((String, CGFloat) -> Void)? = nil,
+        restoreScrollOffset: ((String) -> CGFloat?)? = nil,
         isCursorExcluded: ((CGPoint) -> Bool)? = nil
     ) {
         self._text = text
@@ -173,6 +184,8 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.headerCollapsedHeight = headerCollapsedHeight
         self.headerExpanded = headerExpanded
         self.retainedScrollDocumentIds = retainedScrollDocumentIds
+        self.onPersistScrollOffset = onPersistScrollOffset
+        self.restoreScrollOffset = restoreScrollOffset
         self.isCursorExcluded = isCursorExcluded
     }
 
@@ -382,6 +395,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
 
         let isNodeSwitch = context.coordinator.documentId != documentId
 
+        // Refreshed here, not with the other callbacks at the bottom — teardown has
+        // to reach the CURRENT closures even when the pass below returns early.
+        context.coordinator.onPersistScrollOffset = onPersistScrollOffset
+        context.coordinator.restoreScrollOffset = restoreScrollOffset
+
         // Drop remembered offsets for documents no longer retained (always keep
         // the current one). Only rebuilds the dict when something must go.
         if let retained = retainedScrollDocumentIds {
@@ -554,9 +572,14 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         if isNodeSwitch {
             // Save the outgoing document's scroll position — unless it just left
             // the retained set, in which case let it reset to top next time.
-            if let outgoingId = context.coordinator.documentId,
-               retainedScrollDocumentIds?.contains(outgoingId) ?? true {
-                context.coordinator.scrollOffsets[outgoingId] = nsView.contentView.bounds.origin.y
+            if let outgoingId = context.coordinator.documentId {
+                let offsetY = nsView.contentView.bounds.origin.y
+                if retainedScrollDocumentIds?.contains(outgoingId) ?? true {
+                    context.coordinator.scrollOffsets[outgoingId] = offsetY
+                }
+                // The embedder's store applies its own retention — it is asked live,
+                // so it can see what the snapshot above was taken too early to know.
+                onPersistScrollOffset?(outgoingId, offsetY)
             }
             // Snapshot the outgoing document's content (storage form) so a later
             // switch-back can detect a file rewritten while it was backgrounded.
@@ -571,6 +594,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             // across a file switch.
             textView.breakUndoCoalescing()
             context.coordinator.documentId = documentId
+            context.coordinator.armScrollRestore(for: documentId)
             // Drop the incoming document's undo stack if its text changed while
             // switched away — its recorded ranges are now stale.
             context.coordinator.invalidateUndoIfContentDiverged(for: documentId, incomingText: text)
@@ -611,11 +635,23 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.recalcOverscroll(for: nsView)
         (nsView as? ClampedScrollView)?.clampToInsets()
         // Height is measured now, so restore the saved offset; clampToInsets keeps
-        // it in range if the document got shorter.
-        if isNodeSwitch, let savedY = context.coordinator.scrollOffsets[documentId] {
-            nsView.contentView.scroll(to: NSPoint(x: nsView.contentView.bounds.origin.x, y: savedY))
-            nsView.reflectScrolledClipView(nsView.contentView)
-            (nsView as? ClampedScrollView)?.clampToInsets()
+        // it in range if the document got shorter. Latched rather than gated on
+        // `isNodeSwitch`, because a remount is not a switch and its first pass still
+        // carries the embedder's empty buffer — the clamp would pull it back to top.
+        if context.coordinator.pendingScrollRestoreDocumentId == documentId {
+            context.coordinator.pendingScrollRestoreAttempts -= 1
+            let saved = restoreScrollOffset?(documentId) ?? context.coordinator.scrollOffsets[documentId]
+            if let savedY = saved {
+                nsView.contentView.scroll(to: NSPoint(x: nsView.contentView.bounds.origin.x, y: savedY))
+                nsView.reflectScrolledClipView(nsView.contentView)
+                (nsView as? ClampedScrollView)?.clampToInsets()
+                let landed = abs(nsView.contentView.bounds.origin.y - savedY) < 1
+                if landed || context.coordinator.pendingScrollRestoreAttempts <= 0 {
+                    context.coordinator.pendingScrollRestoreDocumentId = nil
+                }
+            } else {
+                context.coordinator.pendingScrollRestoreDocumentId = nil
+            }
         }
         // Document rebuilds bypass textDidChange — re-derive emptiness here.
         textView.refreshPlaceholderVisibility()
@@ -641,6 +677,11 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             onInlineSelectionChange: onInlineSelectionChange
         )
         coordinator.documentId = documentId
+        coordinator.onPersistScrollOffset = onPersistScrollOffset
+        coordinator.restoreScrollOffset = restoreScrollOffset
+        // Seeding documentId above means the first update pass is not a switch, so
+        // arm the restore here or a remount would always open at the top.
+        coordinator.armScrollRestore(for: documentId)
         coordinator.configuration = configuration
         coordinator.lastImageFingerprint = configuration.services.images.fingerprint()
         coordinator.lastWikiFingerprint = configuration.services.wikiLinks.fingerprint()
@@ -651,6 +692,14 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.userPrefersAutomaticSpellingCorrection = configuration.spellChecking.automaticSpellingCorrection
         coordinator.onSpellCheckingPolicyChanged = onSpellCheckingPolicyChanged
         return coordinator
+    }
+
+    /// The editor can go away without a document switch — an embedder routing to a
+    /// different screen — and that is the only moment left to record where the
+    /// reader was; the coordinator's own offsets die with it.
+    public static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
+        guard let documentId = coordinator.documentId else { return }
+        coordinator.onPersistScrollOffset?(documentId, nsView.contentView.bounds.origin.y)
     }
 }
 // MARK: - Scrolling header view

--- a/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
@@ -67,6 +67,18 @@ struct ScrollMemoryTests {
         #expect(callCount == 0)
     }
 
+    @Test("Teardown mid-restore keeps the remembered offset instead of the load position")
+    func dismantleDuringPendingRestorePersistsNothing() {
+        var callCount = 0
+        let coordinator = makeCoordinator(documentId: "note-a")
+        coordinator.onPersistScrollOffset = { _, _ in callCount += 1 }
+        coordinator.armScrollRestore(for: "note-a")
+
+        NativeTextViewWrapper.dismantleNSView(makeScrollView(scrolledTo: 0), coordinator: coordinator)
+
+        #expect(callCount == 0)
+    }
+
     @Test("Arming latches the document and gives it a bounded retry budget")
     func armingLatchesWithBudget() {
         let coordinator = makeCoordinator(documentId: "note-a")

--- a/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
@@ -1,0 +1,91 @@
+//
+//  ScrollMemoryTests.swift
+//  MarkdownEngineTests
+//
+//  Created by Luca Chen on 06.08.26.
+//
+//  The embedder-owned scroll memory: the teardown hand-off and the restore
+//  latch. The restore itself runs inside `updateNSView`, which needs a SwiftUI
+//  `Context` that cannot be built headlessly — verify that in a host app.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+private func makeCoordinator(documentId: String?) -> NativeTextViewCoordinator {
+    var text = ""
+    var wikiActive = false
+    let coordinator = NativeTextViewCoordinator(
+        text: Binding(get: { text }, set: { text = $0 }),
+        fontName: "SF Pro",
+        fontSize: 16,
+        isWikiLinkActive: Binding(get: { wikiActive }, set: { wikiActive = $0 }),
+        onLinkClick: nil,
+        onInlineSelectionChange: nil
+    )
+    coordinator.documentId = documentId
+    return coordinator
+}
+
+@MainActor
+private func makeScrollView(scrolledTo offsetY: CGFloat) -> NSScrollView {
+    let scrollView = ClampedScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+    let documentView = NSView(frame: NSRect(x: 0, y: 0, width: 600, height: 4000))
+    scrollView.documentView = documentView
+    scrollView.contentView.scroll(to: NSPoint(x: 0, y: offsetY))
+    scrollView.reflectScrolledClipView(scrollView.contentView)
+    return scrollView
+}
+
+@Suite("Embedder scroll memory")
+@MainActor
+struct ScrollMemoryTests {
+
+    @Test("Teardown hands the current offset to the embedder")
+    func dismantlePersistsOffset() {
+        var persisted: [String: CGFloat] = [:]
+        let coordinator = makeCoordinator(documentId: "note-a")
+        coordinator.onPersistScrollOffset = { persisted[$0] = $1 }
+        let scrollView = makeScrollView(scrolledTo: 1234)
+
+        NativeTextViewWrapper.dismantleNSView(scrollView, coordinator: coordinator)
+
+        #expect(persisted == ["note-a": 1234])
+    }
+
+    @Test("Teardown without a current document persists nothing")
+    func dismantleWithoutDocumentIdPersistsNothing() {
+        var callCount = 0
+        let coordinator = makeCoordinator(documentId: nil)
+        coordinator.onPersistScrollOffset = { _, _ in callCount += 1 }
+
+        NativeTextViewWrapper.dismantleNSView(makeScrollView(scrolledTo: 1234), coordinator: coordinator)
+
+        #expect(callCount == 0)
+    }
+
+    @Test("Arming latches the document and gives it a bounded retry budget")
+    func armingLatchesWithBudget() {
+        let coordinator = makeCoordinator(documentId: "note-a")
+        #expect(coordinator.pendingScrollRestoreDocumentId == nil)
+
+        coordinator.armScrollRestore(for: "note-a")
+
+        #expect(coordinator.pendingScrollRestoreDocumentId == "note-a")
+        #expect(coordinator.pendingScrollRestoreAttempts > 1)
+    }
+
+    @Test("Typing disarms a restore that has not landed yet")
+    func typingDisarmsPendingRestore() {
+        let coordinator = makeCoordinator(documentId: "note-a")
+        coordinator.armScrollRestore(for: "note-a")
+        let textView = NativeTextView(frame: .zero)
+
+        coordinator.textDidChange(Notification(name: NSText.didChangeNotification, object: textView))
+
+        #expect(coordinator.pendingScrollRestoreDocumentId == nil)
+    }
+}


### PR DESCRIPTION
An embedder that routes away from the editor and back — Nodes switching to its Home page or a tag page — lost every remembered scroll offset and reopened the note at the top. Note-to-note was always fine.

Three things had to give, each sufficient on its own:

1. **The store dies with the view.** `scrollOffsets` is an instance property of the coordinator, and unmounting the editor takes the coordinator with it.
2. **Nothing recorded the offset on the way out.** The only save site sat inside `if isNodeSwitch` in `updateNSView`, and there was no `dismantleNSView` in the package at all.
3. **The restore could never fire on a remount.** `makeCoordinator` seeds `documentId`, so the first `updateNSView` has `isNodeSwitch == false`.

Because of (3), simply making the dictionary `static` would not have fixed anything — and it would leak offsets between an embedder's separate editor windows.

## What this adds

`onPersistScrollOffset` / `restoreScrollOffset` on `NativeTextViewWrapper`, plus a real `dismantleNSView` that persists on teardown. Both closures are asked at call time rather than snapshotted per update, so an embedder's own retention rules can see changes made on the way out — Nodes needs exactly that to tell "went to Home, tab still open" from "the tab was replaced".

The restore is now **latched** instead of gated on `isNodeSwitch`: the first pass after a remount still carries the embedder's empty buffer, so the clamp would pull it straight back to the top and it has to try again on the pass that brings the real content.

**Passing neither closure leaves behavior unchanged.**

## The latch's own footgun, and why it is bounded

An earlier revision retried *until the offset landed*. That is wrong: a restore that clamps short leaves the latch armed, and the header's hosting view resolves its real height through an AppKit `frameDidChangeNotification` that generates no SwiftUI pass — so the retry budget can never be spent on the very case it was sized for. Any later pass that gets past the no-op gate then scrolls the reader away from wherever they had gone (a font change is explicitly exempted from that gate; the raw-source toggle clears `didInitialFormatting`).

So it now also gives up once `!text.isEmpty` — the real content has had its chance. A missed restore is a wrong offset once; an armed latch is a teleport minutes later. Teardown likewise refuses to record an offset while a restore is still pending, since the current position is the load position, not the reader's.

Note for anyone tempted by the tidier-looking `isNodeSwitch || lastSyncedText != text`: the coordinator init seeds `lastSyncedText = text.wrappedValue`, so on a remount both are `""` and that condition drops the latch before the document ever arrives.

## Testing

`swift build` and `swift test` green — 318 tests, 5 of them new (`ScrollMemoryTests`): the teardown hand-off, teardown without a current document, teardown mid-restore, the latch bookkeeping, and typing disarming an unlanded restore. The restore itself runs inside `updateNSView`, which needs a SwiftUI `Context` that cannot be built headlessly; that gap is stated in the test file header and was verified by hand in Nodes.

## Contributors

- @luca-chen198

🤖 Generated with [Claude Code](https://claude.com/claude-code)