### PR TITLE
Fix NSRangeException crash in updateCodeBlockSelection after document swap

### DIFF
--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
@@ -75,6 +75,11 @@ extension NativeTextViewCoordinator {
 
         let selections: [CodeBlockSelection] = cachedCodeBlockTokens.compactMap { originalIndex, token in
             guard !activeTokenIndices.contains(originalIndex) else { return nil }
+            // Cached tokens can be stale for one async hop after a document swap
+            // (shorter new text, queued update still holding the old parse). Skip
+            // out-of-bounds tokens; the next parse refreshes the cache.
+            guard NSMaxRange(token.range) <= nsText.length,
+                  NSMaxRange(token.contentRange) <= nsText.length else { return nil }
             if let visibleRange, NSIntersectionRange(token.range, visibleRange).length == 0 { return nil }
             guard var boundingRect = textView.viewRect(forCharacterRange: token.range, using: layoutBridge) else { return nil }
 


### PR DESCRIPTION
## Crash

A macOS app embedding this package crashes with SIGABRT via an uncaught `NSRangeException` from `-[NSString substringWithRange:]`. Faulting stack from a real .ips crash report:

```
Foundation  -[NSString substringWithRange:]
mm          closure #2 in NativeTextViewCoordinator.updateCodeBlockSelection(textView:parsed:)
libswiftCore Sequence.compactMap
mm          NativeTextViewCoordinator.updateCodeBlockSelection(textView:parsed:)
mm          closure #7 in NativeTextViewWrapper.updateNSView(_:context:)   (dispatched async to main)
```

## Root cause

In `Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift`, `updateCodeBlockSelection` reads `cachedCodeBlockTokens` — token ranges produced by a previous parse — and calls `nsText.substring(with: token.contentRange)` against the text view's **current** string.

When the host swaps documents and the new text is shorter than the old one, an async-queued update from `updateNSView` can run with the stale cached tokens. Their ranges exceed the new string's length, so `substringWithRange:` raises `NSRangeException` and the process aborts. Any document-switch path can trigger it.

## Reproduction sketch

1. Embed the editor in a host app.
2. Open a document that has a fenced code block near its end.
3. Switch to a shorter document. The queued `updateCodeBlockSelection` call still holds the old parse's token cache, whose ranges are out of bounds for the new string → crash.

## Fix

Add a bounds guard at the top of the `compactMap` closure that skips tokens whose `range` or `contentRange` extends past the current string length. Stale tokens are only possible for one async hop after a document swap; the next parse refreshes the cache and the copy-button overlays come back with correct geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)