### PR TITLE
Animate every inspector disclosure, and stop the scroll restore from fighting the reader

### DIFF
--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -32,28 +32,49 @@ final class ClampedScrollView: NSScrollView {
     /// Layout passes left to land it. The document keeps growing for a few passes after
     /// a remount, so the first laid-out pass can still be too short for the offset.
     private var pendingRestoreLayouts = 0
+    /// A pass budget is not a time bound: passes only tick when one happens, so an
+    /// offset that never lands stays armed indefinitely and a much later relayout —
+    /// a find match, ⌘+, a window resize — replays it onto a reader who has long
+    /// since gone somewhere else. Restoring is only ever correct immediately after
+    /// the document arrives.
+    private var pendingRestoreDeadline: Date?
 
     /// Restore `y` once the geometry can carry it.
     func armScrollRestore(to y: CGFloat) {
         guard !fitsContent else { return }
         pendingRestoreY = y
         pendingRestoreLayouts = 8
+        pendingRestoreDeadline = Date(timeIntervalSinceNow: 1.0)
+    }
+
+    /// The reader (or something acting for them) moved the viewport — that position
+    /// wins over anything still queued. Every path that scrolls the clip view
+    /// directly must call this: find-match reveal, keyboard paging, drag-select
+    /// autoscroll. They bypass `scrollWheel` entirely.
+    func cancelPendingScrollRestore() {
+        pendingRestoreY = nil
+        pendingRestoreDeadline = nil
     }
 
     override func layout() {
         super.layout()
-        guard let y = pendingRestoreY, contentView.bounds.height > 0 else { return }
+        guard let y = pendingRestoreY else { return }
+        if let deadline = pendingRestoreDeadline, Date() > deadline {
+            cancelPendingScrollRestore()
+            return
+        }
+        guard contentView.bounds.height > 0 else { return }
         pendingRestoreLayouts -= 1
         contentView.scroll(to: NSPoint(x: contentView.bounds.origin.x, y: y))
         reflectScrolledClipView(contentView)
         clampToInsets()
         let landed = abs(contentView.bounds.origin.y - y) < 1
-        if landed || pendingRestoreLayouts <= 0 { pendingRestoreY = nil }
+        if landed || pendingRestoreLayouts <= 0 { cancelPendingScrollRestore() }
     }
 
     override func scrollWheel(with event: NSEvent) {
         // The reader took over; never yank them back to a remembered offset.
-        pendingRestoreY = nil
+        cancelPendingScrollRestore()
         if fitsContent {
             // No scrollable range — forward to the responder chain so the
             // enclosing (SwiftUI) scroll view receives the event. In the

--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -23,7 +23,37 @@ final class ClampedScrollView: NSScrollView {
         return NSSize(width: NSView.noIntrinsicMetric, height: container.scrollableContentHeight)
     }
 
+    /// Offset waiting for geometry. `updateNSView` runs on a SwiftUI state tick, where
+    /// the clip view can still be zero-height — a scroll applied there is accepted
+    /// verbatim (nothing to clamp against) and then discarded by the first real layout.
+    /// Restores are therefore handed here and applied from `layout()`, which is the
+    /// first moment the viewport and document heights actually exist.
+    private var pendingRestoreY: CGFloat?
+    /// Layout passes left to land it. The document keeps growing for a few passes after
+    /// a remount, so the first laid-out pass can still be too short for the offset.
+    private var pendingRestoreLayouts = 0
+
+    /// Restore `y` once the geometry can carry it.
+    func armScrollRestore(to y: CGFloat) {
+        guard !fitsContent else { return }
+        pendingRestoreY = y
+        pendingRestoreLayouts = 8
+    }
+
+    override func layout() {
+        super.layout()
+        guard let y = pendingRestoreY, contentView.bounds.height > 0 else { return }
+        pendingRestoreLayouts -= 1
+        contentView.scroll(to: NSPoint(x: contentView.bounds.origin.x, y: y))
+        reflectScrolledClipView(contentView)
+        clampToInsets()
+        let landed = abs(contentView.bounds.origin.y - y) < 1
+        if landed || pendingRestoreLayouts <= 0 { pendingRestoreY = nil }
+    }
+
     override func scrollWheel(with event: NSEvent) {
+        // The reader took over; never yank them back to a remembered offset.
+        pendingRestoreY = nil
         if fitsContent {
             // No scrollable range — forward to the responder chain so the
             // enclosing (SwiftUI) scroll view receives the event. In the

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -20,7 +20,25 @@ extension NSAttributedString.Key {
     static let findHighlight = NSAttributedString.Key("FindHighlight")
 }
 
+#if DEBUG
+/// Temporary find-navigation trace (stderr — stdout is block-buffered when redirected).
+func engineFindTrace(_ message: String) {
+    FileHandle.standardError.write(Data("FINDTRACE \(message)\n".utf8))
+}
+#endif
+
 extension NativeTextViewCoordinator {
+    #if DEBUG
+    /// Short per-coordinator identity, so a broadcast answered by several live
+    /// editors (`object: nil`) is visible as several different senders.
+    var findTraceID: String {
+        let addr = String(UInt(bitPattern: ObjectIdentifier(self).hashValue) & 0xFFFF, radix: 16)
+        let doc = documentId?.suffix(4).description ?? "nil"
+        let windowed = textView?.window != nil
+        return "\(addr)/doc:\(doc)\(windowed ? "" : "/OFFSCREEN")"
+    }
+    #endif
+
     /// Legacy path: the host computes match ranges and posts them. Kept for compatibility, but
     /// it trusts SOURCE-coordinate ranges, which misalign wherever the displayed text is shorter
     /// than the source (node links etc.). Prefer `handleFindQuery`.
@@ -38,11 +56,19 @@ extension NativeTextViewCoordinator {
     @objc func handleFindQuery(_ notification: Notification) {
         guard let tv = textView,
               let info = notification.userInfo,
-              let query = info["query"] as? String else { return }
+              let query = info["query"] as? String else {
+            #if DEBUG
+            engineFindTrace("query      \(findTraceID) IGNORED (no textView/query)")
+            #endif
+            return
+        }
         let requestedIndex = info["currentIndex"] as? Int ?? 0
 
         let allRanges = findMatches(of: query, in: tv.string as NSString)
         let currentIndex = allRanges.isEmpty ? 0 : min(max(requestedIndex, 0), allRanges.count - 1)
+        #if DEBUG
+        engineFindTrace("query      \(findTraceID) requested=\(requestedIndex) -> current=\(currentIndex) matches=\(allRanges.count) textLen=\((tv.string as NSString).length)")
+        #endif
         renderFindMatches(allRanges, currentIndex: currentIndex)
         postFindResults(count: allRanges.count)
     }
@@ -66,7 +92,12 @@ extension NativeTextViewCoordinator {
 
     private func postFindResults(count: Int) {
         if let resultsName = configuration.services.bus.findResults {
-            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: ["count": count])
+            var userInfo: [String: Any] = ["count": count]
+            #if DEBUG
+            userInfo["who"] = findTraceID
+            engineFindTrace("results    \(findTraceID) posts count=\(count)")
+            #endif
+            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: userInfo)
         }
     }
 
@@ -190,7 +221,12 @@ extension NativeTextViewCoordinator {
         }
 
         // Scroll the current match into view.
-        guard allRanges.indices.contains(currentIndex) else { return }
+        guard allRanges.indices.contains(currentIndex) else {
+            #if DEBUG
+            engineFindTrace("reveal     \(findTraceID) SKIPPED idx=\(currentIndex) out of \(allRanges.count)")
+            #endif
+            return
+        }
         let range = allRanges[currentIndex]
         guard range.location + range.length <= fullRange.length else { return }
         // Scroll via TextKit 2 fragment layout, which works whether or not the
@@ -202,6 +238,9 @@ extension NativeTextViewCoordinator {
         guard let tlm = tv.textLayoutManager,
               let scrollView = tv.enclosingScrollView,
               let matchStart = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: range.location) else {
+            #if DEBUG
+            engineFindTrace("reveal     \(findTraceID) FALLBACK scrollRangeToVisible idx=\(currentIndex)")
+            #endif
             tv.scrollRangeToVisible(range)
             return
         }
@@ -221,6 +260,16 @@ extension NativeTextViewCoordinator {
                 cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
                 scrollView.reflectScrolledClipView(cv)
                 (scrollView as? ClampedScrollView)?.clampToInsets()
+                #if DEBUG
+                engineFindTrace(String(format: "reveal     %@ idx=%d frag=[%.0f…%.0f] visible=[%.0f…%.0f] target=%.0f landed=%.0f",
+                                       findTraceID, currentIndex, frame.minY, frame.maxY,
+                                       visibleTop, visibleBottom, targetY, cv.bounds.origin.y))
+                #endif
+            } else {
+                #if DEBUG
+                engineFindTrace(String(format: "reveal     %@ idx=%d NO-SCROLL (deemed visible) frag=[%.0f…%.0f] visible=[%.0f…%.0f]",
+                                       findTraceID, currentIndex, frame.minY, frame.maxY, visibleTop, visibleBottom))
+                #endif
             }
             return false
         }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -39,6 +39,12 @@ extension NativeTextViewCoordinator {
         guard let tv = textView,
               let info = notification.userInfo,
               let query = info["query"] as? String else { return }
+        // Every live coordinator hears this (`object: nil`), and an editor the host
+        // has routed away from can outlive its view for a while — it is not the
+        // document being searched, and its answer would overwrite the real one's.
+        // Measured: 24 coordinators replying to one ⌘F, 22 of them windowless with
+        // an empty buffer, each reporting 0 matches and resetting the host's index.
+        guard tv.window != nil else { return }
         let requestedIndex = info["currentIndex"] as? Int ?? 0
 
         let allRanges = findMatches(of: query, in: tv.string as NSString)

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -20,25 +20,7 @@ extension NSAttributedString.Key {
     static let findHighlight = NSAttributedString.Key("FindHighlight")
 }
 
-#if DEBUG
-/// Temporary find-navigation trace (stderr — stdout is block-buffered when redirected).
-func engineFindTrace(_ message: String) {
-    FileHandle.standardError.write(Data("FINDTRACE \(message)\n".utf8))
-}
-#endif
-
 extension NativeTextViewCoordinator {
-    #if DEBUG
-    /// Short per-coordinator identity, so a broadcast answered by several live
-    /// editors (`object: nil`) is visible as several different senders.
-    var findTraceID: String {
-        let addr = String(UInt(bitPattern: ObjectIdentifier(self).hashValue) & 0xFFFF, radix: 16)
-        let doc = documentId?.suffix(4).description ?? "nil"
-        let windowed = textView?.window != nil
-        return "\(addr)/doc:\(doc)\(windowed ? "" : "/OFFSCREEN")"
-    }
-    #endif
-
     /// Legacy path: the host computes match ranges and posts them. Kept for compatibility, but
     /// it trusts SOURCE-coordinate ranges, which misalign wherever the displayed text is shorter
     /// than the source (node links etc.). Prefer `handleFindQuery`.
@@ -56,19 +38,11 @@ extension NativeTextViewCoordinator {
     @objc func handleFindQuery(_ notification: Notification) {
         guard let tv = textView,
               let info = notification.userInfo,
-              let query = info["query"] as? String else {
-            #if DEBUG
-            engineFindTrace("query      \(findTraceID) IGNORED (no textView/query)")
-            #endif
-            return
-        }
+              let query = info["query"] as? String else { return }
         let requestedIndex = info["currentIndex"] as? Int ?? 0
 
         let allRanges = findMatches(of: query, in: tv.string as NSString)
         let currentIndex = allRanges.isEmpty ? 0 : min(max(requestedIndex, 0), allRanges.count - 1)
-        #if DEBUG
-        engineFindTrace("query      \(findTraceID) requested=\(requestedIndex) -> current=\(currentIndex) matches=\(allRanges.count) textLen=\((tv.string as NSString).length)")
-        #endif
         renderFindMatches(allRanges, currentIndex: currentIndex)
         postFindResults(count: allRanges.count)
     }
@@ -92,12 +66,7 @@ extension NativeTextViewCoordinator {
 
     private func postFindResults(count: Int) {
         if let resultsName = configuration.services.bus.findResults {
-            var userInfo: [String: Any] = ["count": count]
-            #if DEBUG
-            userInfo["who"] = findTraceID
-            engineFindTrace("results    \(findTraceID) posts count=\(count)")
-            #endif
-            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: userInfo)
+            NotificationCenter.default.post(name: resultsName, object: nil, userInfo: ["count": count])
         }
     }
 
@@ -221,12 +190,7 @@ extension NativeTextViewCoordinator {
         }
 
         // Scroll the current match into view.
-        guard allRanges.indices.contains(currentIndex) else {
-            #if DEBUG
-            engineFindTrace("reveal     \(findTraceID) SKIPPED idx=\(currentIndex) out of \(allRanges.count)")
-            #endif
-            return
-        }
+        guard allRanges.indices.contains(currentIndex) else { return }
         let range = allRanges[currentIndex]
         guard range.location + range.length <= fullRange.length else { return }
         // Scroll via TextKit 2 fragment layout, which works whether or not the
@@ -238,9 +202,6 @@ extension NativeTextViewCoordinator {
         guard let tlm = tv.textLayoutManager,
               let scrollView = tv.enclosingScrollView,
               let matchStart = tlm.textContentManager?.location(tlm.documentRange.location, offsetBy: range.location) else {
-            #if DEBUG
-            engineFindTrace("reveal     \(findTraceID) FALLBACK scrollRangeToVisible idx=\(currentIndex)")
-            #endif
             tv.scrollRangeToVisible(range)
             return
         }
@@ -260,16 +221,6 @@ extension NativeTextViewCoordinator {
                 cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
                 scrollView.reflectScrolledClipView(cv)
                 (scrollView as? ClampedScrollView)?.clampToInsets()
-                #if DEBUG
-                engineFindTrace(String(format: "reveal     %@ idx=%d frag=[%.0f…%.0f] visible=[%.0f…%.0f] target=%.0f landed=%.0f",
-                                       findTraceID, currentIndex, frame.minY, frame.maxY,
-                                       visibleTop, visibleBottom, targetY, cv.bounds.origin.y))
-                #endif
-            } else {
-                #if DEBUG
-                engineFindTrace(String(format: "reveal     %@ idx=%d NO-SCROLL (deemed visible) frag=[%.0f…%.0f] visible=[%.0f…%.0f]",
-                                       findTraceID, currentIndex, frame.minY, frame.maxY, visibleTop, visibleBottom))
-                #endif
             }
             return false
         }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -217,6 +217,7 @@ extension NativeTextViewCoordinator {
             // Only scroll when the match is off-screen; reveal it a little below the top.
             if frame.minY < visibleTop || frame.maxY > visibleBottom {
                 let targetY = frame.minY - insetsTop - cv.bounds.height * 0.2
+                (scrollView as? ClampedScrollView)?.cancelPendingScrollRestore()
                 cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
                 scrollView.reflectScrolledClipView(cv)
                 (scrollView as? ClampedScrollView)?.clampToInsets()

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+DragSelectBoost.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+DragSelectBoost.swift
@@ -92,6 +92,7 @@ extension NativeTextView {
         }
 
         let origin = scrollView.contentView.bounds.origin
+        (scrollView as? ClampedScrollView)?.cancelPendingScrollRestore()
         scrollView.contentView.scroll(to: NSPoint(x: origin.x, y: origin.y + dragPolicy.scrollStepPerTick * direction))
         scrollView.reflectScrolledClipView(scrollView.contentView)
         (scrollView as? ClampedScrollView)?.clampToInsets()

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -391,6 +391,7 @@ extension NativeTextView {
             } else {
                 return false   // already visible (or a spurious verdict, corrected)
             }
+            (scrollView as? ClampedScrollView)?.cancelPendingScrollRestore()
             cv.scroll(to: NSPoint(x: cv.bounds.origin.x, y: targetY))
             scrollView.reflectScrolledClipView(cv)
             (scrollView as? ClampedScrollView)?.clampToInsets()

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -645,12 +645,30 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
                 nsView.contentView.scroll(to: NSPoint(x: nsView.contentView.bounds.origin.x, y: savedY))
                 nsView.reflectScrolledClipView(nsView.contentView)
                 (nsView as? ClampedScrollView)?.clampToInsets()
-                let landed = abs(nsView.contentView.bounds.origin.y - savedY) < 1
+                // A zero-height viewport cannot contradict any offset: with no range to
+                // clamp against the scroll is taken verbatim, so this is true for EVERY
+                // value — it says the offset was set, not that it survived. Believing it
+                // retires the latch before the geometry exists; the first real layout
+                // then clamps the reader back to the top and nothing is left to correct
+                // it. Measured on a remount after routing away: saved=201 actual=201
+                // landed=true viewportH=0.
+                let measured = nsView.contentView.bounds.height > 0
+                let landed = measured && abs(nsView.contentView.bounds.origin.y - savedY) < 1
                 // Also give up once the real content has had its chance, landed or
                 // not: an armed latch outliving the document's arrival lets a much
                 // later unrelated pass — ⌘+/⌘−, the raw-source toggle, a buffer
                 // reload — scroll the reader away from wherever they went.
-                if landed || !text.isEmpty || context.coordinator.pendingScrollRestoreAttempts <= 0 {
+                // The "content has arrived" give-up needs the same proof: a non-empty
+                // buffer laid out into nothing has not had its chance either.
+                if !measured {
+                    // No geometry on this tick: hand it to the scroll view, which applies
+                    // it from its own layout. Retiring the latch here is safe because the
+                    // offset is no longer waiting on another update pass — and those stop
+                    // coming (measured: two passes, both viewportH=0, then nothing, with
+                    // the latch left armed forever and teardown refusing to save).
+                    (nsView as? ClampedScrollView)?.armScrollRestore(to: savedY)
+                    context.coordinator.pendingScrollRestoreDocumentId = nil
+                } else if landed || !text.isEmpty || context.coordinator.pendingScrollRestoreAttempts <= 0 {
                     context.coordinator.pendingScrollRestoreDocumentId = nil
                 }
             } else {

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -737,6 +737,13 @@ private extension NativeTextViewWrapper {
         }
         let controller = coord.headerController ?? ScrollingHeaderController()
         coord.headerController = controller
+        // A document switch re-lays the header out at the new document's height a few
+        // milliseconds later. That is not a disclosure and must not be revealed — see
+        // `snapNextHeightChange`. Read before `updateNSView` advances the coordinator's
+        // `documentId`, so this is the switch's own pass.
+        if coord.documentId != documentId {
+            controller.snapNextHeightChange()
+        }
         controller.reconcile(
             header: header,
             collapsedHeight: headerCollapsedHeight,

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -219,17 +219,32 @@ final class ScrollingHeaderController {
     /// crossing's own curve, and the reveal starts where the reader last saw it.
     private func hostHeightChanged(container: NativeTextViewContainer) {
         guard lastExpanded == true,
-              animationToken == settledToken,               // no crossing in flight
               let constantC = constantConstraint, constantC.isActive,
               let host = hostingView else { return }
         let target = host.frame.height
-        guard target > 0, abs(target - constantC.constant) > 0.5 else { return }
+        // RETARGET rather than ignore while an animation is in flight. Dropping the
+        // change loses it for good — the band is held by the constant constraint for
+        // the whole expanded state, so nothing comes along later to correct it. Toggling
+        // a section twice in quick succession then finished on the height of the OPEN
+        // state while the content was already closed. Mid-flight the constant is a
+        // moving value, so the comparison has to be against the target it is heading for.
+        let pending = (animationToken == settledToken) ? constantC.constant
+                                                       : (animationTargetHeight ?? constantC.constant)
+        guard target > 0, abs(target - pending) > 0.5 else { return }
 
         // A live window resize reflows the inspector continuously, and an offscreen
         // container is still settling its first layout — neither is a disclosure, so
-        // track those directly instead of animating them.
+        // track those directly instead of animating them. Still through the animator
+        // at zero duration: a plain property set would leave an animation already in
+        // flight ticking toward its stale target underneath.
         guard !container.inLiveResize, container.window != nil else {
-            constantC.constant = target
+            animationToken += 1
+            settledToken = animationToken
+            animationTargetHeight = nil
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                constantC.animator().constant = target
+            }
             return
         }
         animate(to: target, expandedAfter: true, container: container)

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -87,16 +87,26 @@ final class ScrollingHeaderController {
         animationToken += 1
         settledToken = animationToken   // no animation in flight after teardown
         animationTargetHeight = nil
+        // Observers first, and the state they guard on before the views are detached:
+        // `removeFromSuperview()` lays out, which fires the HOST observer synchronously
+        // (queue: nil). Reached with `lastExpanded`/`constantConstraint` still set, it
+        // passes every guard and starts an animation — advancing `animationToken` right
+        // after this method equalised it, so the controller believes an animation is in
+        // flight for the rest of its life.
         if let clipFrameObserver {
             NotificationCenter.default.removeObserver(clipFrameObserver)
             self.clipFrameObserver = nil
         }
-        clipView?.removeFromSuperview()
-        clipView = nil
-        hostingView = nil
+        if let hostFrameObserver {
+            NotificationCenter.default.removeObserver(hostFrameObserver)
+            self.hostFrameObserver = nil
+        }
+        lastExpanded = nil
         equalityConstraint = nil
         constantConstraint = nil
-        lastExpanded = nil
+        hostingView = nil
+        clipView?.removeFromSuperview()
+        clipView = nil
         container?.headerHeight = 0   // → restack: text view back to y=0, container shrinks
     }
 
@@ -230,6 +240,13 @@ final class ScrollingHeaderController {
         // moving value, so the comparison has to be against the target it is heading for.
         let pending = (animationToken == settledToken) ? constantC.constant
                                                        : (animationTargetHeight ?? constantC.constant)
+        // `> 0` is load-bearing: an un-laid-out host reports 0, and accepting that here
+        // drives the band to zero and desynchronises it from the expansion state
+        // (proven — allowing 0 swaps the expand and collapse test outcomes). The cost is
+        // that a header which legitimately EMPTIES cannot collapse the band: zero is
+        // both "not measured yet" and "nothing to show", and the two are not
+        // distinguishable from the height alone. Such an embedder must collapse the
+        // header via `headerExpanded` instead of by emptying its content.
         guard target > 0, abs(target - pending) > 0.5 else { return }
 
         // A live window resize reflows the inspector continuously, and an offscreen

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -41,6 +41,27 @@ final class ScrollingHeaderController {
     /// Collapse/expand animation duration. Internal so tests can shrink it.
     var animationDuration: TimeInterval = 0.32
 
+    /// Height changes arriving before this instant are applied without animating.
+    ///
+    /// A document switch changes the hosted header's height exactly like a disclosure
+    /// does — the controller sees "the content is now a different height" and nothing
+    /// else — but it must not be revealed: the reader asked for another document, not
+    /// for the header to grow, and animating it drags the whole body text along for
+    /// 0.32s. Measured: two notes whose inspectors differ by 6pt slid the entire
+    /// document on every switch.
+    ///
+    /// A deadline rather than a one-shot flag: if the new document happens to have the
+    /// SAME header height, no change arrives and a one-shot flag would stay armed and
+    /// swallow the next real disclosure. The window is short enough that only the
+    /// switch's own relayout falls inside it (measured 3ms after the reconcile).
+    private var snapHeightChangesUntil: Date?
+
+    /// The embedder is switching documents: apply the next header height change
+    /// straight away instead of revealing it.
+    func snapNextHeightChange() {
+        snapHeightChangesUntil = Date(timeIntervalSinceNow: 0.2)
+    }
+
     /// The reserved top band the body should sit below. When the constant
     /// constraint governs (collapsed / animating) this is its `constant` — stable
     /// against transient mid-layout clip frames; otherwise the live clip height.
@@ -50,6 +71,7 @@ final class ScrollingHeaderController {
         }
         return clipView?.frame.height ?? 0
     }
+
 
     deinit {
         if let clipFrameObserver {
@@ -80,7 +102,50 @@ final class ScrollingHeaderController {
             // header survives (same root structure diffs in place).
             hostingView.rootView = header
         }
+        adoptSwitchedContentHeight(container: container)
         applyExpansion(collapsedHeight: collapsedHeight, expanded: expanded, container: container)
+    }
+
+    /// The embedder just swapped the document. Take the new content's height NOW,
+    /// in the same pass that installed it.
+    ///
+    /// Waiting for `hostHeightChanged` is too late even when it applies the change
+    /// instantly: the host is only re-measured a layout pass later, so the new
+    /// document's text is laid out against the OLD band and then moved. Measured on a
+    /// 6pt difference — reconcile at 72795 and 72809 both still saw the old height, the
+    /// host resized at 72812, the band followed at 72817, and the body text visibly
+    /// stepped. The equality constraint used to make this free, because it resized the
+    /// clip in the same pass as the host.
+    ///
+    /// Nothing to animate here by definition: the reader asked for another document.
+    private func adoptSwitchedContentHeight(container: NativeTextViewContainer) {
+        guard let until = snapHeightChangesUntil, Date() < until,
+              lastExpanded == true,
+              let host = hostingView,
+              let constantC = constantConstraint, constantC.isActive else { return }
+
+        host.invalidateIntrinsicContentSize()
+        host.layoutSubtreeIfNeeded()
+        let target = host.fittingSize.height
+        guard target > 0 else { return }
+
+        if abs(target - constantC.constant) > 0.5 {
+            animationToken += 1
+            settledToken = animationToken
+            animationTargetHeight = nil
+            constantC.constant = target
+        }
+        // Gated on the CLIP, not the constant. The host observer usually sets the
+        // constant a few ms before this runs, so a constant-based guard returned early
+        // and left the clip — which is what `headerHeight` and therefore the body's
+        // origin are read from — trailing by 42ms on every switch. Small deltas hide
+        // that; a note with many tags against one with none would not.
+        guard let clip = clipView, abs(clip.frame.height - constantC.constant) > 0.5 else { return }
+
+        // Resolve in THIS pass, so the band is right before the new document paints.
+        // Legal here (unlike inside the frame observers): reconcile runs from
+        // updateNSView, not from within a layout pass.
+        container.layoutSubtreeIfNeeded()
     }
 
     func remove(from container: NativeTextViewContainer?) {
@@ -249,19 +314,28 @@ final class ScrollingHeaderController {
         // header via `headerExpanded` instead of by emptying its content.
         guard target > 0, abs(target - pending) > 0.5 else { return }
 
-        // A live window resize reflows the inspector continuously, and an offscreen
-        // container is still settling its first layout — neither is a disclosure, so
-        // track those directly instead of animating them. Still through the animator
-        // at zero duration: a plain property set would leave an animation already in
-        // flight ticking toward its stale target underneath.
-        guard !container.inLiveResize, container.window != nil else {
+        // A live window resize reflows the inspector continuously, an offscreen
+        // container is still settling its first layout, and a document switch is the
+        // reader asking for other content — none of the three is a disclosure, so track
+        // those directly instead of animating them. Still through the animator at zero
+        // duration: a plain property set would leave an animation already in flight
+        // ticking toward its stale target underneath.
+        let isDocumentSwitch = (snapHeightChangesUntil.map { Date() < $0 } ?? false)
+        guard !container.inLiveResize, container.window != nil, !isDocumentSwitch else {
             animationToken += 1
             settledToken = animationToken
             animationTargetHeight = nil
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0
-                constantC.animator().constant = target
-            }
+            // Assigned DIRECTLY, not through the animator. Even at zero duration the
+            // animator defers the model value to a later transaction — measured 57ms,
+            // which on a document switch reads as the body text sitting still and then
+            // jumping. The token is advanced so a completion from an animation that was
+            // in flight cannot settle on top of this; that animation's remaining frames
+            // are a rare, brief tail, which is the cheaper trade against a visible
+            // delay on every single switch.
+            animationToken += 1
+            settledToken = animationToken
+            animationTargetHeight = nil
+            constantC.constant = target
             return
         }
         animate(to: target, expandedAfter: true, container: container)

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -28,6 +28,11 @@ final class ScrollingHeaderController {
     private var constantConstraint: NSLayoutConstraint?
     /// Observes the clip's height; the SOLE writer of `container.headerHeight`.
     private var clipFrameObserver: NSObjectProtocol?
+    /// Observes the HOSTED view's height. While expanded the clip is held by the
+    /// animatable constant constraint, so a content change reaches the band only
+    /// through here — and it reaches it BEFORE the band has moved, which is the whole
+    /// point (see `hostHeightChanged`).
+    private var hostFrameObserver: NSObjectProtocol?
     /// Last applied expanded state, to detect toggles.
     private var lastExpanded: Bool?
     /// Invalidates stale animation completions when a new toggle interrupts one.
@@ -50,7 +55,11 @@ final class ScrollingHeaderController {
         if let clipFrameObserver {
             NotificationCenter.default.removeObserver(clipFrameObserver)
         }
+        if let hostFrameObserver {
+            NotificationCenter.default.removeObserver(hostFrameObserver)
+        }
     }
+
 
     /// Build the header on first call; afterwards refresh the hosted content
     /// (every call — the embedder's view may capture changing values) and apply
@@ -178,7 +187,52 @@ final class ScrollingHeaderController {
         }
 
         container.layoutSubtreeIfNeeded()
+
+        // Expanded: hand the clip straight to the constant constraint, seeded with the
+        // height equality just resolved. From here on the band is OWNED by the constant
+        // and content changes arrive via `hostHeightChanged` — if the equality
+        // constraint kept the clip, Auto Layout would resize the band to the new content
+        // before anything could animate it, and the reveal would start from a frame
+        // already showing the end state (measured: clip=782 while the band read 913).
+        if expanded, let equalityC = equalityConstraint, let constantC = constantConstraint,
+           let clip = clipView, clip.frame.height > 0 {
+            constantC.constant = clip.frame.height
+            equalityC.isActive = false
+            constantC.isActive = true
+        }
+        host.postsFrameChangedNotifications = true
+        hostFrameObserver = NotificationCenter.default.addObserver(
+            forName: NSView.frameDidChangeNotification, object: host, queue: nil
+        ) { [weak self, weak container] _ in
+            MainActor.assumeIsolated {
+                guard let self, let container else { return }
+                self.hostHeightChanged(container: container)
+            }
+        }
+
         container.headerHeight = reservedHeight
+    }
+
+    /// The hosted content changed height while the header is expanded — a second
+    /// inspector section opened or closed. The clip is on the constant constraint, so
+    /// the band has NOT moved yet: animate it to the content's new height with the
+    /// crossing's own curve, and the reveal starts where the reader last saw it.
+    private func hostHeightChanged(container: NativeTextViewContainer) {
+        guard lastExpanded == true,
+              animationToken == settledToken,               // no crossing in flight
+              let constantC = constantConstraint, constantC.isActive,
+              let host = hostingView else { return }
+        let target = host.frame.height
+        guard target > 0, abs(target - constantC.constant) > 0.5 else { return }
+
+        // A live window resize reflows the inspector continuously, and an offscreen
+        // container is still settling its first layout — neither is a disclosure, so
+        // track those directly instead of animating them.
+        guard !container.inLiveResize, container.window != nil else {
+            constantC.constant = target
+            return
+        }
+        animate(to: target, expandedAfter: true, container: container)
     }
 
     private func applyExpansion(
@@ -222,7 +276,10 @@ final class ScrollingHeaderController {
                 container.layoutSubtreeIfNeeded()
             }
         }
-        // Expanded steady: the equality constraint already tracks the content.
+        // Expanded steady: nothing to do here. The band is held by the constant
+        // constraint and follows content through `hostHeightChanged`, which sees a
+        // disclosure the moment the hosted view resizes — earlier than this reconcile,
+        // which an embedder may skip entirely when its own state has not changed.
     }
 
     /// Tracks whether an animation is in flight: `animationToken` advances on every
@@ -241,12 +298,10 @@ final class ScrollingHeaderController {
             guard token == animationToken else { return }   // interrupted by a newer toggle
             settledToken = token
             animationTargetHeight = nil
-            if expandedAfter, let equalityC = equalityConstraint, let constantC = constantConstraint {
-                // Hand back to the live-tracking equality constraint.
-                constantC.isActive = false
-                equalityC.isActive = true
-                clipView?.superview?.layoutSubtreeIfNeeded()
-            }
+            // The clip STAYS on the constant constraint while expanded. Handing it back
+            // to the live-tracking equality constraint is what let a later disclosure
+            // resize the band in one layout pass before anything could animate it; the
+            // band now follows content through `hostHeightChanged` instead.
             // One clamp once the height has settled (skipped during the animation).
             (container.enclosingScrollView as? ClampedScrollView)?.clampToInsets()
         }

--- a/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
+++ b/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
@@ -32,7 +32,10 @@ struct FindHighlightRestoreTests {
     private static let text = "plain ==marked== tail"
     private static let blockContent = NSRange(location: 8, length: 6)
 
-    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+    /// The window is returned, not just built: find ignores an editor that is in no
+    /// window (a torn-down one must not answer for the visible document), and
+    /// nothing else here would keep the window alive.
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView, NSWindow) {
         _ = NSApplication.shared
         let coordinator = NativeTextViewCoordinator(
             text: .constant(text), fontName: "SF Pro", fontSize: 16,
@@ -47,12 +50,17 @@ struct FindHighlightRestoreTests {
         // fallback, which has no layout manager to route through here.
         let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
         scrollView.documentView = tv
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 400),
+            styleMask: [.borderless], backing: .buffered, defer: false
+        )
+        window.contentView = scrollView
         coordinator.textView = tv
         coordinator.rebuildTextStorageAndStyle(tv, from: text)
         coordinator.lastSyncedText = text
         coordinator.lastComputedStorage = text
         coordinator.previousDisplayLength = (text as NSString).length
-        return (coordinator, tv)
+        return (coordinator, tv, window)
     }
 
     private func background(_ tv: NativeTextView, at location: Int) -> NSColor? {
@@ -75,7 +83,8 @@ struct FindHighlightRestoreTests {
 
     @Test("searching the highlighted word and dismissing leaves the block painted")
     func blockReturnsAfterClearingItsOwnMatch() {
-        let (coordinator, tv) = makeEditor(Self.text)
+        let (coordinator, tv, window) = makeEditor(Self.text)
+        defer { window.contentView = nil }
         #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
 
         find("marked", coordinator)
@@ -88,7 +97,8 @@ struct FindHighlightRestoreTests {
 
     @Test("a match somewhere else never touches the block")
     func blockSurvivesAMatchElsewhere() {
-        let (coordinator, tv) = makeEditor(Self.text)
+        let (coordinator, tv, window) = makeEditor(Self.text)
+        defer { window.contentView = nil }
 
         find("tail", coordinator)
         #expect(background(tv, at: Self.blockContent.location) == NSColor.white)
@@ -98,9 +108,26 @@ struct FindHighlightRestoreTests {
         #expect(background(tv, at: 17) == nil)
     }
 
+    /// The query is broadcast to every live coordinator, and an editor the host has
+    /// routed away from can outlive its view. It answers for a document nobody is
+    /// looking at — with an empty buffer, so it reports zero matches and the host
+    /// resets its match index. Measured in the app: 24 coordinators replying to one
+    /// ⌘F, 22 of them windowless, and next/previous stuck bouncing between the first
+    /// two matches.
+    @Test("an editor that is in no window stays out of the search")
+    func windowlessEditorIgnoresTheQuery() {
+        let (coordinator, tv, window) = makeEditor(Self.text)
+        window.contentView = nil
+
+        find("tail", coordinator)
+
+        #expect(background(tv, at: 17) == nil)
+    }
+
     @Test("re-running the query drops the previous highlight instead of stacking")
     func repeatedQueriesLeaveNoResidue() {
-        let (coordinator, tv) = makeEditor(Self.text)
+        let (coordinator, tv, window) = makeEditor(Self.text)
+        defer { window.contentView = nil }
 
         find("marked", coordinator)
         find("tail", coordinator)


### PR DESCRIPTION
The inspector's header band only animated when its disclosure crossed between "nothing open" and "something open". Opening a second section while one was already open jumped. This animates every disclosure, then fixes the three things that turned up while making that hold.

## Header band

- **Animate on every disclosure**, not just the crossing one.
- **Retarget mid-animation.** A rapid open/close left the band stuck at the open height: the in-flight animation's target was compared against the *settled* constant, so the second change was dropped. It now retargets against whatever is actually pending.
- **Adopt a switched document's height without revealing it.** Routing to another note animated the band from the old note's height; the switch now assigns the constant directly.
- **Tear the host observer down with the clip, and before the views**, so a dismantled controller can't act on a half-removed hierarchy.

## Scroll restore

- **Apply the restore from `layout()`**, not from a SwiftUI state tick. A zero-height clip view accepts any offset verbatim, so the old code "succeeded" against no geometry and the first real layout dropped it (measured: `saved=201 actual=201 landed=true viewportH=0`).
- **Cancel the queued restore when the reader moves the viewport.** Only `scrollWheel` cleared it, but find-match reveal, keyboard paging and drag-select autoscroll all scroll the clip view directly — so the next layout pass replayed the remembered offset and threw the reader back.
- **Give the latch a deadline.** A pass budget only ticks when a pass happens, so an offset that never landed stayed armed indefinitely and any later relayout could replay it.

## Find

- **Windowless editors stay out of the search.** The query is broadcast to every live coordinator (`object: nil`), and an editor the host has routed away from can outlive its view. It answers for a document nobody is looking at — with an empty buffer, so it reports zero matches and the host resets its match index. Measured in the app: 24 coordinators replying to one ⌘F, 22 of them windowless, leaving next/previous bouncing between the first two matches forever.

## Tests

323 pass. Two find tests hosted their text view in no window at all and went red on the window guard — correct, a document being searched is on screen by definition; the fixture now uses a real `NSWindow` and a new test covers the windowless case. The suite also caught a `>= 0` boundary I got wrong on the retarget guard.

Note the animated band itself is not covered: the tests have no `NSWindow` driving `NSAnimationContext`, so the animated path can only be verified by hand.