### PR TITLE
Autolink bare URLs and emails in the HTML renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Table cells rasterize their own text and keep the glyph-box fill.
 
 ### Fixed
+- Bare URLs and emails survive rich copy as real links. The editor styler
+  linkifies them with `NSDataDetector`, but the HTML renderer emitted them as
+  plain text, so the pasteboard's HTML/RTF/web-archive flavors carried no
+  anchor — and rich-paste consumers (Mail, Outlook) run no link detection of
+  their own, leaving a URL that is clickable in the editor to paste as dead
+  text. `MarkdownHTMLRenderer` now wraps detector matches in `<a href>`
+  (emails as `mailto:`) using the same system detector as the styler; the RTF
+  and web-archive flavors are derived from that HTML, so all three inherit
+  the link. Explicit `[title](url)` links were already correct; a URL-shaped
+  run inside a link's own title stays plain so anchors never nest, and code
+  spans remain excluded, matching the styler.
 - Initially narrow tables reflow when the editor width shrinks instead of
   retaining stale image geometry until an unrelated full restyle.
 

--- a/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
@@ -192,22 +192,25 @@ public enum MarkdownHTMLRenderer {
 
     // MARK: - Inlines
 
-    private static func renderInlines(_ nodes: [InlineNode], ns: NSString, env: Env) -> String {
+    /// `linkable` is false inside an explicit link's title text, where wrapping
+    /// a URL-shaped run in its own anchor would nest `<a>` inside `<a>`.
+    private static func renderInlines(_ nodes: [InlineNode], ns: NSString, env: Env, linkable: Bool = true) -> String {
         var out = ""
-        for node in nodes { out += renderInline(node, ns: ns, env: env) }
+        for node in nodes { out += renderInline(node, ns: ns, env: env, linkable: linkable) }
         return out
     }
 
-    private static func renderInline(_ node: InlineNode, ns: NSString, env: Env) -> String {
+    private static func renderInline(_ node: InlineNode, ns: NSString, env: Env, linkable: Bool = true) -> String {
         switch node {
         case .text(let r):
-            return escape(ns.substring(with: r))
+            let s = ns.substring(with: r)
+            return linkable ? escapeAndAutolink(s) : escape(s)
 
         case .code(_, let content):
             return "<code>\(escape(ns.substring(with: content)))</code>"
 
         case .emphasis(let kind, _, _, let children):
-            let inner = renderInlines(children, ns: ns, env: env)
+            let inner = renderInlines(children, ns: ns, env: env, linkable: linkable)
             switch kind {
             case .italic:     return "<em>\(inner)</em>"
             case .bold:       return "<strong>\(inner)</strong>"
@@ -215,7 +218,7 @@ public enum MarkdownHTMLRenderer {
             }
 
         case .link(_, _, let url, _, let children):
-            return "<a href=\"\(escape(ns.substring(with: url)))\">\(renderInlines(children, ns: ns, env: env))</a>"
+            return "<a href=\"\(escape(ns.substring(with: url)))\">\(renderInlines(children, ns: ns, env: env, linkable: false))</a>"
 
         case .image(_, let alt, let url, _):
             return "<img src=\"\(escape(ns.substring(with: url)))\" alt=\"\(escape(ns.substring(with: alt)))\">"
@@ -233,7 +236,7 @@ public enum MarkdownHTMLRenderer {
             }
             let inner = node.children.isEmpty
                 ? escape(ns.substring(with: node.contentRange))
-                : renderInlines(node.children, ns: ns, env: env)
+                : renderInlines(node.children, ns: ns, env: env, linkable: linkable)
             return ext.html(childrenHTML: inner)
 
         case .inlineLatex(let range, _, _):
@@ -242,6 +245,37 @@ public enum MarkdownHTMLRenderer {
         case .escape(_, let character, _):
             return escape(ns.substring(with: character))
         }
+    }
+
+    // MARK: - Autolinking
+
+    // Built once: rebuilding the detector per render is the styler's documented
+    // 43ms trap (ENG-8g1b).
+    private static let autoLinkDetector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+
+    /// Escape a text run, wrapping bare URLs/emails in anchors. The editor's
+    /// styler linkifies these via the same system detector, but rich-paste
+    /// consumers (Mail, Outlook) take the pasteboard's HTML/RTF flavor verbatim
+    /// and never run their own link detection on it — without a real `<a>` a
+    /// URL that is clickable in the editor pastes as dead text. Code spans
+    /// never reach this path (they are their own inline node), matching the
+    /// styler's in-code exclusion.
+    private static func escapeAndAutolink(_ s: String) -> String {
+        guard let detector = autoLinkDetector else { return escape(s) }
+        let ns = s as NSString
+        let matches = detector.matches(in: s, range: NSRange(location: 0, length: ns.length))
+        guard !matches.isEmpty else { return escape(s) }
+
+        var out = ""
+        var cursor = 0
+        for match in matches {
+            guard let url = match.url else { continue }
+            out += escape(ns.substring(with: NSRange(location: cursor, length: match.range.location - cursor)))
+            out += "<a href=\"\(escape(url.absoluteString))\">\(escape(ns.substring(with: match.range)))</a>"
+            cursor = NSMaxRange(match.range)
+        }
+        out += escape(ns.substring(from: cursor))
+        return out
     }
 
     // MARK: - Escaping

--- a/Tests/MarkdownEngineTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownHTMLRendererTests.swift
@@ -60,4 +60,38 @@ struct MarkdownHTMLRendererTests {
         #expect(out.contains("<td>1</td>"))
         #expect(out.contains("<td>2</td>"))
     }
+
+    // The editor's styler makes bare URLs clickable via NSDataDetector, but
+    // rich-paste consumers (Mail, Outlook) take the HTML/RTF flavor verbatim
+    // and run no link detection of their own — so the renderer must emit a
+    // real anchor for everything the editor shows as a link.
+
+    @Test("bare URLs and emails autolink — mid-sentence, query escaping, scheme-less, mailto")
+    func bareURLAutolink() {
+        #expect(html("https://example.com")
+            == "<p><a href=\"https://example.com\">https://example.com</a></p>")
+        #expect(html("see https://example.com/a?b=1&c=2 now")
+            == "<p>see <a href=\"https://example.com/a?b=1&amp;c=2\">https://example.com/a?b=1&amp;c=2</a> now</p>")
+        #expect(html("www.example.com")
+            == "<p><a href=\"http://www.example.com\">www.example.com</a></p>")
+        #expect(html("mail me@example.com")
+            == "<p>mail <a href=\"mailto:me@example.com\">me@example.com</a></p>")
+    }
+
+    @Test("autolink reaches nested inline and re-parsed blockquote content")
+    func autolinkNestedContexts() {
+        #expect(html("**https://example.com**")
+            == "<p><strong><a href=\"https://example.com\">https://example.com</a></strong></p>")
+        #expect(html("> https://example.com")
+            == "<blockquote><a href=\"https://example.com\">https://example.com</a></blockquote>")
+    }
+
+    @Test("no autolink inside code spans or an explicit link's title")
+    func autolinkExclusions() {
+        #expect(html("`https://example.com`")
+            == "<p><code>https://example.com</code></p>")
+        // A URL-shaped title must not nest a second anchor inside the link's own.
+        #expect(html("[https://example.com](https://example.com)")
+            == "<p><a href=\"https://example.com\">https://example.com</a></p>")
+    }
 }

--- a/Tests/MarkdownEngineTests/MarkdownPasteboardWriterTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownPasteboardWriterTests.swift
@@ -9,6 +9,7 @@
 //  substitutes visible stand-ins for what RTF cannot represent.
 //
 
+import AppKit
 import Foundation
 import Testing
 @testable import MarkdownEngine
@@ -39,5 +40,22 @@ struct MarkdownPasteboardWriterTests {
         let rule = String(repeating: "─", count: 40)
         #expect(MarkdownPasteboardWriter.rtfFallbackBody("<p>a</p>\n<hr>\n<p>b</p>")
             == "<p>a</p>\n<p>\(rule)</p>\n<p>b</p>")
+    }
+
+    @Test("bare URL reaches the rich flavors as a real link (Mail/Outlook run no detection of their own)")
+    @MainActor
+    func bareURLRichFlavorsCarryAnchor() throws {
+        let pb = NSPasteboard(name: NSPasteboard.Name("MarkdownPasteboardWriterTests.bareURL"))
+        MarkdownPasteboardWriter.write(markdown: "https://example.com", to: pb)
+
+        let html = try #require(pb.string(forType: .html))
+        #expect(html.contains("<a href=\"https://example.com\">https://example.com</a>"))
+
+        // The RTF flavor is derived from that HTML; the anchor must come out
+        // the other side as an RTF hyperlink field, not styled plain text.
+        let rtf = try #require(pb.data(forType: .rtf))
+        let rtfSource = try #require(String(data: rtf, encoding: .isoLatin1))
+        #expect(rtfSource.contains("HYPERLINK"))
+        #expect(rtfSource.contains("example.com"))
     }
 }


### PR DESCRIPTION
## Problem

Copying a bare URL from the editor and pasting it into Mail or Outlook produced dead text. The editor styler linkifies bare URLs with `NSDataDetector`, but the HTML renderer emitted them as plain text — so the pasteboard's rich flavors (HTML, RTF, web archive) carried no anchor, and rich-paste consumers take those flavors verbatim without running any link detection of their own. (Explicit `[title](url)` links were always fine; only bare URLs died.)

**Reproducer:** type `https://example.com` in the editor (renders clickable), select + copy, paste into Outlook/Mail → plain text instead of a hyperlink.

## Fix

`MarkdownHTMLRenderer` now wraps detector matches in `<a href>` (emails as `mailto:`) when rendering text runs, using the same system detector as the styler so in-editor and copied-out linking agree. The RTF and web-archive flavors are derived from that HTML, so all three inherit the anchor.

Guards, both matching the styler's exclusions:
- Text inside an explicit link's title renders with `linkable: false`, so a URL-shaped title never nests a second `<a>` inside the link's own.
- Code spans are their own inline node and never reach the autolink path.

The detector is built once (per the styler's documented rebuild cost, ENG-8g1b).

## Tests

- Renderer: bare URL / mid-sentence URL with `&`-escaped query / scheme-less `www.` / email `mailto:`; autolink through bold and re-parsed blockquote content; exclusion inside code spans and link titles.
- Writer (end-to-end): a bare URL lands on the pasteboard with a real anchor in the `.html` flavor and a `HYPERLINK` field in the derived `.rtf`.

All 317 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)