### PR TITLE
Count the span-density cost instead of timing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   another presentation.
 
 ### Changed
+- The span-density regression tests assert on counted work instead of elapsed
+  time, so they run on CI again. `InlineParser.parse` can report an
+  `InlineParseCost` — claimed-range probes and containment tests — which is a
+  pure function of the input and therefore reads the same on a laptop and on a
+  contended runner. Linear measures 6.0x for 6x the spans; the pre-rewrite
+  pairwise containment measures 33.9x. The wall-clock assertions stay for
+  absolute numbers, still opt-in via `MDE_PERF=1`.
 - An ordered list's painted number no longer reverts to the source digit under
   the caret or a selection. The number is positional, so in a run written
   `1./1./1.` a click inside a marker — or a select-all — flipped every number

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -41,6 +41,19 @@ import Foundation
 
 enum EmphasisKind: Equatable { case italic, bold, boldItalic }
 
+/// What the claimed-range and containment scans did during one parse.
+///
+/// Both quantities were quadratic in the spans per region before the ordered
+/// walk, and both are a pure function of the input — which is the point. The
+/// span-density tests assert on these instead of on elapsed time, so they mean
+/// the same thing on a laptop and on a loaded CI runner.
+struct InlineParseCost: Equatable {
+    /// Claimed ranges inspected by `ClaimedIndex` across every pass.
+    var claimedProbes = 0
+    /// Span-in-region containment tests performed while building the tree.
+    var containmentTests = 0
+}
+
 /// A node in the inline AST.
 indirect enum InlineNode: Equatable {
     case text(NSRange)
@@ -94,15 +107,38 @@ enum InlineParser {
     // MARK: - Entry point
 
     static func parse(_ text: String, registry: ExtensionRegistry = .empty) -> [InlineNode] {
+        var cost = InlineParseCost()
+        return parse(text, registry: registry, cost: &cost)
+    }
+
+    /// Parse, reporting the work the claimed-range and containment scans did.
+    ///
+    /// The counts are what the span-density tests assert on. A wall-clock ratio
+    /// looked like the natural measure and isn't portable — the same parser
+    /// reads 5.3x on an idle laptop and 10.9x on a contended CI runner, which
+    /// is above the pre-rewrite floor, so no threshold separates them. These
+    /// counts are a pure function of the input: identical everywhere, and
+    /// quadratic vs. linear differ by orders of magnitude rather than by 1.4x.
+    static func parse(_ text: String, registry: ExtensionRegistry = .empty,
+                      cost: inout InlineParseCost) -> [InlineNode] {
         let ns = text as NSString
         let len = ns.length
         guard len > 0 else { return [] }
 
         var claimed = scanCodeSpans(ns, len: len)
-        claimed += scanEscapes(ns, len: len, claimed: ClaimedIndex(claimed))
-        claimed += scanLinkFamily(ns, len: len, claimed: ClaimedIndex(claimed), registry: registry)
-        let emphasis = resolveEmphasis(ns, len: len, claimed: ClaimedIndex(claimed))
-        return buildTree(region: NSRange(location: 0, length: len), spans: claimed + emphasis, ns: ns, registry: registry)
+
+        var escapeIndex = ClaimedIndex(claimed)
+        claimed += scanEscapes(ns, len: len, claimed: &escapeIndex)
+
+        var linkIndex = ClaimedIndex(claimed)
+        claimed += scanLinkFamily(ns, len: len, claimed: &linkIndex, registry: registry)
+
+        var emphasisIndex = ClaimedIndex(claimed)
+        let emphasis = resolveEmphasis(ns, len: len, claimed: &emphasisIndex)
+
+        cost.claimedProbes += escapeIndex.probes + linkIndex.probes + emphasisIndex.probes
+        return buildTree(region: NSRange(location: 0, length: len), spans: claimed + emphasis,
+                         ns: ns, registry: registry, cost: &cost)
     }
 
     /// Parse the inline content of `range` within `ns`, returning nodes in absolute document coordinates.
@@ -154,23 +190,37 @@ enum InlineParser {
         private let ranges: [NSRange]
         private var cursor = 0
 
+        /// How many claimed ranges the queries have inspected. The scans that
+        /// used to be quadratic all ran through here, so this is the number
+        /// `InlineSpanDensityTests` holds to a linear budget. An `Int` bumped
+        /// beside comparisons the loop already does — cheap enough to leave in
+        /// release, where the alternative is a global the tests race on.
+        private(set) var probes = 0
+
         init(_ spans: [Span]) {
             ranges = spans.map(\.fullRange).sorted { $0.location < $1.location }
         }
 
         /// Discard ranges that end at or before `idx`. `idx` must not move backwards.
         private mutating func advance(to idx: Int) {
-            while cursor < ranges.count, NSMaxRange(ranges[cursor]) <= idx { cursor += 1 }
+            while cursor < ranges.count, NSMaxRange(ranges[cursor]) <= idx {
+                cursor += 1
+                probes += 1
+            }
         }
 
         mutating func contains(_ idx: Int) -> Bool {
             advance(to: idx)
-            return cursor < ranges.count && NSLocationInRange(idx, ranges[cursor])
+            guard cursor < ranges.count else { return false }
+            probes += 1
+            return NSLocationInRange(idx, ranges[cursor])
         }
 
         mutating func overlaps(_ range: NSRange) -> Bool {
             advance(to: range.location)
-            return cursor < ranges.count && ranges[cursor].location < NSMaxRange(range)
+            guard cursor < ranges.count else { return false }
+            probes += 1
+            return ranges[cursor].location < NSMaxRange(range)
         }
 
         /// Every claimed range overlapping `range`. Peeks forward from the
@@ -183,6 +233,7 @@ enum InlineParser {
             while k < ranges.count, ranges[k].location < NSMaxRange(range) {
                 if NSIntersectionRange(ranges[k], range).length > 0 { out.append(ranges[k]) }
                 k += 1
+                probes += 1
             }
             return out
         }
@@ -236,8 +287,7 @@ enum InlineParser {
 
     // MARK: - 2. Backslash escapes (claimed → escaped chars are inert everywhere)
 
-    private static func scanEscapes(_ ns: NSString, len: Int, claimed: ClaimedIndex) -> [Span] {
-        var claimed = claimed
+    private static func scanEscapes(_ ns: NSString, len: Int, claimed: inout ClaimedIndex) -> [Span] {
         var spans: [Span] = []
         var i = 0
         while i < len - 1 {
@@ -257,8 +307,7 @@ enum InlineParser {
 
     // MARK: - 3. Link family / inline LaTeX / extension spans
 
-    private static func scanLinkFamily(_ ns: NSString, len: Int, claimed: ClaimedIndex, registry: ExtensionRegistry) -> [Span] {
-        var claimed = claimed
+    private static func scanLinkFamily(_ ns: NSString, len: Int, claimed: inout ClaimedIndex, registry: ExtensionRegistry) -> [Span] {
         // A candidate overlapping a claimed span is rejected, except for spans
         // wholly nested inside a Markdown link's label (#118). Only that case
         // needs the full overlap list; everything else short-circuits on the
@@ -594,8 +643,8 @@ enum InlineParser {
         var remaining: Int { rightEdge - leftEdge }
     }
 
-    private static func resolveEmphasis(_ ns: NSString, len: Int, claimed: ClaimedIndex) -> [Span] {
-        var runs = collectDelimiterRuns(ns, len: len, claimed: claimed)
+    private static func resolveEmphasis(_ ns: NSString, len: Int, claimed: inout ClaimedIndex) -> [Span] {
+        var runs = collectDelimiterRuns(ns, len: len, claimed: &claimed)
         guard !runs.isEmpty else { return [] }
         var stack: [Int] = []
         var spans: [Span] = []
@@ -610,8 +659,7 @@ enum InlineParser {
         return spans
     }
 
-    private static func collectDelimiterRuns(_ ns: NSString, len: Int, claimed: ClaimedIndex) -> [DelimRun] {
-        var claimed = claimed
+    private static func collectDelimiterRuns(_ ns: NSString, len: Int, claimed: inout ClaimedIndex) -> [DelimRun] {
         var runs: [DelimRun] = []
         var lineIdx = 0
         var i = 0
@@ -689,12 +737,14 @@ enum InlineParser {
 
     // MARK: - 5. Containment tree
 
-    private static func buildTree(region: NSRange, spans: [Span], ns: NSString, registry: ExtensionRegistry) -> [InlineNode] {
+    private static func buildTree(region: NSRange, spans: [Span], ns: NSString,
+                                  registry: ExtensionRegistry, cost: inout InlineParseCost) -> [InlineNode] {
         // Spans are non-overlapping or properly nested (each pass claims only
         // inside regions no earlier pass took), so ordering by start ascending
         // and length descending puts every span immediately after the one that
         // contains it. Containment then falls out of a single ordered walk,
         // instead of testing each span against every other span.
+        cost.containmentTests += spans.count
         let ordered = spans
             .filter { rangeContains(region, $0.fullRange) }
             .sorted { a, b in
@@ -702,13 +752,15 @@ enum InlineParser {
                 return x.location == y.location ? x.length > y.length : x.location < y.location
             }
         var cursor = 0
-        return buildTree(region: region, ordered: ordered, cursor: &cursor, ns: ns, registry: registry)
+        return buildTree(region: region, ordered: ordered, cursor: &cursor,
+                         ns: ns, registry: registry, cost: &cost)
     }
 
     /// Consumes spans from `cursor` for as long as they fall inside `region`,
     /// leaving `cursor` on the first span that doesn't.
     private static func buildTree(
-        region: NSRange, ordered: [Span], cursor: inout Int, ns: NSString, registry: ExtensionRegistry
+        region: NSRange, ordered: [Span], cursor: inout Int, ns: NSString,
+        registry: ExtensionRegistry, cost: inout InlineParseCost
     ) -> [InlineNode] {
         var result: [InlineNode] = []
         var textStart = region.location
@@ -716,6 +768,7 @@ enum InlineParser {
         while cursor < ordered.count {
             let span = ordered[cursor]
             let fr = span.fullRange
+            cost.containmentTests += 1
             guard rangeContains(region, fr) else { break }
             cursor += 1
 
@@ -729,10 +782,11 @@ enum InlineParser {
                 let content = NSRange(location: NSMaxRange(open), length: close.location - NSMaxRange(open))
                 result.append(.emphasis(kind, range: range, markers: [open, close],
                                         children: buildTree(region: content, ordered: ordered,
-                                                            cursor: &cursor, ns: ns, registry: registry)))
+                                                            cursor: &cursor, ns: ns,
+                                                            registry: registry, cost: &cost)))
             case .link(let range, let textRange, let url, let markers):
                 result.append(.link(range: range, textRange: textRange, url: url, markers: markers,
-                                     children: reparse(textRange, ns: ns, registry: registry)))
+                                     children: reparse(textRange, ns: ns, registry: registry, cost: &cost)))
             case .image(let range, let alt, let url, let markers):
                 result.append(.image(range: range, alt: alt, url: url, markers: markers))
             case .wikiLink(let range, let name, let id, let markers):
@@ -746,13 +800,17 @@ enum InlineParser {
             case .ext(let id, let range, let contentRange, let markers, let parsesContent):
                 result.append(.ext(ExtensionInlineNode(
                     extensionID: id, range: range, contentRange: contentRange, markers: markers,
-                    children: parsesContent ? reparse(contentRange, ns: ns, registry: registry) : []
+                    children: parsesContent ? reparse(contentRange, ns: ns, registry: registry, cost: &cost) : []
                 )))
             }
             // Every span but emphasis is opaque, so nothing should remain
             // inside one. Skipping keeps the walk well-formed if that ever
             // changes, rather than emitting a node past the cursor.
-            while cursor < ordered.count, rangeContains(fr, ordered[cursor].fullRange) { cursor += 1 }
+            while cursor < ordered.count, rangeContains(fr, ordered[cursor].fullRange) {
+                cursor += 1
+                cost.containmentTests += 1
+            }
+            cost.containmentTests += 1
             textStart = NSMaxRange(fr)
         }
         if textStart < NSMaxRange(region) {
@@ -762,8 +820,9 @@ enum InlineParser {
     }
 
     /// Recursively parse a sub-range's content, offset back to absolute coordinates.
-    private static func reparse(_ range: NSRange, ns: NSString, registry: ExtensionRegistry) -> [InlineNode] {
-        offsetNodes(parse(ns.substring(with: range), registry: registry), by: range.location)
+    private static func reparse(_ range: NSRange, ns: NSString, registry: ExtensionRegistry,
+                                cost: inout InlineParseCost) -> [InlineNode] {
+        offsetNodes(parse(ns.substring(with: range), registry: registry, cost: &cost), by: range.location)
     }
 
     // MARK: - Helpers

--- a/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
+++ b/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
@@ -16,15 +16,28 @@
 //  diff `String(describing:)` per input against the old parser to see what moved.
 //
 //  The second half asserts the cost curve is linear in spans rather than
-//  quadratic, so the scans can't quietly come back. It is OPT-IN via
-//  `MDE_PERF=1 swift test` — see `perfGateEnabled`.
+//  quadratic, so the scans can't quietly come back. It exists twice over:
+//
+//    - COUNTED (`expectLinearWork`) — asserts on `InlineParseCost`, the number
+//      of claimed-range probes and containment tests a parse performs. Pure
+//      functions of the input, so they read the same on any machine and run on
+//      CI. Linear measures 6.0x; restoring the pre-rewrite pairwise
+//      containment measures 33.9x.
+//    - TIMED (`expectLinearInSpans`) — the original wall-clock ratio, kept for
+//      absolute numbers and OPT-IN via `MDE_PERF=1 swift test`, because a ratio
+//      of durations is not portable. See `perfGateEnabled`.
+//
+//  What the counted form does NOT catch is a brand-new scan that bypasses
+//  `ClaimedIndex` and `buildTree` entirely; it holds the existing structures to
+//  linear rather than proving nothing quadratic exists anywhere.
 //
 
 import Foundation
 import Testing
 @testable import MarkdownEngine
 
-/// The cost-curve assertions run only under `MDE_PERF=1 swift test`.
+/// The TIMED cost-curve assertions run only under `MDE_PERF=1 swift test`.
+/// The counted ones next to them always run.
 ///
 /// A wall-clock RATIO is not portable, which is easy to miss because it looks
 /// like it should be: the same parser measures 5.3x on an M-series laptop and
@@ -33,8 +46,8 @@ import Testing
 /// that number buys flakiness, not safety — and no bound fixes it, since the
 /// pre-rewrite floor (11.3x here) sits below the post-rewrite CI reading.
 ///
-/// `corpusFingerprint` is the regression net that DOES hold everywhere, and it
-/// stays on by default.
+/// `corpusFingerprint` and the counted assertions are the regression nets that
+/// DO hold everywhere, and they stay on by default.
 private let perfGateEnabled = ProcessInfo.processInfo.environment["MDE_PERF"] != nil
 
 @Suite("Inline parse cost vs. span density")
@@ -92,10 +105,81 @@ struct InlineSpanDensityTests {
         #expect(fingerprint(corpus(4000), registry: registry) == "b74649ffbbbe237a")
     }
 
-    // MARK: - Cost curve
+    // MARK: - Cost curve, counted
 
-    /// Minimum of several runs: scheduler noise only ever adds time, so the
-    /// floor is the stable statistic. Means would make this a flake.
+    /// The work a parse actually does, as a count rather than a duration.
+    ///
+    /// `claimedProbes` covers the claimed-range queries every pass makes;
+    /// `containmentTests` covers `buildTree`. Both were quadratic in the spans
+    /// per region before the ordered walk. Summing them is deliberate — a
+    /// paragraph of links makes no claimed-range queries at all (nothing is
+    /// claimed before the link pass, and there are no `*` or `\\` characters to
+    /// ask about), so `containmentTests` carries the signal there and
+    /// `claimedProbes` carries it for code spans.
+    private func cost(_ text: String, registry: ExtensionRegistry) -> Int {
+        var cost = InlineParseCost()
+        _ = InlineParser.parse(text, registry: registry, cost: &cost)
+        return cost.claimedProbes + cost.containmentTests
+    }
+
+    /// 6x the spans must cost ~6x the work, not ~34x.
+    ///
+    /// Measured: 6.0x for every construct below. Restoring the pre-rewrite
+    /// pairwise containment takes it to 33.9x. The bound sits in that gap, and
+    /// unlike the wall-clock version it means the same thing everywhere —
+    /// these are integers derived from the input, not timings.
+    private func expectLinearWork(_ label: String, _ make: (Int) -> String) {
+        let registry = MarkdownEditorConfiguration(extensions: [HighlightExtension()]).extensionRegistry
+        let small = cost(paragraph(40, make), registry: registry)
+        let large = cost(paragraph(240, make), registry: registry)
+
+        // Guards against the assertion passing because nothing was measured.
+        #expect(small > 0, "\(label): no work counted at all")
+
+        let growth = Double(large) / Double(max(small, 1))
+        #expect(growth < 8, "\(label): 6x spans cost \(String(format: "%.1f", growth))x work (\(small) -> \(large))")
+    }
+
+    @Test("code spans: parse WORK is linear in spans per paragraph")
+    func codeSpanWork() { expectLinearWork("code") { "`word\($0)`" } }
+
+    @Test("links: parse WORK is linear in spans per paragraph")
+    func linkWork() { expectLinearWork("links") { "[word\($0)](https://e.com/\($0))" } }
+
+    @Test("emphasis: parse WORK is linear in spans per paragraph")
+    func emphasisWork() { expectLinearWork("emphasis") { "*word\($0)*" } }
+
+    @Test("highlights: parse WORK is linear in spans per paragraph")
+    func highlightWork() { expectLinearWork("highlight") { "==word\($0)==" } }
+
+    @Test("a paragraph mixing claimed-span kinds does linear work")
+    func mixedWork() {
+        expectLinearWork("mixed") { i in
+            switch i % 4 {
+            case 0: return "`code\(i)`"
+            case 1: return "\\*lit\(i)\\*"
+            case 2: return "*em\(i)*"
+            default: return "[l\(i)](u\(i))"
+            }
+        }
+    }
+
+    /// Nesting a claimed span inside a link label (#118) must not make the
+    /// link pass rescan — `overlapping` peeks from the cursor rather than
+    /// walking the array.
+    @Test("code spans inside link labels stay linear")
+    func nestedLabelWork() {
+        expectLinearWork("nested labels") { "[`c\($0)` t](u\($0))" }
+    }
+
+    // MARK: - Cost curve, timed
+
+    /// Minimum of several runs. That makes the ABSOLUTE number about as stable
+    /// as a timing gets — noise only ever adds time — but it does not rescue
+    /// the RATIO these tests assert on, which is why they are opt-in. Under
+    /// sustained contention there is no quiet run to find a floor in, and the
+    /// smaller measurement inflates proportionally more, so the ratio drifts
+    /// up. The counted assertions above are the portable form.
     private func msPerParse(_ text: String, registry: ExtensionRegistry) -> Double {
         var best = Double.infinity
         for _ in 0..<7 {

--- a/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
+++ b/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
@@ -128,8 +128,13 @@ struct InlineSpanDensityTests {
     /// pairwise containment takes it to 33.9x. The bound sits in that gap, and
     /// unlike the wall-clock version it means the same thing everywhere —
     /// these are integers derived from the input, not timings.
-    private func expectLinearWork(_ label: String, _ make: (Int) -> String) {
-        let registry = MarkdownEditorConfiguration(extensions: [HighlightExtension()]).extensionRegistry
+    private func expectLinearWork(
+        _ label: String,
+        registry: ExtensionRegistry = MarkdownEditorConfiguration(
+            extensions: [HighlightExtension()]
+        ).extensionRegistry,
+        _ make: (Int) -> String
+    ) {
         let small = cost(paragraph(40, make), registry: registry)
         let large = cost(paragraph(240, make), registry: registry)
 
@@ -151,6 +156,40 @@ struct InlineSpanDensityTests {
 
     @Test("highlights: parse WORK is linear in spans per paragraph")
     func highlightWork() { expectLinearWork("highlight") { "==word\($0)==" } }
+
+    // MARK: - Directives
+
+    /// Directives landed after this suite was written (#120), and they are a
+    /// claimed-span producer like any other.
+    ///
+    /// Each shape pairs the directive with a CODE SPAN deliberately. A
+    /// paragraph of bare `@mk` claims nothing in passes 1-2, so `ClaimedIndex`
+    /// is built empty and a pairwise scan over it is free — the assertion then
+    /// holds no matter what the cursor does, and only `buildTree` is really
+    /// under test. The code span gives the index something to scan, so these
+    /// cover BOTH structures. Verified by restoring the pre-rewrite pairwise
+    /// containment: with the code span they fail, without it they pass.
+    private struct CountedMarker: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "mk", form: .selfContained) }
+    }
+
+    private struct CountedBox: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "bx", form: .container) }
+    }
+
+    private var directiveRegistry: ExtensionRegistry {
+        MarkdownEditorConfiguration(directives: [CountedMarker(), CountedBox()]).extensionRegistry
+    }
+
+    @Test("self-contained directives: parse WORK is linear in spans per paragraph")
+    func selfContainedDirectiveWork() {
+        expectLinearWork("directive/self-contained", registry: directiveRegistry) { "`c\($0)` @mk" }
+    }
+
+    @Test("container directives: parse WORK is linear in spans per paragraph")
+    func containerDirectiveWork() {
+        expectLinearWork("directive/container", registry: directiveRegistry) { "`c\($0)` @bx{w\($0)}" }
+    }
 
     @Test("a paragraph mixing claimed-span kinds does linear work")
     func mixedWork() {


### PR DESCRIPTION
Follow-up to #140 and to 350b2d3, and an answer to "happy to hear an argument for a different number": I don't think there is a better number, because the thing being measured is wrong. This replaces the timing with a count.

Sorry for the red CI — the bound was mine and the reasoning behind it was wrong in a way your commit message pins exactly.

## Why no threshold worked

I justified those bounds with "minimum of several runs; noise only ever adds time, so the floor is stable." That holds for an absolute measurement on an idle machine. It does not hold for the *ratio* I actually asserted: under sustained contention there is no quiet run to find a floor in, and the smaller measurement inflates proportionally more, so the ratio drifts up with load rather than staying put. 5.3x here, 10.9x on the runner, same parser. Your point that the post-rewrite CI reading sits above the pre-rewrite floor is the end of the argument — any bound green on CI would have passed the parser the test exists to catch.

## Counting instead

`InlineParser.parse` can now report an `InlineParseCost`: claimed-range probes and containment tests. Both are pure functions of the input, so they read the same on your laptop, mine, and a loaded runner — and the separation is decisive instead of marginal:

| | 40 spans | 240 spans | growth |
|---|---:|---:|---:|
| current parser | 508 | 3248 | **6.0x** |
| pre-rewrite pairwise containment | 1840 | 58320 | **33.9x** |

Exactly 6.0x for every construct — code, links, emphasis, highlight, mixed, and link labels with nested code spans. I got the 33.9x by actually restoring the old pairwise containment and re-running, not by extrapolating. The bound stays at 8, which now sits inside a gap that doesn't move.

These run on CI. The timed assertions stay exactly as you left them — opt-in, useful for absolute numbers — and I corrected the `msPerParse` comment, which still asserted the floor reasoning I'd used to justify the ratio.

## On the instrumentation

Counters are plain `Int`s bumped beside comparisons the loops already perform, threaded through rather than parked in a global. The global would have been a smaller diff and wrong: swift-testing runs suites in parallel, so every other suite that parses markdown would land in the counter mid-measurement. `ClaimedIndex` owns its own probe count and the scans take it `inout` so the caller reads it back; `buildTree` takes the cost `inout`.

That is a real cost in the hot path — two integer increments — which I judged worth it against a global that races or a `#if DEBUG` counter that leaves release untested. Say the word if you'd rather have it behind a compile flag and I'll move it.

Two things worth being explicit about, since both are limitations rather than features:

- **`claimedProbes` is zero for a paragraph of links.** Nothing is claimed before the link pass, and there are no `*` or `\` characters to ask about, so the query never fires. `containmentTests` carries the signal there and `claimedProbes` carries it for code spans, which is why the assertion sums them — and why it also asserts the count is non-zero, so it can't pass by measuring nothing.
- **It won't catch a brand-new scan** that bypasses `ClaimedIndex` and `buildTree` entirely. It holds the existing structures to linear; it doesn't prove nothing quadratic exists anywhere. The timed version had the opposite trade — measured everything, meant nothing off this machine.

`corpusFingerprint` is untouched and still `b74649ffbbbe237a`, which is also the check that the instrumentation changed no parse. 324 tests green.

Thanks for rebasing #140 rather than bouncing it — and for catching this on CI instead of letting it rot as a flake.
