### PR TITLE
Directives (2/4): styling — font composition, colour, and rich copy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -103,6 +103,13 @@ deliberately no "applies to everything after me" form: that would make styling
 depend on document position rather than tree position, breaking both the
 styler's compose-on-descent model and the block-scoped incremental restyle.
 
+Container styling lives in `MarkdownASTStyler+Directives.swift`: it resolves the
+directive, coerces its arguments against the declared schema, and returns the
+composed font the body's children inherit — one more step in the styler's
+existing compose-on-descent walk. `MarkdownHTMLRenderer` recovers arguments from
+the same prefix geometry, so rich copy and on-screen styling cannot disagree
+about what was passed.
+
 `DirectiveScanner` runs from `InlineParser.matchClaimedSpan` after every
 built-in, so a directive can never take text away from core markdown. Matches
 project into the AST as **extension-shaped nodes** (`InlineNode.ext`) under the

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,6 +7,7 @@ Sources/
 ├── MarkdownEngine/                          # core target — zero deps
 │   ├── Configuration/                       # MarkdownEditorConfiguration + MarkdownEditorTheme
 │   ├── Extensions/                          # the extension seam: MarkdownExtension + bundled opt-ins
+│   ├── Directives/                          # the directive seam: @font(size: 18){…} — parsing + registry
 │   ├── Services/                            # 4 protocols, no-op defaults, WikiLinkService
 │   ├── Parser/                              # two-phase AST: BlockParser → InlineParser → DocumentAST (+ token projection)
 │   ├── Styling/                             # MarkdownASTStyler (AST walk) + MarkdownStyler facade for NSImage passes
@@ -87,6 +88,50 @@ registered set can change at runtime.
 
 **Invariant:** built-in constructs always classify first; an extension can
 never take text away from core markdown.
+
+## [`Directives/`](Sources/MarkdownEngine/Directives): named inline commands
+
+`MarkdownDirective` is the extension seam's sibling for constructs that need a
+NAME and TYPED ARGUMENTS rather than delimiters — `@pagebreak`,
+`@font(size: 18){text}`. Registered via `MarkdownEditorConfiguration.directives`;
+the marker defaults to `@` and is configurable per registry and per directive.
+
+Two forms, both **tree-shaped** — a directive's effect never escapes its own
+node: **self-contained** (`@pagebreak`, a leaf) and **container**
+(`@font(size: 18){text}`, whose body is re-parsed as markdown). There is
+deliberately no "applies to everything after me" form: that would make styling
+depend on document position rather than tree position, breaking both the
+styler's compose-on-descent model and the block-scoped incremental restyle.
+
+`DirectiveScanner` runs from `InlineParser.matchClaimedSpan` after every
+built-in, so a directive can never take text away from core markdown. Matches
+project into the AST as **extension-shaped nodes** (`InlineNode.ext`) under the
+reserved `directive.` id namespace, rather than as a new node kind — so
+`InlineNode`, `buildTree`, `offsetNodes`, `InlineASTAdapter`, `MarkdownToken`,
+and `shrinkInlineMarkers` are untouched, and directives inherit marker shrink,
+caret reveal, token projection, incremental restyle, and rich copy unchanged.
+
+`DirectiveRegistry` is carried BY `ExtensionRegistry`, so the directive
+fingerprint folds into the one grammar fingerprint every parse cache already
+keys on — registering a directive at runtime invalidates those caches with no
+second key threaded through the pipeline. A directive-free registry produces a
+byte-identical fingerprint to before the seam existed, so no existing document
+re-parses.
+
+Arguments are coerced against the declared schema at STYLING time, not parse
+time: the parser stays geometry-only, and a directive-free document pays
+nothing.
+
+**Invariant:** registered names only. `@home` in prose stays literal text unless
+`home` is registered — the property that makes the seam safe to enable over an
+existing corpus.
+
+**Invariant:** a directive opens only after a non-word character, so
+`name@example.com` never opens one.
+
+**Invariant:** every rejection — unregistered name, malformed call, wrong form,
+unbalanced or multi-line run — leaves the candidate literal. Nothing here can
+produce a partial construct.
 
 ## [`Services/`](Sources/MarkdownEngine/Services): how does the engine talk to your app?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contains a span claimed by an earlier pass — a code span or a backslash
   escape — stays literal as a whole; constructs claimed in the same pass or
   later (`$…$`, links, emphasis, nesting) compose normally.
+- **Directive styling**: a container directive's `style` composes over the font
+  inherited at that point in the tree, so `@font(size: 18){**bold**}` is bold
+  AND 18pt rather than one overwriting the other. `FontDirective` and
+  `ColorDirective` ship as opt-in reference directives, off by default like the
+  bundled extensions. `MarkdownHTMLRenderer.html(from:extensions:directives:)`
+  takes the registered set so rich copy matches what is on screen.
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Directive seam (parsing)**: opt-in named inline commands with typed
+  arguments, for constructs that need a name and parameters rather than
+  delimiters. A `MarkdownDirective` declares a name, a form — self-contained
+  (`@pagebreak`) or container (`@font(size: 18){text}`) — and a parameter
+  schema; register instances via `MarkdownEditorConfiguration.directives`.
+  Directives never emit ranges and project into the AST as extension-shaped
+  nodes under a reserved `directive.` id namespace, so marker shrink, caret
+  reveal, token projection, incremental restyle, and rich copy apply unchanged.
+  The directive registry folds into the existing grammar fingerprint, so a
+  directive-free registry is byte-identical to before. The marker defaults to
+  `@` and is configurable per registry and per directive; unregistered names
+  stay literal text. Styling and autocomplete follow separately. A directive whose body
+  contains a span claimed by an earlier pass — a code span or a backslash
+  escape — stays literal as a whole; constructs claimed in the same pass or
+  later (`$…$`, links, emphasis, nesting) compose normally.
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+<<<<<<< HEAD
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.
@@ -27,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   items instead of rebuilding the whole list block. Marker, indentation,
   line-break, programmatic, and undo/redo edits still widen ordered-list runs
   when downstream display numbers can change.
+=======
+- **Directive seam (parsing)**: opt-in named inline commands with typed
+  arguments, for constructs that need a name and parameters rather than
+  delimiters. A `MarkdownDirective` declares a name, a form — self-contained
+  (`@pagebreak`) or container (`@font(size: 18){text}`) — and a parameter
+  schema; register instances via `MarkdownEditorConfiguration.directives`.
+  Directives never emit ranges and project into the AST as extension-shaped
+  nodes under a reserved `directive.` id namespace, so marker shrink, caret
+  reveal, token projection, incremental restyle, and rich copy apply unchanged.
+  The directive registry folds into the existing grammar fingerprint, so a
+  directive-free registry is byte-identical to before. The marker defaults to
+  `@` and is configurable per registry and per directive; unregistered names
+  stay literal text. Styling and autocomplete follow separately.
+>>>>>>> 68f1411 (Add the directive seam: parsing, registry, and argument coercion)
 
 ## [0.12.0] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-<<<<<<< HEAD
+- **Directive seam (parsing)**: opt-in named inline commands with typed
+  arguments, for constructs that need a name and parameters rather than
+  delimiters. A `MarkdownDirective` declares a name, a form — self-contained
+  (`@pagebreak`) or container (`@font(size: 18){text}`) — and a parameter
+  schema; register instances via `MarkdownEditorConfiguration.directives`.
+  Directives never emit ranges and project into the AST as extension-shaped
+  nodes under a reserved `directive.` id namespace, so marker shrink, caret
+  reveal, token projection, incremental restyle, and rich copy apply unchanged.
+  The directive registry folds into the existing grammar fingerprint, so a
+  directive-free registry is byte-identical to before. The marker defaults to
+  `@` and is configurable per registry and per directive; unregistered names
+  stay literal text. Styling and autocomplete follow separately. A directive whose body
+  contains a span claimed by an earlier pass — a code span or a backslash
+  escape — stays literal as a whole; constructs claimed in the same pass or
+  later (`$…$`, links, emphasis, nesting) compose normally.
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.
@@ -28,20 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   items instead of rebuilding the whole list block. Marker, indentation,
   line-break, programmatic, and undo/redo edits still widen ordered-list runs
   when downstream display numbers can change.
-=======
-- **Directive seam (parsing)**: opt-in named inline commands with typed
-  arguments, for constructs that need a name and parameters rather than
-  delimiters. A `MarkdownDirective` declares a name, a form — self-contained
-  (`@pagebreak`) or container (`@font(size: 18){text}`) — and a parameter
-  schema; register instances via `MarkdownEditorConfiguration.directives`.
-  Directives never emit ranges and project into the AST as extension-shaped
-  nodes under a reserved `directive.` id namespace, so marker shrink, caret
-  reveal, token projection, incremental restyle, and rich copy apply unchanged.
-  The directive registry folds into the existing grammar fingerprint, so a
-  directive-free registry is byte-identical to before. The marker defaults to
-  `@` and is configurable per registry and per directive; unregistered names
-  stay literal text. Styling and autocomplete follow separately.
->>>>>>> 68f1411 (Add the directive seam: parsing, registry, and argument coercion)
 
 ## [0.12.0] - 2026-08-10
 

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -151,6 +151,12 @@ struct ContentView: View {
         // you register. Unregistered syntax stays literal text.
         config.extensions = [HighlightExtension(), StrikethroughExtension()]
 
+        // The second opt-in seam: named inline commands with typed arguments,
+        // for constructs that need a name and parameters rather than
+        // delimiters. The marker defaults to `@` and is configurable via
+        // `config.directiveSettings`.
+        config.directives = [FontDirective(), ColorDirective()]
+
         // Toolbar-driven modes.
         config.rawSourceMode = showRawSource
         config.readingWidth = useReadingColumn ? 620 : nil
@@ -175,6 +181,7 @@ private var sampleMarkdown: String {
         blocksSection,
         taskListSection,
         extensionSection,
+        directiveSection,
         tableSection,
         latexSection,
         codeSection,
@@ -220,6 +227,38 @@ This ==highlighted text== comes from `HighlightExtension`, and this \
 ~~struck-through text~~ from `StrikethroughExtension`. Unregistered, the exact \
 same characters would stay literal markdown. Nesting works too: \
 ==with *italic* inside== and ~~also *nested*~~.
+"""
+
+/// Directive seam demo: `@font(…){…}` and `@color(…){…}` are supplied by the
+/// opt-in `FontDirective` and `ColorDirective` registered above.
+///
+/// The point of the section is COMPOSITION — a directive contributes a font
+/// transform to the styler's walk, so it stacks with whatever encloses it and
+/// with whatever it encloses, in both directions. That is why directives are
+/// scoped to a body instead of running "from here on": the effect lives in the
+/// tree, not in the document position.
+private let directiveSection = """
+## Directives
+
+The other opt-in seam: named inline commands with typed arguments, for \
+constructs that need a name and parameters rather than delimiters. \
+Unregistered, `@anything` stays literal text — and a bare `@` in prose or an \
+address like jason@wildthink.com never opens one.
+
+Sizes can be absolute — @font(size: 24){twenty-four point} — or relative to the \
+surrounding text: @font(size: 0.75em){three-quarter em} and @font(size: 150%){one-and-a-half}.
+
+Composition is the whole idea. Inside a directive, markup keeps the \
+directive's size: @font(size: 20){**bold**, *italic*, and ***both***}. Outside, \
+the directive keeps its context — the same call in a heading stays bold:
+
+### Headings compose too: @font(size: 28){bigger, still a heading}
+
+Colours work the same way, and directives nest: @color(red){red text}, \
+@color(blue){blue text}, and @font(size: 22){@color(purple){big and purple}}.
+
+Put the caret inside any directive to reveal its source; move away and the \
+syntax collapses back to just the styled text — exactly like every other marker.
 """
 
 /// Table layout demo: the first table's cells WRAP to the available width

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ checkboxes.
 
 - **Live Markdown styling** — bold, italic, headings, lists, blockquotes, GFM tables, code, links, task checkboxes, horizontal rules
 - **Extensions** — opt-in constructs beyond CommonMark (`==highlight==`, `~~strikethrough~~`, …); add your own via [`MarkdownExtension`](#extensions)
+- **Directives** — opt-in inline commands with typed arguments (`@font(size: 18){text}`); add your own via [`MarkdownDirective`](#directives)
 - **Wiki-style linking** with two-form storage / display roundtripping
   (`[[Name|<id>]]` ↔ `[[Name]]`)
 - **Image embeds** — both `![[Name]]` (Obsidian-style, embedder supplies the                           
@@ -140,6 +141,35 @@ attributes for its content and an HTML wrapper for rich copy. The parser owns
 all geometry, marker/fence hiding, caret reveal, and incremental restyling, so
 extensions behave identically to built-ins and cannot affect neighboring
 constructs. Conform to `MarkdownExtension` to add your own.
+
+### Directives
+
+The second opt-in seam, for constructs that need a NAME and TYPED ARGUMENTS
+rather than delimiters:
+
+```swift
+var config = MarkdownEditorConfiguration()
+config.directives = [FontDirective(), ColorDirective()]
+```
+
+```markdown
+@font(size: 18){eighteen point}, @font(size: 1.5em){half again}, @color(red){tinted}
+```
+
+Two forms: **self-contained** (`@pagebreak`) and **container**
+(`@font(size: 18){text}`). A container's font transform composes over the font
+inherited at that point in the tree, so `@font(size: 18){**bold**}` is bold
+*and* 18pt, and the same call inside a heading keeps the heading's weight.
+There is no "applies to everything after me" form — a directive's effect is
+scoped to its own node, which is what keeps per-keystroke restyling
+block-local.
+
+The marker defaults to `@` and is configurable per registry
+(`config.directiveSettings`) and per directive, and several markers can be
+registered at once. An unregistered name stays literal text, and a directive
+only opens at a non-word character — so `name@example.com` is never a
+directive. Conform to `MarkdownDirective` to add your own; a typical one is
+about 30 lines, including its argument schema and HTML.
 
 ### Code Blocks
 

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -84,6 +84,12 @@ public struct MarkdownEditorConfiguration: Sendable {
     /// so this stays the embedder's explicit decision rather than something the
     /// engine infers from a color it happens to see.
     public var cursorFollowsSpanInk: Bool
+    /// Opt-in inline commands (e.g. `@font(size: 18){text}`). Empty by
+    /// default: an unregistered name stays literal text. Order defines match
+    /// precedence among directives; built-in constructs always win first.
+    public var directives: [any MarkdownDirective]
+    /// Marker configuration for ``directives`` (default `@`).
+    public var directiveSettings: DirectiveRegistrySettings
 
     public init(
         theme: MarkdownEditorTheme = .default,
@@ -110,7 +116,9 @@ public struct MarkdownEditorConfiguration: Sendable {
         heightBehavior: HeightBehavior = .scrolls,
         rawSourceMode: Bool = false,
         extensions: [any MarkdownExtension] = [],
-        cursorFollowsSpanInk: Bool = false
+        cursorFollowsSpanInk: Bool = false,
+        directives: [any MarkdownDirective] = [],
+        directiveSettings: DirectiveRegistrySettings = .default
     ) {
         self.theme = theme
         self.services = services
@@ -137,6 +145,8 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.rawSourceMode = rawSourceMode
         self.extensions = extensions
         self.cursorFollowsSpanInk = cursorFollowsSpanInk
+        self.directives = directives
+        self.directiveSettings = directiveSettings
     }
 
     public static let `default` = MarkdownEditorConfiguration()

--- a/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
+++ b/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
@@ -7,7 +7,7 @@
 //  default — the core engine parses pure markdown; embedders opt in the way
 //  they do for extensions:
 //
-//      configuration.directives = [FontDirective(), ColorDirective(), PageBreakDirective()]
+//      configuration.directives = [FontDirective(), ColorDirective()]
 //
 //  `style` and `presentation` are declared here but not yet consulted by the
 //  styler (Phase 2 / Phase 3). In Phase 1 a container directive's syntax
@@ -50,17 +50,6 @@ public struct FontDirective: MarkdownDirective {
                       defaultValue: .keyword("regular"),
                       documentation: "Font weight."),
             ]
-        )
-    }
-
-    public var completion: DirectiveCompletion {
-        DirectiveCompletion(
-            id: id,
-            title: "font",
-            subtitle: "Set size, family, or weight for a span",
-            keywords: ["size", "typeface", "typography"],
-            snippet: "@font(size: |){}",
-            symbolName: "textformat.size"
         )
     }
 
@@ -123,17 +112,6 @@ public struct ColorDirective: MarkdownDirective {
         )
     }
 
-    public var completion: DirectiveCompletion {
-        DirectiveCompletion(
-            id: id,
-            title: "color",
-            subtitle: "Tint a span",
-            keywords: ["colour", "tint", "foreground"],
-            snippet: "@color(|){}",
-            symbolName: "paintpalette"
-        )
-    }
-
     public func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle {
         guard let name = arguments.positional.first?.asString else { return .inherit }
         // An unresolvable name leaves the body alone rather than guessing —
@@ -145,41 +123,5 @@ public struct ColorDirective: MarkdownDirective {
     public func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
         guard let name = arguments.positional.first?.asString else { return bodyHTML }
         return "<span style=\"color:\(name)\">\(bodyHTML)</span>"
-    }
-}
-
-// MARK: - @pagebreak — self-contained
-
-public struct PageBreakDirective: MarkdownDirective {
-
-    public static let identifier = "pagebreak"
-
-    public init() {}
-
-    public var id: String { Self.identifier }
-
-    public var syntax: DirectiveSyntax {
-        DirectiveSyntax(name: Self.identifier, form: .selfContained)
-    }
-
-    public var completion: DirectiveCompletion {
-        DirectiveCompletion(
-            id: id,
-            title: "pagebreak",
-            subtitle: "Force a page break when printing",
-            keywords: ["page", "break", "print"],
-            snippet: "@pagebreak",
-            symbolName: "arrow.down.to.line"
-        )
-    }
-
-    public func presentation(arguments: DirectiveArguments, context: DirectiveContext) -> DirectivePresentation {
-        // While the caret is inside, the source stays visible — the engine
-        // handles that flip; the directive just declines the glyph.
-        context.isActive ? .literal : .symbol(name: "arrow.down.to.line", tint: context.theme.mutedText)
-    }
-
-    public func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
-        "<hr class=\"pagebreak\" />"
     }
 }

--- a/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
+++ b/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
@@ -1,0 +1,185 @@
+//
+//  BuiltinDirectives.swift
+//  MarkdownEngine
+//
+//  Three directives that between them exercise every part of the seam, and
+//  double as the "is a new command easy to write?" test. Not registered by
+//  default — the core engine parses pure markdown; embedders opt in the way
+//  they do for extensions:
+//
+//      configuration.directives = [FontDirective(), ColorDirective(), PageBreakDirective()]
+//
+//  `style` and `presentation` are declared here but not yet consulted by the
+//  styler (Phase 2 / Phase 3). In Phase 1 a container directive's syntax
+//  shrinks and its body renders as ordinary markdown; a self-contained call
+//  renders as literal text.
+//
+
+import AppKit
+import Foundation
+
+// MARK: - @font(size: 18){…}  — container, font composition
+
+/// The motivating case.
+///
+/// Note the FORM: a bare `@font(size: 18)` has no meaning under tree-shaped
+/// semantics — there is nothing for it to apply to — so the directive requires
+/// a body. That is the one place this seam departs from a LaTeX-style
+/// `\font(size: 18)` sketch, and it is what keeps per-keystroke restyling
+/// block-local.
+public struct FontDirective: MarkdownDirective {
+
+    /// Well-known id, so embedders can reference the directive without
+    /// constructing one.
+    public static let identifier = "font"
+
+    public init() {}
+
+    public var id: String { Self.identifier }
+
+    public var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: Self.identifier,
+            form: .container,
+            parameters: [
+                .init(label: "size", kind: .length,
+                      documentation: "Point size, or 1.5em / 120% relative to the surrounding text."),
+                .init(label: "family", kind: .string,
+                      documentation: "Font family name; falls back to the editor font when unavailable."),
+                .init(label: "weight", kind: .keyword(["regular", "bold"]),
+                      defaultValue: .keyword("regular"),
+                      documentation: "Font weight."),
+            ]
+        )
+    }
+
+    public var completion: DirectiveCompletion {
+        DirectiveCompletion(
+            id: id,
+            title: "font",
+            subtitle: "Set size, family, or weight for a span",
+            keywords: ["size", "typeface", "typography"],
+            snippet: "@font(size: |){}",
+            symbolName: "textformat.size"
+        )
+    }
+
+    public func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle {
+        // An invalid call mutes rather than restyles, so a typo reads as broken
+        // instead of silently doing nothing.
+        guard arguments.isValid else {
+            return DirectiveStyle(attributes: [.foregroundColor: context.theme.disabledText])
+        }
+        var transform = DirectiveFontTransform()
+        if let size = arguments.length("size", relativeTo: context.inheritedFont.pointSize) {
+            transform.size = .absolute(size)
+        }
+        transform.familyName = arguments.string("family")
+        if arguments.string("weight") == "bold" { transform.traits = .boldFontMask }
+        return DirectiveStyle(font: transform)
+    }
+
+    public func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
+        var css: [String] = []
+        if let size = arguments.number("size") { css.append("font-size:\(size)px") }
+        if let family = arguments.string("family") { css.append("font-family:\(family)") }
+        if arguments.string("weight") == "bold" { css.append("font-weight:bold") }
+        return css.isEmpty ? bodyHTML : "<span style=\"\(css.joined(separator: ";"))\">\(bodyHTML)</span>"
+    }
+}
+
+// MARK: - @color(red){…}  — container, positional argument
+
+public struct ColorDirective: MarkdownDirective {
+
+    public static let identifier = "color"
+
+    public init() {}
+
+    public var id: String { Self.identifier }
+
+    /// Standard colour names, resolved without an asset catalog so
+    /// `@color(red){…}` works out of the box. An unlisted name falls back to
+    /// `NSColor(named:)`, so embedders can add their own palette entries.
+    private static let named: [String: NSColor] = [
+        "red": .systemRed, "orange": .systemOrange, "yellow": .systemYellow,
+        "green": .systemGreen, "mint": .systemMint, "teal": .systemTeal,
+        "cyan": .systemCyan, "blue": .systemBlue, "indigo": .systemIndigo,
+        "purple": .systemPurple, "pink": .systemPink, "brown": .systemBrown,
+        "gray": .systemGray, "grey": .systemGray,
+    ]
+
+    public var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: Self.identifier,
+            form: .container,
+            parameters: [
+                // Open set, not closed: the schema can't know the embedder's
+                // asset-catalog names, so resolution (and failure) belongs in
+                // `style`, not in argument coercion.
+                .init(label: nil, kind: .keyword([]), isRequired: true,
+                      documentation: "Standard colour name, or a name from your asset catalog."),
+            ]
+        )
+    }
+
+    public var completion: DirectiveCompletion {
+        DirectiveCompletion(
+            id: id,
+            title: "color",
+            subtitle: "Tint a span",
+            keywords: ["colour", "tint", "foreground"],
+            snippet: "@color(|){}",
+            symbolName: "paintpalette"
+        )
+    }
+
+    public func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle {
+        guard let name = arguments.positional.first?.asString else { return .inherit }
+        // An unresolvable name leaves the body alone rather than guessing —
+        // the source stays readable and the mistake is visible.
+        guard let color = Self.named[name.lowercased()] ?? NSColor(named: name) else { return .inherit }
+        return DirectiveStyle(attributes: [.foregroundColor: color])
+    }
+
+    public func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
+        guard let name = arguments.positional.first?.asString else { return bodyHTML }
+        return "<span style=\"color:\(name)\">\(bodyHTML)</span>"
+    }
+}
+
+// MARK: - @pagebreak — self-contained
+
+public struct PageBreakDirective: MarkdownDirective {
+
+    public static let identifier = "pagebreak"
+
+    public init() {}
+
+    public var id: String { Self.identifier }
+
+    public var syntax: DirectiveSyntax {
+        DirectiveSyntax(name: Self.identifier, form: .selfContained)
+    }
+
+    public var completion: DirectiveCompletion {
+        DirectiveCompletion(
+            id: id,
+            title: "pagebreak",
+            subtitle: "Force a page break when printing",
+            keywords: ["page", "break", "print"],
+            snippet: "@pagebreak",
+            symbolName: "arrow.down.to.line"
+        )
+    }
+
+    public func presentation(arguments: DirectiveArguments, context: DirectiveContext) -> DirectivePresentation {
+        // While the caret is inside, the source stays visible — the engine
+        // handles that flip; the directive just declines the glyph.
+        context.isActive ? .literal : .symbol(name: "arrow.down.to.line", tint: context.theme.mutedText)
+    }
+
+    public func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
+        "<hr class=\"pagebreak\" />"
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
@@ -1,0 +1,266 @@
+//
+//  DirectiveArguments.swift
+//  MarkdownEngine
+//
+//  Schema-driven coercion of a directive's argument list.
+//
+//  Runs at STYLING time, not parse time: the parser stays geometry-only (the
+//  isolation contract), and a document with no directives pays nothing. One
+//  short scan per directive per restyle sits well under the existing per-block
+//  token memo cost; if it ever shows up in a profile, memoise on
+//  (substring, schema fingerprint).
+//
+//  Coercion never throws and never partially applies: an argument that fails
+//  its schema is dropped and recorded as a diagnostic, so a directive always
+//  receives a well-formed `DirectiveArguments` and can decide for itself
+//  whether to render as invalid.
+//
+
+import Foundation
+
+// MARK: - Diagnostics
+
+/// A problem found while coercing a call against its schema.
+public struct DirectiveDiagnostic: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case unknownLabel(String)
+        case typeMismatch(label: String, expected: String)
+        case missingRequired(String)
+        case tooManyPositional
+    }
+    public let kind: Kind
+    /// Absolute range of the offending argument, for diagnostics styling.
+    public let range: NSRange
+
+    public init(kind: Kind, range: NSRange) {
+        self.kind = kind
+        self.range = range
+    }
+}
+
+// MARK: - Arguments
+
+/// Arguments of one directive call, already coerced against the schema.
+public struct DirectiveArguments: Sendable, Equatable {
+    public let labeled: [String: DirectiveValue]
+    public let positional: [DirectiveValue]
+    public let diagnostics: [DirectiveDiagnostic]
+
+    public static let empty = DirectiveArguments(labeled: [:], positional: [], diagnostics: [])
+
+    public init(
+        labeled: [String: DirectiveValue],
+        positional: [DirectiveValue],
+        diagnostics: [DirectiveDiagnostic]
+    ) {
+        self.labeled = labeled
+        self.positional = positional
+        self.diagnostics = diagnostics
+    }
+
+    /// True when every argument coerced cleanly and every required parameter
+    /// was supplied.
+    public var isValid: Bool { diagnostics.isEmpty }
+
+    public subscript(_ label: String) -> DirectiveValue? { labeled[label] }
+
+    public func string(_ label: String) -> String? { labeled[label]?.asString }
+    public func number(_ label: String) -> Double? { labeled[label]?.asDouble }
+    public func bool(_ label: String) -> Bool? { labeled[label]?.asBool }
+    public func length(_ label: String, relativeTo base: CGFloat) -> CGFloat? {
+        labeled[label]?.resolvedLength(relativeTo: base)
+    }
+}
+
+// MARK: - Parsing
+
+extension DirectiveArguments {
+
+    /// Parse and coerce the argument list at `range` against `schema`.
+    /// A nil or empty range still applies defaults and reports missing
+    /// required parameters, so `@font` and `@font()` behave identically.
+    init(parsing range: NSRange?, in ns: NSString, schema: [DirectiveParameter]) {
+        let anchor = range ?? NSRange(location: 0, length: 0)
+        guard let range, range.length > 0 else {
+            self = Self.applyingDefaults(labeled: [:], positional: [], diagnostics: [],
+                                         schema: schema, anchor: anchor)
+            return
+        }
+
+        let positionalSchema = schema.filter { $0.label == nil }
+        var labeled: [String: DirectiveValue] = [:]
+        var positional: [DirectiveValue] = []
+        var diagnostics: [DirectiveDiagnostic] = []
+
+        for argument in Self.splitArguments(range, in: ns) {
+            let (labelRange, valueRange) = Self.splitLabel(argument, in: ns)
+            let raw = ns.substring(with: valueRange).trimmingCharacters(in: .whitespaces)
+            guard !raw.isEmpty else { continue }
+
+            guard let labelRange else {
+                let index = positional.count
+                guard index < positionalSchema.count else {
+                    diagnostics.append(.init(kind: .tooManyPositional, range: argument))
+                    continue
+                }
+                let parameter = positionalSchema[index]
+                guard let value = Self.coerce(raw, to: parameter.kind) else {
+                    diagnostics.append(.init(
+                        kind: .typeMismatch(label: "#\(index)", expected: Self.describe(parameter.kind)),
+                        range: valueRange))
+                    continue
+                }
+                positional.append(value)
+                continue
+            }
+
+            let label = ns.substring(with: labelRange).trimmingCharacters(in: .whitespaces)
+            guard let parameter = schema.first(where: { $0.label == label }) else {
+                diagnostics.append(.init(kind: .unknownLabel(label), range: argument))
+                continue
+            }
+            guard let value = Self.coerce(raw, to: parameter.kind) else {
+                diagnostics.append(.init(
+                    kind: .typeMismatch(label: label, expected: Self.describe(parameter.kind)),
+                    range: valueRange))
+                continue
+            }
+            labeled[label] = value
+        }
+
+        self = Self.applyingDefaults(labeled: labeled, positional: positional,
+                                     diagnostics: diagnostics, schema: schema, anchor: range)
+    }
+
+    /// Fill unsupplied parameters — labelled and positional alike — from their
+    /// defaults, then report whatever required parameter is still missing.
+    ///
+    /// Positional defaults fill by POSITION, so they only apply to a tail the
+    /// call didn't reach: given `(a, b = 2, c)`, `@x(1)` yields `1, 2` and
+    /// still reports `#2` missing. A default can't be skipped over, because
+    /// there is no syntax for "use the default here but supply the next one" —
+    /// so the first positional without a default ends the filling.
+    private static func applyingDefaults(
+        labeled: [String: DirectiveValue],
+        positional: [DirectiveValue],
+        diagnostics: [DirectiveDiagnostic],
+        schema: [DirectiveParameter],
+        anchor: NSRange
+    ) -> DirectiveArguments {
+        var labeled = labeled
+        var positional = positional
+        var diagnostics = diagnostics
+
+        for parameter in schema {
+            guard let label = parameter.label, labeled[label] == nil else { continue }
+            if let fallback = parameter.defaultValue {
+                labeled[label] = fallback
+            } else if parameter.isRequired {
+                diagnostics.append(.init(kind: .missingRequired(label), range: anchor))
+            }
+        }
+
+        let positionalSchema = schema.filter { $0.label == nil }
+        for index in positional.count..<max(positional.count, positionalSchema.count) {
+            guard let fallback = positionalSchema[index].defaultValue else { break }
+            positional.append(fallback)
+        }
+        for index in positional.count..<max(positional.count, positionalSchema.count)
+        where positionalSchema[index].isRequired {
+            diagnostics.append(.init(kind: .missingRequired("#\(index)"), range: anchor))
+        }
+
+        return DirectiveArguments(labeled: labeled, positional: positional, diagnostics: diagnostics)
+    }
+
+    /// Split on commas at depth 0, respecting quotes and nested brackets, so
+    /// `@x(a: "one, two", b: f(1, 2))` is two arguments.
+    private static func splitArguments(_ range: NSRange, in ns: NSString) -> [NSRange] {
+        var out: [NSRange] = []
+        var depth = 0
+        var inQuote = false
+        var start = range.location
+        for k in range.location..<NSMaxRange(range) {
+            let c = ns.character(at: k)
+            if c == 0x22 { inQuote.toggle(); continue }             // "
+            guard !inQuote else { continue }
+            switch c {
+            case 0x28, 0x5B, 0x7B: depth += 1                       // ( [ {
+            case 0x29, 0x5D, 0x7D: depth -= 1                       // ) ] }
+            case 0x2C where depth == 0:                             // ,
+                out.append(NSRange(location: start, length: k - start))
+                start = k + 1
+            default: break
+            }
+        }
+        if start < NSMaxRange(range) {
+            out.append(NSRange(location: start, length: NSMaxRange(range) - start))
+        }
+        return out
+    }
+
+    /// Split `label: value` at the first depth-0, unquoted colon. A value
+    /// containing a colon (`"12:30"`) is safe because quotes suppress the split.
+    private static func splitLabel(_ range: NSRange, in ns: NSString) -> (label: NSRange?, value: NSRange) {
+        var inQuote = false
+        for k in range.location..<NSMaxRange(range) {
+            let c = ns.character(at: k)
+            if c == 0x22 { inQuote.toggle(); continue }
+            if c == 0x3A, !inQuote {                                 // :
+                let label = NSRange(location: range.location, length: k - range.location)
+                let value = NSRange(location: k + 1, length: NSMaxRange(range) - (k + 1))
+                // A leading colon (`:value`) is not a label.
+                return label.length > 0 ? (label, value) : (nil, range)
+            }
+        }
+        return (nil, range)
+    }
+
+    private static func coerce(_ raw: String, to kind: DirectiveParameter.Kind) -> DirectiveValue? {
+        if raw.count >= 2, raw.hasPrefix("\""), raw.hasSuffix("\"") {
+            let inner = String(raw.dropFirst().dropLast())
+            // A quoted literal is a string; it satisfies .string and .keyword,
+            // and nothing else.
+            switch kind {
+            case .string:                 return .string(inner)
+            case .keyword(let allowed):   return allowed.isEmpty || allowed.contains(inner) ? .keyword(inner) : nil
+            default:                      return nil
+            }
+        }
+        switch kind {
+        case .string:
+            return .string(raw)
+        case .boolean:
+            guard let value = Bool(raw) else { return nil }
+            return .boolean(value)
+        case .number:
+            guard let value = Double(raw) else { return nil }
+            return .number(value)
+        case .length:
+            return parseLength(raw)
+        case .keyword(let allowed):
+            guard allowed.isEmpty || allowed.contains(raw) else { return nil }
+            return .keyword(raw)
+        }
+    }
+
+    /// `18`, `18pt`, `1.5em`, `50%`
+    private static func parseLength(_ raw: String) -> DirectiveValue? {
+        for unit in [DirectiveUnit.percent, .em, .point] where raw.hasSuffix(unit.rawValue) {
+            guard let value = Double(raw.dropLast(unit.rawValue.count)) else { return nil }
+            return .length(value, unit)
+        }
+        guard let value = Double(raw) else { return nil }
+        return .length(value, .none)
+    }
+
+    private static func describe(_ kind: DirectiveParameter.Kind) -> String {
+        switch kind {
+        case .string:               return "string"
+        case .number:               return "number"
+        case .length:               return "length"
+        case .boolean:              return "boolean"
+        case .keyword(let allowed): return allowed.isEmpty ? "keyword" : allowed.joined(separator: "|")
+        }
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
@@ -1,0 +1,251 @@
+//
+//  DirectiveArguments.swift
+//  MarkdownEngine
+//
+//  Schema-driven coercion of a directive's argument list.
+//
+//  Runs at STYLING time, not parse time: the parser stays geometry-only (the
+//  isolation contract), and a document with no directives pays nothing. One
+//  short scan per directive per restyle sits well under the existing per-block
+//  token memo cost; if it ever shows up in a profile, memoise on
+//  (substring, schema fingerprint).
+//
+//  Coercion never throws and never partially applies: an argument that fails
+//  its schema is dropped and recorded as a diagnostic, so a directive always
+//  receives a well-formed `DirectiveArguments` and can decide for itself
+//  whether to render as invalid.
+//
+
+import Foundation
+
+// MARK: - Diagnostics
+
+/// A problem found while coercing a call against its schema.
+public struct DirectiveDiagnostic: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case unknownLabel(String)
+        case typeMismatch(label: String, expected: String)
+        case missingRequired(String)
+        case tooManyPositional
+    }
+    public let kind: Kind
+    /// Absolute range of the offending argument, for diagnostics styling.
+    public let range: NSRange
+
+    public init(kind: Kind, range: NSRange) {
+        self.kind = kind
+        self.range = range
+    }
+}
+
+// MARK: - Arguments
+
+/// Arguments of one directive call, already coerced against the schema.
+public struct DirectiveArguments: Sendable, Equatable {
+    public let labeled: [String: DirectiveValue]
+    public let positional: [DirectiveValue]
+    public let diagnostics: [DirectiveDiagnostic]
+
+    public static let empty = DirectiveArguments(labeled: [:], positional: [], diagnostics: [])
+
+    public init(
+        labeled: [String: DirectiveValue],
+        positional: [DirectiveValue],
+        diagnostics: [DirectiveDiagnostic]
+    ) {
+        self.labeled = labeled
+        self.positional = positional
+        self.diagnostics = diagnostics
+    }
+
+    /// True when every argument coerced cleanly and every required parameter
+    /// was supplied.
+    public var isValid: Bool { diagnostics.isEmpty }
+
+    public subscript(_ label: String) -> DirectiveValue? { labeled[label] }
+
+    public func string(_ label: String) -> String? { labeled[label]?.asString }
+    public func number(_ label: String) -> Double? { labeled[label]?.asDouble }
+    public func bool(_ label: String) -> Bool? { labeled[label]?.asBool }
+    public func length(_ label: String, relativeTo base: CGFloat) -> CGFloat? {
+        labeled[label]?.resolvedLength(relativeTo: base)
+    }
+}
+
+// MARK: - Parsing
+
+extension DirectiveArguments {
+
+    /// Parse and coerce the argument list at `range` against `schema`.
+    /// A nil or empty range still applies defaults and reports missing
+    /// required parameters, so `@font` and `@font()` behave identically.
+    init(parsing range: NSRange?, in ns: NSString, schema: [DirectiveParameter]) {
+        let anchor = range ?? NSRange(location: 0, length: 0)
+        guard let range, range.length > 0 else {
+            self = Self.applyingDefaults(labeled: [:], positional: [], diagnostics: [],
+                                         schema: schema, anchor: anchor)
+            return
+        }
+
+        let positionalSchema = schema.filter { $0.label == nil }
+        var labeled: [String: DirectiveValue] = [:]
+        var positional: [DirectiveValue] = []
+        var diagnostics: [DirectiveDiagnostic] = []
+
+        for argument in Self.splitArguments(range, in: ns) {
+            let (labelRange, valueRange) = Self.splitLabel(argument, in: ns)
+            let raw = ns.substring(with: valueRange).trimmingCharacters(in: .whitespaces)
+            guard !raw.isEmpty else { continue }
+
+            guard let labelRange else {
+                let index = positional.count
+                guard index < positionalSchema.count else {
+                    diagnostics.append(.init(kind: .tooManyPositional, range: argument))
+                    continue
+                }
+                let parameter = positionalSchema[index]
+                guard let value = Self.coerce(raw, to: parameter.kind) else {
+                    diagnostics.append(.init(
+                        kind: .typeMismatch(label: "#\(index)", expected: Self.describe(parameter.kind)),
+                        range: valueRange))
+                    continue
+                }
+                positional.append(value)
+                continue
+            }
+
+            let label = ns.substring(with: labelRange).trimmingCharacters(in: .whitespaces)
+            guard let parameter = schema.first(where: { $0.label == label }) else {
+                diagnostics.append(.init(kind: .unknownLabel(label), range: argument))
+                continue
+            }
+            guard let value = Self.coerce(raw, to: parameter.kind) else {
+                diagnostics.append(.init(
+                    kind: .typeMismatch(label: label, expected: Self.describe(parameter.kind)),
+                    range: valueRange))
+                continue
+            }
+            labeled[label] = value
+        }
+
+        self = Self.applyingDefaults(labeled: labeled, positional: positional,
+                                     diagnostics: diagnostics, schema: schema, anchor: range)
+    }
+
+    /// Fill unsupplied labelled parameters from their defaults, then report
+    /// whatever required parameter is still missing.
+    private static func applyingDefaults(
+        labeled: [String: DirectiveValue],
+        positional: [DirectiveValue],
+        diagnostics: [DirectiveDiagnostic],
+        schema: [DirectiveParameter],
+        anchor: NSRange
+    ) -> DirectiveArguments {
+        var labeled = labeled
+        var diagnostics = diagnostics
+        for parameter in schema {
+            guard let label = parameter.label, labeled[label] == nil else { continue }
+            if let fallback = parameter.defaultValue {
+                labeled[label] = fallback
+            } else if parameter.isRequired {
+                diagnostics.append(.init(kind: .missingRequired(label), range: anchor))
+            }
+        }
+        let requiredPositional = schema.filter { $0.label == nil && $0.isRequired }.count
+        if positional.count < requiredPositional {
+            diagnostics.append(.init(kind: .missingRequired("#\(positional.count)"), range: anchor))
+        }
+        return DirectiveArguments(labeled: labeled, positional: positional, diagnostics: diagnostics)
+    }
+
+    /// Split on commas at depth 0, respecting quotes and nested brackets, so
+    /// `@x(a: "one, two", b: f(1, 2))` is two arguments.
+    private static func splitArguments(_ range: NSRange, in ns: NSString) -> [NSRange] {
+        var out: [NSRange] = []
+        var depth = 0
+        var inQuote = false
+        var start = range.location
+        for k in range.location..<NSMaxRange(range) {
+            let c = ns.character(at: k)
+            if c == 0x22 { inQuote.toggle(); continue }             // "
+            guard !inQuote else { continue }
+            switch c {
+            case 0x28, 0x5B, 0x7B: depth += 1                       // ( [ {
+            case 0x29, 0x5D, 0x7D: depth -= 1                       // ) ] }
+            case 0x2C where depth == 0:                             // ,
+                out.append(NSRange(location: start, length: k - start))
+                start = k + 1
+            default: break
+            }
+        }
+        if start < NSMaxRange(range) {
+            out.append(NSRange(location: start, length: NSMaxRange(range) - start))
+        }
+        return out
+    }
+
+    /// Split `label: value` at the first depth-0, unquoted colon. A value
+    /// containing a colon (`"12:30"`) is safe because quotes suppress the split.
+    private static func splitLabel(_ range: NSRange, in ns: NSString) -> (label: NSRange?, value: NSRange) {
+        var inQuote = false
+        for k in range.location..<NSMaxRange(range) {
+            let c = ns.character(at: k)
+            if c == 0x22 { inQuote.toggle(); continue }
+            if c == 0x3A, !inQuote {                                 // :
+                let label = NSRange(location: range.location, length: k - range.location)
+                let value = NSRange(location: k + 1, length: NSMaxRange(range) - (k + 1))
+                // A leading colon (`:value`) is not a label.
+                return label.length > 0 ? (label, value) : (nil, range)
+            }
+        }
+        return (nil, range)
+    }
+
+    private static func coerce(_ raw: String, to kind: DirectiveParameter.Kind) -> DirectiveValue? {
+        if raw.count >= 2, raw.hasPrefix("\""), raw.hasSuffix("\"") {
+            let inner = String(raw.dropFirst().dropLast())
+            // A quoted literal is a string; it satisfies .string and .keyword,
+            // and nothing else.
+            switch kind {
+            case .string:                 return .string(inner)
+            case .keyword(let allowed):   return allowed.isEmpty || allowed.contains(inner) ? .keyword(inner) : nil
+            default:                      return nil
+            }
+        }
+        switch kind {
+        case .string:
+            return .string(raw)
+        case .boolean:
+            guard let value = Bool(raw) else { return nil }
+            return .boolean(value)
+        case .number:
+            guard let value = Double(raw) else { return nil }
+            return .number(value)
+        case .length:
+            return parseLength(raw)
+        case .keyword(let allowed):
+            guard allowed.isEmpty || allowed.contains(raw) else { return nil }
+            return .keyword(raw)
+        }
+    }
+
+    /// `18`, `18pt`, `1.5em`, `50%`
+    private static func parseLength(_ raw: String) -> DirectiveValue? {
+        for unit in [DirectiveUnit.percent, .em, .point] where raw.hasSuffix(unit.rawValue) {
+            guard let value = Double(raw.dropLast(unit.rawValue.count)) else { return nil }
+            return .length(value, unit)
+        }
+        guard let value = Double(raw) else { return nil }
+        return .length(value, .none)
+    }
+
+    private static func describe(_ kind: DirectiveParameter.Kind) -> String {
+        switch kind {
+        case .string:               return "string"
+        case .number:               return "number"
+        case .length:               return "length"
+        case .boolean:              return "boolean"
+        case .keyword(let allowed): return allowed.isEmpty ? "keyword" : allowed.joined(separator: "|")
+        }
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
@@ -132,8 +132,14 @@ extension DirectiveArguments {
                                      diagnostics: diagnostics, schema: schema, anchor: range)
     }
 
-    /// Fill unsupplied labelled parameters from their defaults, then report
-    /// whatever required parameter is still missing.
+    /// Fill unsupplied parameters — labelled and positional alike — from their
+    /// defaults, then report whatever required parameter is still missing.
+    ///
+    /// Positional defaults fill by POSITION, so they only apply to a tail the
+    /// call didn't reach: given `(a, b = 2, c)`, `@x(1)` yields `1, 2` and
+    /// still reports `#2` missing. A default can't be skipped over, because
+    /// there is no syntax for "use the default here but supply the next one" —
+    /// so the first positional without a default ends the filling.
     private static func applyingDefaults(
         labeled: [String: DirectiveValue],
         positional: [DirectiveValue],
@@ -142,7 +148,9 @@ extension DirectiveArguments {
         anchor: NSRange
     ) -> DirectiveArguments {
         var labeled = labeled
+        var positional = positional
         var diagnostics = diagnostics
+
         for parameter in schema {
             guard let label = parameter.label, labeled[label] == nil else { continue }
             if let fallback = parameter.defaultValue {
@@ -151,10 +159,17 @@ extension DirectiveArguments {
                 diagnostics.append(.init(kind: .missingRequired(label), range: anchor))
             }
         }
-        let requiredPositional = schema.filter { $0.label == nil && $0.isRequired }.count
-        if positional.count < requiredPositional {
-            diagnostics.append(.init(kind: .missingRequired("#\(positional.count)"), range: anchor))
+
+        let positionalSchema = schema.filter { $0.label == nil }
+        for index in positional.count..<max(positional.count, positionalSchema.count) {
+            guard let fallback = positionalSchema[index].defaultValue else { break }
+            positional.append(fallback)
         }
+        for index in positional.count..<max(positional.count, positionalSchema.count)
+        where positionalSchema[index].isRequired {
+            diagnostics.append(.init(kind: .missingRequired("#\(index)"), range: anchor))
+        }
+
         return DirectiveArguments(labeled: labeled, positional: positional, diagnostics: diagnostics)
     }
 

--- a/Sources/MarkdownEngine/Directives/DirectiveRegistry.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveRegistry.swift
@@ -1,0 +1,169 @@
+//
+//  DirectiveRegistry.swift
+//  MarkdownEngine
+//
+//  Precompiled, purely syntactic view of the registered directives — the only
+//  thing the parser sees. Mirrors `ExtensionRegistry`, and is carried BY it
+//  (`ExtensionRegistry.directives`) so the directive fingerprint folds into
+//  the one grammar fingerprint every parse cache already keys on. Registering
+//  a directive therefore invalidates the caches for free; there is no second
+//  cache key to thread through the pipeline.
+//
+
+import Foundation
+
+// MARK: - Marker settings
+
+/// Marker configuration for the whole registry.
+///
+/// `@` is the default: it is the modern convention for "invoke something
+/// inline" (Notion / Linear / Slack), and unlike `\` it collides neither with
+/// the LaTeX vocabulary this engine renders through `$…$` / `$$…$$` nor with
+/// CommonMark's `\`+punctuation escapes.
+///
+/// Additional markers may be registered simultaneously — the scanner
+/// dispatches on the first character — so an embedder that wants
+/// LaTeX-flavoured authoring can register directives under `\` and keep `@`
+/// free for mentions, or drop `@` entirely.
+///
+/// - Important: `@` is also the conventional trigger for @-mentions. An app
+///   that already uses `@` for people or documents should give directives a
+///   different marker rather than disambiguating at the trigger: the two
+///   pickers would otherwise compete for the same keystroke. The
+///   registered-names-only rule limits the damage (`@alice` stays literal
+///   unless `alice` is a directive), but the completion picker still opens on
+///   the bare marker.
+///
+/// - Note: A marker must be a single UTF-16 code unit. Emoji and other
+///   multi-scalar characters are rejected at registration so marker dispatch
+///   stays one dictionary probe per character on the parse hot path.
+public struct DirectiveRegistrySettings: Sendable, Equatable {
+    /// Marker used by directives that don't override it. Must be a single
+    /// UTF-16 code unit; see the type's note.
+    public var defaultMarker: Character
+
+    public static let `default` = DirectiveRegistrySettings()
+
+    public init(defaultMarker: Character = "@") {
+        self.defaultMarker = defaultMarker
+    }
+}
+
+// MARK: - Parser-facing registry (internal)
+
+/// Precompiled directive rules. Built once per parse entry from the
+/// configuration, exactly like `ExtensionRegistry`.
+struct DirectiveRegistry {
+
+    /// Directive nodes are represented in the AST as extension-shaped nodes
+    /// (`InlineNode.ext`) whose id carries this prefix. That gives directives
+    /// the whole downstream pipeline — marker shrink, caret reveal, token
+    /// projection, incremental restyle, rich copy — with no new node kind, and
+    /// keeps the directive seam additive against upstream changes.
+    ///
+    /// An extension whose own id starts with this prefix would collide; the
+    /// prefix contains a `.`, which no bundled extension id uses.
+    static let idPrefix = "directive."
+
+    /// The AST id for a directive id.
+    static func nodeID(for directiveID: String) -> String { idPrefix + directiveID }
+
+    /// The directive id for an AST id, or nil when the node isn't a directive.
+    static func directiveID(forNodeID nodeID: String) -> String? {
+        nodeID.hasPrefix(idPrefix) ? String(nodeID.dropFirst(idPrefix.count)) : nil
+    }
+
+    struct Entry {
+        let id: String
+        let name: String
+        let marker: unichar
+        let form: DirectiveSyntax.Form
+        let parsesBody: Bool
+    }
+
+    /// marker → name → entry. Two-level so the scanner rejects a non-marker
+    /// character in a single dictionary probe — the common case on every
+    /// character of every parse.
+    let byMarker: [unichar: [String: Entry]]
+    /// Stable fingerprint for cache keying ("" when empty). Two registries
+    /// with the same fingerprint produce identical parses for identical text.
+    let fingerprint: String
+
+    static let empty = DirectiveRegistry(byMarker: [:], fingerprint: "")
+
+    private init(byMarker: [unichar: [String: Entry]], fingerprint: String) {
+        self.byMarker = byMarker
+        self.fingerprint = fingerprint
+    }
+
+    init(directives: [any MarkdownDirective], settings: DirectiveRegistrySettings = .default) {
+        guard !directives.isEmpty else {
+            self = .empty
+            return
+        }
+        let defaultMarker = Self.unichar(for: settings.defaultMarker)
+        var table: [unichar: [String: Entry]] = [:]
+        for directive in directives {
+            let syntax = directive.syntax
+            guard !syntax.name.isEmpty else { continue }
+            let marker = syntax.marker.map(Self.unichar(for:)) ?? defaultMarker
+            guard marker != 0 else { continue }
+            // First registration wins, matching extension precedence.
+            guard table[marker]?[syntax.name] == nil else { continue }
+            table[marker, default: [:]][syntax.name] = Entry(
+                id: directive.id,
+                name: syntax.name,
+                marker: marker,
+                form: syntax.form,
+                parsesBody: syntax.parsesBody
+            )
+        }
+        self.byMarker = table
+        // Only fields that change the PARSE participate — presentation-only
+        // edits (colours, completion prose) must not invalidate parse caches.
+        // Free-text fields are length-prefixed so the concatenation is
+        // injective: a name containing the separator cannot alias another
+        // registry.
+        func framed(_ string: String) -> String { "\(string.utf16.count).\(string)" }
+        self.fingerprint = directives
+            .map { directive in
+                let syntax = directive.syntax
+                let marker = syntax.marker.map(String.init) ?? String(settings.defaultMarker)
+                return [
+                    framed(directive.id), framed(syntax.name), framed(marker),
+                    syntax.form.rawValue, "\(syntax.parsesBody)",
+                ].joined(separator: ",")
+            }
+            .joined(separator: "|")
+    }
+
+    var isEmpty: Bool { byMarker.isEmpty }
+
+    func entry(marker: unichar, name: String) -> Entry? { byMarker[marker]?[name] }
+
+    /// UTF-16 code unit for a marker, or 0 when the character isn't
+    /// representable in one unit (an emoji marker is rejected at registration
+    /// rather than half-matched at scan time).
+    private static func unichar(for character: Character) -> unichar {
+        let units = Array(String(character).utf16)
+        return units.count == 1 ? units[0] : 0
+    }
+}
+
+// MARK: - Configuration bridge
+
+public extension MarkdownEditorConfiguration {
+    /// Styler-facing lookup: directive behaviour by id.
+    var directivesByID: [String: any MarkdownDirective] {
+        var out: [String: any MarkdownDirective] = [:]
+        for directive in directives { out[directive.id] = directive }
+        return out
+    }
+}
+
+extension MarkdownEditorConfiguration {
+    /// The parser-facing directive registry derived from `directives`.
+    var directiveRegistry: DirectiveRegistry {
+        DirectiveRegistry(directives: directives, settings: directiveSettings)
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
@@ -1,0 +1,256 @@
+//
+//  DirectiveScanner.swift
+//  MarkdownEngine
+//
+//  The parser side of the directive seam. Called from
+//  `InlineParser.matchClaimedSpan` AFTER every built-in, so a directive can
+//  never take text away from core markdown — the same precedence rule
+//  extension spans follow.
+//
+//  Self-contained by design: the scanner re-implements the two helpers it
+//  needs (`isEscaped`, balanced-delimiter scanning) rather than reaching into
+//  `InlineParser`'s private ones, so the whole seam is one directory of new
+//  files plus a four-line hook.
+//
+//  Rejection is always silent and always means "stays literal text": an
+//  unregistered name, a malformed call, a wrong-form call, a run crossing a
+//  line break. Nothing here can produce a partial construct.
+//
+//  Because the scanner runs inside `scanLinkFamily` (pass 3), a directive
+//  inside a code span is already claimed and never fires.
+//
+//  KNOWN LIMITATION — a directive whose BODY holds a pre-claimed span is
+//  rejected whole, so `@font(size: 18){a `b` c}` produces no directive node
+//  at all rather than a directive containing a code span. The same applies to
+//  a backslash escape (`{a \* c}`), since escapes are claimed in pass 2.
+//
+//  It is exactly the pre-claimed passes that bite — code spans and escapes.
+//  Constructs claimed in this pass or later are fine: `$…$`, links, emphasis
+//  and nesting all work inside a body. The cause is `scanLinkFamily`'s
+//  overlap rule, which rejects any candidate meeting a claimed span; #118
+//  granted link labels an exemption from the same rule, and directives want
+//  the equivalent. Tracked separately — it belongs with that rule, not here.
+//
+
+import Foundation
+
+/// A matched directive, in absolute UTF-16 coordinates. Neutral value type:
+/// `InlineParser` converts it into its own private `Span` at the call site.
+struct DirectiveMatch: Equatable {
+    /// AST node id — already namespaced via `DirectiveRegistry.nodeID(for:)`.
+    let nodeID: String
+    let range: NSRange
+    /// The name run, without the marker (`font` in `@font(…)`).
+    let nameRange: NSRange
+    /// Inside the parens; `nil` when the call has no argument list.
+    let argumentsRange: NSRange?
+    /// Inside the braces; `nil` for a self-contained call.
+    let bodyRange: NSRange?
+    /// Ranges that shrink when the caret leaves: `[prefix, closingBrace]` for
+    /// a container, empty for a self-contained call (Phase 1 renders those
+    /// literally — the glyph pass that collapses them lands in Phase 3).
+    let markers: [NSRange]
+    /// Range carrying the node's content: the body for a container, the whole
+    /// call for a self-contained one.
+    let contentRange: NSRange
+    /// Whether the content is re-parsed as markdown.
+    let parsesContent: Bool
+}
+
+enum DirectiveScanner {
+
+    private static let lparen: unichar = 0x28
+    private static let rparen: unichar = 0x29
+    private static let lbrace: unichar = 0x7B
+    private static let rbrace: unichar = 0x7D
+    private static let backslash: unichar = 0x5C
+    private static let quote: unichar = 0x22
+    private static let dot: unichar = 0x2E
+    private static let newline: unichar = 0x0A
+    private static let carriageReturn: unichar = 0x0D
+
+    /// Try to match a directive starting at `i`. Returns nil for every
+    /// rejection — the candidate then stays literal text.
+    static func match(_ ns: NSString, len: Int, at i: Int, registry: DirectiveRegistry) -> DirectiveMatch? {
+        guard !registry.isEmpty, i >= 0, i < len else { return nil }
+        let marker = ns.character(at: i)
+        guard let table = registry.byMarker[marker], !table.isEmpty else { return nil }
+
+        // Left boundary: anything that isn't a word character. Markup
+        // delimiters therefore open directives (`*@font(size: 18){x}*`), while
+        // `name@example.com` never does, and a `@@` run stays literal
+        // (mirrors `InlineSyntax.rejectsOpenerRun`).
+        if i > 0 {
+            let previous = ns.character(at: i - 1)
+            guard previous != marker, isBoundary(previous) else { return nil }
+        }
+        guard !isEscaped(i, ns) else { return nil }
+
+        // Name: ident ('.' ident)*
+        var cursor = i + 1
+        let nameStart = cursor
+        guard cursor < len, isIdentStart(ns.character(at: cursor)) else { return nil }
+        while cursor < len {
+            let c = ns.character(at: cursor)
+            if isIdentChar(c) {
+                cursor += 1
+            } else if c == dot, cursor + 1 < len, isIdentStart(ns.character(at: cursor + 1)) {
+                cursor += 1
+            } else {
+                break
+            }
+        }
+        let nameRange = NSRange(location: nameStart, length: cursor - nameStart)
+
+        // REGISTERED NAMES ONLY — the property that makes this safe to enable
+        // over an existing document corpus.
+        guard let entry = table[ns.substring(with: nameRange)] else { return nil }
+
+        // Optional argument list `( … )`: balanced, single line.
+        var argumentsRange: NSRange?
+        if cursor < len, ns.character(at: cursor) == lparen {
+            guard let close = balanced(ns, len: len, from: cursor + 1, open: lparen, close: rparen) else { return nil }
+            argumentsRange = NSRange(location: cursor + 1, length: close - (cursor + 1))
+            cursor = close + 1
+        }
+
+        // Optional body `{ … }`: balanced, single line, escape-aware.
+        var bodyRange: NSRange?
+        if cursor < len, ns.character(at: cursor) == lbrace {
+            guard let close = balanced(ns, len: len, from: cursor + 1, open: lbrace, close: rbrace) else { return nil }
+            bodyRange = NSRange(location: cursor + 1, length: close - (cursor + 1))
+            cursor = close + 1
+        }
+
+        // Form check — a mismatched call stays literal rather than rendering
+        // half-configured.
+        switch entry.form {
+        case .selfContained: guard bodyRange == nil else { return nil }
+        case .container:     guard bodyRange != nil else { return nil }
+        case .either:        break
+        }
+
+        let range = NSRange(location: i, length: cursor - i)
+
+        if let body = bodyRange {
+            // Markers are what shrinks when the caret leaves: the whole
+            // `@font(size: 18){` prefix and the closing `}`, leaving only the
+            // styled body visible.
+            let prefix = NSRange(location: i, length: body.location - i)
+            let closingBrace = NSRange(location: NSMaxRange(body), length: 1)
+            return DirectiveMatch(
+                nodeID: DirectiveRegistry.nodeID(for: entry.id),
+                range: range,
+                nameRange: nameRange,
+                argumentsRange: argumentsRange,
+                bodyRange: body,
+                markers: [prefix, closingBrace],
+                contentRange: body,
+                parsesContent: entry.parsesBody
+            )
+        }
+
+        // Self-contained: no markers in Phase 1, so the call renders as plain
+        // literal text instead of collapsing to nothing. It is still CLAIMED,
+        // so emphasis and autolinking can't fire inside it, and it still
+        // projects a token — the glyph pass in Phase 3 only has to add
+        // presentation.
+        return DirectiveMatch(
+            nodeID: DirectiveRegistry.nodeID(for: entry.id),
+            range: range,
+            nameRange: nameRange,
+            argumentsRange: argumentsRange,
+            bodyRange: nil,
+            markers: [],
+            contentRange: range,
+            parsesContent: false
+        )
+    }
+
+    /// Recover the argument range from a directive node's PREFIX marker
+    /// (`@font(size: 18){`, or the whole call when self-contained).
+    ///
+    /// The AST carries directives as extension-shaped nodes, which have no
+    /// slot for an argument range, so styling recovers it from the geometry
+    /// the parser already emitted. The prefix is well-formed by construction —
+    /// this scanner produced it — so the walk is a short, total re-derivation
+    /// rather than a second parse of the document.
+    static func argumentsRange(inPrefix prefix: NSRange, of ns: NSString) -> NSRange? {
+        let end = min(NSMaxRange(prefix), ns.length)
+        var k = prefix.location + 1                    // past the marker
+        while k < end, isIdentChar(ns.character(at: k)) || ns.character(at: k) == dot { k += 1 }
+        guard k < end, ns.character(at: k) == lparen else { return nil }
+        guard let close = balanced(ns, len: end, from: k + 1, open: lparen, close: rparen) else { return nil }
+        return NSRange(location: k + 1, length: close - (k + 1))
+    }
+
+    // MARK: - Character classes
+
+    /// `[A-Za-z_]`
+    private static func isIdentStart(_ c: unichar) -> Bool {
+        (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A) || c == 0x5F
+    }
+
+    /// `[A-Za-z0-9_-]`
+    private static func isIdentChar(_ c: unichar) -> Bool {
+        isIdentStart(c) || (c >= 0x30 && c <= 0x39) || c == 0x2D
+    }
+
+    /// Whether a directive may open after `c`.
+    ///
+    /// Stated as a DENY list — only letters and digits reject — rather than an
+    /// allow list of punctuation. An allow list looks safer and is wrong: it
+    /// silently breaks every markup context that abuts a directive
+    /// (`*@font(size: 18){x}*`, `**…**`, `~~…~~`, `- @pagebreak`), because the
+    /// preceding character is a markup delimiter nobody remembered to list.
+    ///
+    /// Rejecting word characters is all the email rule needs:
+    /// `name@example.com` is preceded by `e`. Underscore is deliberately a
+    /// boundary so `_@font(size: 18){x}_` works; `foo_@example.com` is not a
+    /// shape worth protecting, and the name still has to be registered.
+    private static func isBoundary(_ c: unichar) -> Bool {
+        guard let scalar = UnicodeScalar(c) else { return true }   // surrogate half
+        return !CharacterSet.alphanumerics.contains(scalar)
+    }
+
+    // MARK: - Scanning helpers
+
+    /// Index of the delimiter balancing the run starting at `from`, or nil
+    /// when the run is unbalanced or crosses a line break. Escaped delimiters
+    /// and delimiters inside a quoted string don't count.
+    private static func balanced(_ ns: NSString, len: Int, from: Int, open: unichar, close: unichar) -> Int? {
+        var depth = 1
+        var inQuote = false
+        var k = from
+        while k < len {
+            let c = ns.character(at: k)
+            if c == newline || c == carriageReturn { return nil }
+            if !isEscaped(k, ns) {
+                if c == quote {
+                    inQuote.toggle()
+                } else if !inQuote {
+                    if c == open { depth += 1 }
+                    if c == close {
+                        depth -= 1
+                        if depth == 0 { return k }
+                    }
+                }
+            }
+            k += 1
+        }
+        return nil
+    }
+
+    /// Whether the character at `index` is preceded by an odd number of
+    /// backslashes. Mirrors `InlineParser.isEscaped`, kept local so this file
+    /// has no private dependency on the parser.
+    private static func isEscaped(_ index: Int, _ ns: NSString) -> Bool {
+        var count = 0
+        var k = index - 1
+        while k >= 0, ns.character(at: k) == backslash {
+            count += 1
+            k -= 1
+        }
+        return count % 2 == 1
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
@@ -1,0 +1,244 @@
+//
+//  DirectiveScanner.swift
+//  MarkdownEngine
+//
+//  The parser side of the directive seam. Called from
+//  `InlineParser.matchClaimedSpan` AFTER every built-in, so a directive can
+//  never take text away from core markdown — the same precedence rule
+//  extension spans follow.
+//
+//  Self-contained by design: the scanner re-implements the two helpers it
+//  needs (`isEscaped`, balanced-delimiter scanning) rather than reaching into
+//  `InlineParser`'s private ones, so the whole seam is one directory of new
+//  files plus a four-line hook.
+//
+//  Rejection is always silent and always means "stays literal text": an
+//  unregistered name, a malformed call, a wrong-form call, a run crossing a
+//  line break. Nothing here can produce a partial construct.
+//
+//  Because the scanner runs inside `scanLinkFamily` (pass 3), a directive
+//  inside a code span or `$…$` is already claimed and never fires.
+//
+
+import Foundation
+
+/// A matched directive, in absolute UTF-16 coordinates. Neutral value type:
+/// `InlineParser` converts it into its own private `Span` at the call site.
+struct DirectiveMatch: Equatable {
+    /// AST node id — already namespaced via `DirectiveRegistry.nodeID(for:)`.
+    let nodeID: String
+    let range: NSRange
+    /// The name run, without the marker (`font` in `@font(…)`).
+    let nameRange: NSRange
+    /// Inside the parens; `nil` when the call has no argument list.
+    let argumentsRange: NSRange?
+    /// Inside the braces; `nil` for a self-contained call.
+    let bodyRange: NSRange?
+    /// Ranges that shrink when the caret leaves: `[prefix, closingBrace]` for
+    /// a container, empty for a self-contained call (Phase 1 renders those
+    /// literally — the glyph pass that collapses them lands in Phase 3).
+    let markers: [NSRange]
+    /// Range carrying the node's content: the body for a container, the whole
+    /// call for a self-contained one.
+    let contentRange: NSRange
+    /// Whether the content is re-parsed as markdown.
+    let parsesContent: Bool
+}
+
+enum DirectiveScanner {
+
+    private static let lparen: unichar = 0x28
+    private static let rparen: unichar = 0x29
+    private static let lbrace: unichar = 0x7B
+    private static let rbrace: unichar = 0x7D
+    private static let backslash: unichar = 0x5C
+    private static let quote: unichar = 0x22
+    private static let dot: unichar = 0x2E
+    private static let newline: unichar = 0x0A
+    private static let carriageReturn: unichar = 0x0D
+
+    /// Try to match a directive starting at `i`. Returns nil for every
+    /// rejection — the candidate then stays literal text.
+    static func match(_ ns: NSString, len: Int, at i: Int, registry: DirectiveRegistry) -> DirectiveMatch? {
+        guard !registry.isEmpty, i >= 0, i < len else { return nil }
+        let marker = ns.character(at: i)
+        guard let table = registry.byMarker[marker], !table.isEmpty else { return nil }
+
+        // Left boundary: anything that isn't a word character. Markup
+        // delimiters therefore open directives (`*@font(size: 18){x}*`), while
+        // `name@example.com` never does, and a `@@` run stays literal
+        // (mirrors `InlineSyntax.rejectsOpenerRun`).
+        if i > 0 {
+            let previous = ns.character(at: i - 1)
+            guard previous != marker, isBoundary(previous) else { return nil }
+        }
+        guard !isEscaped(i, ns) else { return nil }
+
+        // Name: ident ('.' ident)*
+        var cursor = i + 1
+        let nameStart = cursor
+        guard cursor < len, isIdentStart(ns.character(at: cursor)) else { return nil }
+        while cursor < len {
+            let c = ns.character(at: cursor)
+            if isIdentChar(c) {
+                cursor += 1
+            } else if c == dot, cursor + 1 < len, isIdentStart(ns.character(at: cursor + 1)) {
+                cursor += 1
+            } else {
+                break
+            }
+        }
+        let nameRange = NSRange(location: nameStart, length: cursor - nameStart)
+
+        // REGISTERED NAMES ONLY — the property that makes this safe to enable
+        // over an existing document corpus.
+        guard let entry = table[ns.substring(with: nameRange)] else { return nil }
+
+        // Optional argument list `( … )`: balanced, single line.
+        var argumentsRange: NSRange?
+        if cursor < len, ns.character(at: cursor) == lparen {
+            guard let close = balanced(ns, len: len, from: cursor + 1, open: lparen, close: rparen) else { return nil }
+            argumentsRange = NSRange(location: cursor + 1, length: close - (cursor + 1))
+            cursor = close + 1
+        }
+
+        // Optional body `{ … }`: balanced, single line, escape-aware.
+        var bodyRange: NSRange?
+        if cursor < len, ns.character(at: cursor) == lbrace {
+            guard let close = balanced(ns, len: len, from: cursor + 1, open: lbrace, close: rbrace) else { return nil }
+            bodyRange = NSRange(location: cursor + 1, length: close - (cursor + 1))
+            cursor = close + 1
+        }
+
+        // Form check — a mismatched call stays literal rather than rendering
+        // half-configured.
+        switch entry.form {
+        case .selfContained: guard bodyRange == nil else { return nil }
+        case .container:     guard bodyRange != nil else { return nil }
+        case .either:        break
+        }
+
+        let range = NSRange(location: i, length: cursor - i)
+
+        if let body = bodyRange {
+            // Markers are what shrinks when the caret leaves: the whole
+            // `@font(size: 18){` prefix and the closing `}`, leaving only the
+            // styled body visible.
+            let prefix = NSRange(location: i, length: body.location - i)
+            let closingBrace = NSRange(location: NSMaxRange(body), length: 1)
+            return DirectiveMatch(
+                nodeID: DirectiveRegistry.nodeID(for: entry.id),
+                range: range,
+                nameRange: nameRange,
+                argumentsRange: argumentsRange,
+                bodyRange: body,
+                markers: [prefix, closingBrace],
+                contentRange: body,
+                parsesContent: entry.parsesBody
+            )
+        }
+
+        // Self-contained: no markers in Phase 1, so the call renders as plain
+        // literal text instead of collapsing to nothing. It is still CLAIMED,
+        // so emphasis and autolinking can't fire inside it, and it still
+        // projects a token — the glyph pass in Phase 3 only has to add
+        // presentation.
+        return DirectiveMatch(
+            nodeID: DirectiveRegistry.nodeID(for: entry.id),
+            range: range,
+            nameRange: nameRange,
+            argumentsRange: argumentsRange,
+            bodyRange: nil,
+            markers: [],
+            contentRange: range,
+            parsesContent: false
+        )
+    }
+
+    /// Recover the argument range from a directive node's PREFIX marker
+    /// (`@font(size: 18){`, or the whole call when self-contained).
+    ///
+    /// The AST carries directives as extension-shaped nodes, which have no
+    /// slot for an argument range, so styling recovers it from the geometry
+    /// the parser already emitted. The prefix is well-formed by construction —
+    /// this scanner produced it — so the walk is a short, total re-derivation
+    /// rather than a second parse of the document.
+    static func argumentsRange(inPrefix prefix: NSRange, of ns: NSString) -> NSRange? {
+        let end = min(NSMaxRange(prefix), ns.length)
+        var k = prefix.location + 1                    // past the marker
+        while k < end, isIdentChar(ns.character(at: k)) || ns.character(at: k) == dot { k += 1 }
+        guard k < end, ns.character(at: k) == lparen else { return nil }
+        guard let close = balanced(ns, len: end, from: k + 1, open: lparen, close: rparen) else { return nil }
+        return NSRange(location: k + 1, length: close - (k + 1))
+    }
+
+    // MARK: - Character classes
+
+    /// `[A-Za-z_]`
+    private static func isIdentStart(_ c: unichar) -> Bool {
+        (c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A) || c == 0x5F
+    }
+
+    /// `[A-Za-z0-9_-]`
+    private static func isIdentChar(_ c: unichar) -> Bool {
+        isIdentStart(c) || (c >= 0x30 && c <= 0x39) || c == 0x2D
+    }
+
+    /// Whether a directive may open after `c`.
+    ///
+    /// Stated as a DENY list — only letters and digits reject — rather than an
+    /// allow list of punctuation. An allow list looks safer and is wrong: it
+    /// silently breaks every markup context that abuts a directive
+    /// (`*@font(size: 18){x}*`, `**…**`, `~~…~~`, `- @pagebreak`), because the
+    /// preceding character is a markup delimiter nobody remembered to list.
+    ///
+    /// Rejecting word characters is all the email rule needs:
+    /// `name@example.com` is preceded by `e`. Underscore is deliberately a
+    /// boundary so `_@font(size: 18){x}_` works; `foo_@example.com` is not a
+    /// shape worth protecting, and the name still has to be registered.
+    private static func isBoundary(_ c: unichar) -> Bool {
+        guard let scalar = UnicodeScalar(c) else { return true }   // surrogate half
+        return !CharacterSet.alphanumerics.contains(scalar)
+    }
+
+    // MARK: - Scanning helpers
+
+    /// Index of the delimiter balancing the run starting at `from`, or nil
+    /// when the run is unbalanced or crosses a line break. Escaped delimiters
+    /// and delimiters inside a quoted string don't count.
+    private static func balanced(_ ns: NSString, len: Int, from: Int, open: unichar, close: unichar) -> Int? {
+        var depth = 1
+        var inQuote = false
+        var k = from
+        while k < len {
+            let c = ns.character(at: k)
+            if c == newline || c == carriageReturn { return nil }
+            if !isEscaped(k, ns) {
+                if c == quote {
+                    inQuote.toggle()
+                } else if !inQuote {
+                    if c == open { depth += 1 }
+                    if c == close {
+                        depth -= 1
+                        if depth == 0 { return k }
+                    }
+                }
+            }
+            k += 1
+        }
+        return nil
+    }
+
+    /// Whether the character at `index` is preceded by an odd number of
+    /// backslashes. Mirrors `InlineParser.isEscaped`, kept local so this file
+    /// has no private dependency on the parser.
+    private static func isEscaped(_ index: Int, _ ns: NSString) -> Bool {
+        var count = 0
+        var k = index - 1
+        while k >= 0, ns.character(at: k) == backslash {
+            count += 1
+            k -= 1
+        }
+        return count % 2 == 1
+    }
+}

--- a/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
@@ -17,7 +17,19 @@
 //  line break. Nothing here can produce a partial construct.
 //
 //  Because the scanner runs inside `scanLinkFamily` (pass 3), a directive
-//  inside a code span or `$…$` is already claimed and never fires.
+//  inside a code span is already claimed and never fires.
+//
+//  KNOWN LIMITATION — a directive whose BODY holds a pre-claimed span is
+//  rejected whole, so `@font(size: 18){a `b` c}` produces no directive node
+//  at all rather than a directive containing a code span. The same applies to
+//  a backslash escape (`{a \* c}`), since escapes are claimed in pass 2.
+//
+//  It is exactly the pre-claimed passes that bite — code spans and escapes.
+//  Constructs claimed in this pass or later are fine: `$…$`, links, emphasis
+//  and nesting all work inside a body. The cause is `scanLinkFamily`'s
+//  overlap rule, which rejects any candidate meeting a claimed span; #118
+//  granted link labels an exemption from the same rule, and directives want
+//  the equivalent. Tracked separately — it belongs with that rule, not here.
 //
 
 import Foundation

--- a/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
+++ b/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
@@ -1,0 +1,215 @@
+//
+//  MarkdownDirective.swift
+//  MarkdownEngine
+//
+//  The directive seam: a NAMED, ARGUMENT-CARRYING inline command —
+//  `@pagebreak`, `@font(size: 18){styled text}` — contributed by the embedder
+//  instead of hard-coded into the parser. Sibling of `MarkdownExtension`,
+//  which covers delimiter-shaped constructs (`==x==`, `::: … :::`) and cannot
+//  express a name plus a typed argument list.
+//
+//  This file is the PARSING half of the seam: the protocol, the syntax rule,
+//  and the argument schema. Presentation (font transforms, glyphs) and
+//  autocomplete extend the protocol in follow-up changes; nothing here styles
+//  anything yet.
+//
+//  Two forms, both TREE-SHAPED — a directive's effect never escapes its own
+//  node:
+//
+//    * self-contained — `@pagebreak`, `@date(format: iso)`. A leaf.
+//    * container      — `@font(size: 18){text}`. The body is re-parsed as
+//      markdown, and will later be styled with the directive's font transform
+//      COMPOSED over the inherited font, so `@font(size: 18){**bold**}` comes
+//      out bold AND 18pt.
+//
+//  There is deliberately no "applies to everything after me" form. That would
+//  make styling depend on document position rather than tree position, which
+//  breaks both the styler's compose-on-descent model and the block-scoped
+//  incremental restyle (a directive's effect would outlive its own block).
+//
+//  Isolation contract, inherited verbatim from `MarkdownExtension`: a directive
+//  supplies SYNTAX (name + parameter schema) and PRESENTATION (font transform,
+//  attributes, glyph). It never emits ranges — the parser derives all geometry.
+//  A misbehaving directive can restyle its own body at worst, never a neighbor.
+//
+//  Two rules do the safety work, and both live in `DirectiveScanner`:
+//    1. REGISTERED NAMES ONLY — `@home` in prose stays literal text unless
+//       `home` is registered. This is what makes the seam safe to enable over
+//       an existing document corpus.
+//    2. LEFT BOUNDARY — a directive opens only at start-of-line or after
+//       whitespace / opening punctuation, so `name@example.com` never opens
+//       one.
+//
+
+import AppKit
+import Foundation
+
+// MARK: - Values
+
+/// Unit suffix on a numeric argument: `18`, `18pt`, `1.5em`, `50%`.
+public enum DirectiveUnit: String, Sendable, Equatable, CaseIterable {
+    case none = ""
+    case point = "pt"
+    case em
+    case percent = "%"
+}
+
+/// One parsed argument value. Deliberately small and closed — directives get
+/// typed accessors rather than raw text, so an embedder never re-parses.
+public enum DirectiveValue: Sendable, Equatable {
+    /// `"quoted text"`
+    case string(String)
+    /// `18`, `-0.5`
+    case number(Double)
+    /// `18pt`, `1.5em`, `50%` (and bare numbers in a `.length` parameter)
+    case length(Double, DirectiveUnit)
+    /// `true` / `false`
+    case boolean(Bool)
+    /// Bareword: `red`, `center`, `iso8601`
+    case keyword(String)
+
+    public var asString: String? {
+        switch self {
+        case .string(let s), .keyword(let s): return s
+        default: return nil
+        }
+    }
+
+    public var asDouble: Double? {
+        switch self {
+        case .number(let n), .length(let n, _): return n
+        default: return nil
+        }
+    }
+
+    public var asBool: Bool? {
+        if case .boolean(let b) = self { return b }
+        return nil
+    }
+
+    /// Resolve against an inherited size: `pt` and unitless are absolute, `em`
+    /// and `%` are relative.
+    public func resolvedLength(relativeTo base: CGFloat) -> CGFloat? {
+        guard case .length(let value, let unit) = self else {
+            return asDouble.map { CGFloat($0) }
+        }
+        switch unit {
+        case .none, .point: return CGFloat(value)
+        case .em:           return base * CGFloat(value)
+        case .percent:      return base * CGFloat(value) / 100
+        }
+    }
+}
+
+// MARK: - Parameter schema
+
+/// One declared parameter. The schema drives three things at once: argument
+/// coercion, diagnostics for a malformed call, and (later) argument-level
+/// autocomplete inside the parens.
+public struct DirectiveParameter: Sendable, Equatable {
+    public enum Kind: Sendable, Equatable {
+        case string
+        case number
+        case length
+        case boolean
+        /// Closed set of barewords, e.g. `["left", "center", "right"]`. An
+        /// empty set accepts any bareword.
+        case keyword([String])
+    }
+
+    /// `nil` for a positional parameter (`@color(red)`).
+    public var label: String?
+    public var kind: Kind
+    public var isRequired: Bool
+    public var defaultValue: DirectiveValue?
+    /// Shown in the completion picker's argument hint.
+    public var documentation: String
+
+    public init(
+        label: String?,
+        kind: Kind,
+        isRequired: Bool = false,
+        defaultValue: DirectiveValue? = nil,
+        documentation: String = ""
+    ) {
+        self.label = label
+        self.kind = kind
+        self.isRequired = isRequired
+        self.defaultValue = defaultValue
+        self.documentation = documentation
+    }
+}
+
+// MARK: - Syntax rule
+
+/// The syntax of a directive: its name, which form(s) it accepts, and its
+/// parameter schema. The marker character comes from the registry settings
+/// unless the directive overrides it.
+public struct DirectiveSyntax: Sendable, Equatable {
+    public enum Form: String, Sendable, Equatable {
+        /// `@pagebreak` — no body. A body makes the candidate literal.
+        case selfContained
+        /// `@font(size: 18){…}` — body required. No body makes it literal.
+        case container
+        /// Body optional.
+        case either
+    }
+
+    /// `[A-Za-z_][A-Za-z0-9_-]*`, dot-separated segments allowed
+    /// (`layout.columns`). Matched EXACTLY — an unregistered name stays
+    /// literal text, exactly like unregistered extension syntax.
+    public var name: String
+    public var form: Form
+    /// Override the registry's default marker for this one directive. `nil`
+    /// uses ``DirectiveRegistrySettings/defaultMarker`` (`@`).
+    public var marker: Character?
+    public var parameters: [DirectiveParameter]
+    /// Whether the body is re-parsed as markdown (container, like a link's
+    /// text) or kept opaque (leaf, like a code span).
+    public var parsesBody: Bool
+
+    public init(
+        name: String,
+        form: Form,
+        marker: Character? = nil,
+        parameters: [DirectiveParameter] = [],
+        parsesBody: Bool = true
+    ) {
+        self.name = name
+        self.form = form
+        self.marker = marker
+        self.parameters = parameters
+        self.parsesBody = parsesBody
+    }
+}
+
+// MARK: - The protocol
+
+/// An embedder-contributed inline command. Register instances via
+/// `MarkdownEditorConfiguration.directives`; an unregistered name stays
+/// literal text.
+public protocol MarkdownDirective: Sendable {
+    /// Stable identifier, unique per directive. Defaults to `syntax.name`.
+    /// Used for dispatch and cache keying — never shown to users.
+    var id: String { get }
+    var syntax: DirectiveSyntax { get }
+
+    /// Clean-copy path. `bodyHTML` is already escaped / recursively rendered
+    /// (empty for self-contained).
+    func html(arguments: DirectiveArguments, bodyHTML: String) -> String
+
+}
+
+public extension MarkdownDirective {
+    // NOTE: like `MarkdownExtension`, these defaults mean a conformance that
+    // misspells `syntax` compiles fine and yields an inert directive. If your
+    // command never fires, check that name first.
+    var id: String { syntax.name }
+
+    func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
+        bodyHTML.isEmpty
+            ? "<span data-directive=\"\(id)\"></span>"
+            : "<span data-directive=\"\(id)\">\(bodyHTML)</span>"
+    }
+
+}

--- a/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
+++ b/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
@@ -183,6 +183,91 @@ public struct DirectiveSyntax: Sendable, Equatable {
     }
 }
 
+// MARK: - Styling result
+
+/// How a directive changes the font of its body. Data, not a closure, so the
+/// transform is inspectable, testable, and cheap in the per-keystroke styling
+/// path — with `custom` as the escape hatch for the rare case.
+public struct DirectiveFontTransform {
+    public enum Size {
+        case absolute(CGFloat)
+        case scale(CGFloat)
+    }
+
+    public var size: Size?
+    public var traits: NSFontTraitMask?
+    public var familyName: String?
+    public var custom: ((NSFont) -> NSFont)?
+
+    public static let inherit = DirectiveFontTransform()
+
+    public init(
+        size: Size? = nil,
+        traits: NSFontTraitMask? = nil,
+        familyName: String? = nil,
+        custom: ((NSFont) -> NSFont)? = nil
+    ) {
+        self.size = size
+        self.traits = traits
+        self.familyName = familyName
+        self.custom = custom
+    }
+
+    /// Compose over the INHERITED font — the whole point. `@font(size: 18)`
+    /// inside a heading keeps the heading's bold; `**bold**` inside the body
+    /// keeps 18pt.
+    public func apply(to font: NSFont, manager: NSFontManager = .shared) -> NSFont {
+        var result = font
+        if let familyName {
+            result = NSFont(name: familyName, size: result.pointSize) ?? result
+        }
+        switch size {
+        case .absolute(let points): result = manager.convert(result, toSize: points)
+        case .scale(let factor):    result = manager.convert(result, toSize: result.pointSize * factor)
+        case nil:                   break
+        }
+        if let traits { result = manager.convert(result, toHaveTrait: traits) }
+        if let custom { result = custom(result) }
+        return result
+    }
+}
+
+/// What a container directive does to its body.
+public struct DirectiveStyle {
+    public var font: DirectiveFontTransform
+    /// Non-font attributes for the body range (background, colour, kern…).
+    public var attributes: [NSAttributedString.Key: Any]
+
+    public static let inherit = DirectiveStyle()
+
+    public init(
+        font: DirectiveFontTransform = .inherit,
+        attributes: [NSAttributedString.Key: Any] = [:]
+    ) {
+        self.font = font
+        self.attributes = attributes
+    }
+}
+
+/// Everything a directive may read while deciding how to present itself.
+/// Read-only by construction — a directive cannot reach the text storage.
+public struct DirectiveContext {
+    public let theme: MarkdownEditorTheme
+    /// Font inherited at the directive's position (heading font inside a
+    /// heading, body font in a paragraph).
+    public let inheritedFont: NSFont
+    /// True when the caret is inside the directive — source is revealed.
+    public let isActive: Bool
+    public let marker: Character
+
+    public init(theme: MarkdownEditorTheme, inheritedFont: NSFont, isActive: Bool, marker: Character) {
+        self.theme = theme
+        self.inheritedFont = inheritedFont
+        self.isActive = isActive
+        self.marker = marker
+    }
+}
+
 // MARK: - The protocol
 
 /// An embedder-contributed inline command. Register instances via
@@ -193,6 +278,10 @@ public protocol MarkdownDirective: Sendable {
     /// Used for dispatch and cache keying — never shown to users.
     var id: String { get }
     var syntax: DirectiveSyntax { get }
+
+    /// Container form: how the body is styled. Ignored for self-contained.
+    /// Called during styling; must be cheap and synchronous.
+    func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle
 
     /// Clean-copy path. `bodyHTML` is already escaped / recursively rendered
     /// (empty for self-contained).
@@ -205,6 +294,8 @@ public extension MarkdownDirective {
     // misspells `syntax` compiles fine and yields an inert directive. If your
     // command never fires, check that name first.
     var id: String { syntax.name }
+
+    func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle { .inherit }
 
     func html(arguments: DirectiveArguments, bodyHTML: String) -> String {
         bodyHTML.isEmpty

--- a/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
@@ -156,23 +156,33 @@ struct ExtensionRegistry {
     let entries: [Entry]
     /// Fenced block rules, in registration order.
     let blockEntries: [BlockEntry]
+    /// Directive rules (`@font(size: 18){…}`). Carried here so the directive
+    /// fingerprint folds into the one grammar fingerprint every parse cache
+    /// already keys on — registering a directive invalidates those caches with
+    /// no second key to thread through the pipeline.
+    let directives: DirectiveRegistry
     /// Stable fingerprint for cache keying ("" when empty). Two registries with
     /// the same fingerprint produce identical parses for identical text.
     let fingerprint: String
 
-    static let empty = ExtensionRegistry(entries: [], blockEntries: [], fingerprint: "")
+    static let empty = ExtensionRegistry(entries: [], blockEntries: [], directives: .empty, fingerprint: "")
 
-    private init(entries: [Entry], blockEntries: [BlockEntry], fingerprint: String) {
+    private init(entries: [Entry], blockEntries: [BlockEntry], directives: DirectiveRegistry, fingerprint: String) {
         self.entries = entries
         self.blockEntries = blockEntries
+        self.directives = directives
         self.fingerprint = fingerprint
     }
 
-    init(extensions: [any MarkdownExtension]) {
-        guard !extensions.isEmpty else {
+    init(extensions: [any MarkdownExtension], directives: DirectiveRegistry = .empty) {
+        // Directives alone are a non-empty grammar: only bail out when BOTH
+        // halves are empty, or a directive-only configuration would parse as
+        // pure markdown.
+        guard !extensions.isEmpty || !directives.isEmpty else {
             self = .empty
             return
         }
+        self.directives = directives
         self.entries = extensions.compactMap { ext in
             guard let syntax = ext.inline else { return nil }
             return Entry(
@@ -192,7 +202,7 @@ struct ExtensionRegistry {
         // an id containing the separator characters cannot alias another
         // registry.
         func framed(_ str: String) -> String { "\(str.utf16.count).\(str)" }
-        self.fingerprint = extensions
+        let extensionFingerprint = extensions
             .map { ext in
                 var parts = [framed(ext.id)]
                 if let s = ext.inline {
@@ -206,9 +216,16 @@ struct ExtensionRegistry {
                 return parts.joined(separator: ",")
             }
             .joined(separator: "|")
+        // One grammar fingerprint covering both seams. The `~` separator keeps
+        // the halves distinguishable; an empty half contributes nothing, so a
+        // directive-free registry keeps the fingerprint it had before
+        // directives existed.
+        self.fingerprint = directives.isEmpty
+            ? extensionFingerprint
+            : extensionFingerprint + "~" + directives.fingerprint
     }
 
-    var isEmpty: Bool { entries.isEmpty && blockEntries.isEmpty }
+    var isEmpty: Bool { entries.isEmpty && blockEntries.isEmpty && directives.isEmpty }
 
     /// The first registered block rule whose fence opens `line` (column 0),
     /// or nil. Registration order is precedence, matching the inline rules.
@@ -223,9 +240,9 @@ struct ExtensionRegistry {
 }
 
 extension MarkdownEditorConfiguration {
-    /// The parser-facing registry derived from `extensions`.
+    /// The parser-facing registry derived from `extensions` and `directives`.
     var extensionRegistry: ExtensionRegistry {
-        ExtensionRegistry(extensions: extensions)
+        ExtensionRegistry(extensions: extensions, directives: directiveRegistry)
     }
 
     /// Styler-facing lookup: extension behavior by id.

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -286,6 +286,34 @@ enum InlineParser {
 
     private static func matchClaimedSpan(_ ns: NSString, _ len: Int, at i: Int, registry: ExtensionRegistry) -> Span? {
         if let span = matchBuiltIn(ns, len, at: i) { return span }
+        // Directives (`@font(size: 18){…}`) match after every built-in and
+        // BEFORE the extension loop below, on the same terms as extension
+        // spans: registered names only, and a rejection leaves the candidate
+        // literal. The ordering is deliberate — a directive is a named
+        // construct with a boundary rule, so it can't be ambiguous with an
+        // extension's delimiters unless an extension opens with the directive
+        // marker, in which case the directive wins. They project into the AST
+        // as extension-shaped nodes under a reserved id namespace, so marker
+        // shrink, caret reveal, token projection, and rich copy all apply
+        // unchanged.
+        //
+        // A directive candidate overlapping an ALREADY-CLAIMED span is
+        // rejected outright, so a code span or a backslash escape in the body
+        // keeps the whole directive literal — see the known limitation in
+        // `DirectiveScanner`.
+        //
+        // The emptiness test is HOISTED here rather than left to the identical
+        // guard inside `match`. This runs per unclaimed character, and `match`
+        // is too large to inline: the call, the indirect return buffer for a
+        // ~200-byte `DirectiveMatch?` and an outlined ARC helper all execute
+        // before the callee's own guard is reached. Measured on a release
+        // build, that cost a document registering NO directives 12-19% of its
+        // parse stage for a feature it never turned on.
+        if !registry.directives.isEmpty,
+           let match = DirectiveScanner.match(ns, len: len, at: i, registry: registry.directives) {
+            return .ext(id: match.nodeID, range: match.range, contentRange: match.contentRange,
+                        markers: match.markers, parsesContent: match.parsesContent)
+        }
         // Extensions match after every built-in, in registration order. A
         // built-in trigger that matched-and-FAILED (e.g. `$50$` rejected by
         // the math heuristic) falls through here, so an extension sharing a

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -286,12 +286,21 @@ enum InlineParser {
 
     private static func matchClaimedSpan(_ ns: NSString, _ len: Int, at i: Int, registry: ExtensionRegistry) -> Span? {
         if let span = matchBuiltIn(ns, len, at: i) { return span }
-        // Directives (`@font(size: 18){…}`) match after every built-in, on the
-        // same terms as extension spans: registered names only, and a rejection
-        // leaves the candidate literal. They project into the AST as
-        // extension-shaped nodes under a reserved id namespace, so marker
+        // Directives (`@font(size: 18){…}`) match after every built-in and
+        // BEFORE the extension loop below, on the same terms as extension
+        // spans: registered names only, and a rejection leaves the candidate
+        // literal. The ordering is deliberate — a directive is a named
+        // construct with a boundary rule, so it can't be ambiguous with an
+        // extension's delimiters unless an extension opens with the directive
+        // marker, in which case the directive wins. They project into the AST
+        // as extension-shaped nodes under a reserved id namespace, so marker
         // shrink, caret reveal, token projection, and rich copy all apply
         // unchanged.
+        //
+        // A directive candidate overlapping an ALREADY-CLAIMED span is
+        // rejected outright, so a code span or a backslash escape in the body
+        // keeps the whole directive literal — see the known limitation in
+        // `DirectiveScanner`.
         if let match = DirectiveScanner.match(ns, len: len, at: i, registry: registry.directives) {
             return .ext(id: match.nodeID, range: match.range, contentRange: match.contentRange,
                         markers: match.markers, parsesContent: match.parsesContent)

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -286,6 +286,16 @@ enum InlineParser {
 
     private static func matchClaimedSpan(_ ns: NSString, _ len: Int, at i: Int, registry: ExtensionRegistry) -> Span? {
         if let span = matchBuiltIn(ns, len, at: i) { return span }
+        // Directives (`@font(size: 18){…}`) match after every built-in, on the
+        // same terms as extension spans: registered names only, and a rejection
+        // leaves the candidate literal. They project into the AST as
+        // extension-shaped nodes under a reserved id namespace, so marker
+        // shrink, caret reveal, token projection, and rich copy all apply
+        // unchanged.
+        if let match = DirectiveScanner.match(ns, len: len, at: i, registry: registry.directives) {
+            return .ext(id: match.nodeID, range: match.range, contentRange: match.contentRange,
+                        markers: match.markers, parsesContent: match.parsesContent)
+        }
         // Extensions match after every built-in, in registration order. A
         // built-in trigger that matched-and-FAILED (e.g. `$50$` rejected by
         // the math heuristic) falls through here, so an extension sharing a

--- a/Sources/MarkdownEngine/Parser/InlineParser.swift
+++ b/Sources/MarkdownEngine/Parser/InlineParser.swift
@@ -301,7 +301,16 @@ enum InlineParser {
         // rejected outright, so a code span or a backslash escape in the body
         // keeps the whole directive literal — see the known limitation in
         // `DirectiveScanner`.
-        if let match = DirectiveScanner.match(ns, len: len, at: i, registry: registry.directives) {
+        //
+        // The emptiness test is HOISTED here rather than left to the identical
+        // guard inside `match`. This runs per unclaimed character, and `match`
+        // is too large to inline: the call, the indirect return buffer for a
+        // ~200-byte `DirectiveMatch?` and an outlined ARC helper all execute
+        // before the callee's own guard is reached. Measured on a release
+        // build, that cost a document registering NO directives 12-19% of its
+        // parse stage for a feature it never turned on.
+        if !registry.directives.isEmpty,
+           let match = DirectiveScanner.match(ns, len: len, at: i, registry: registry.directives) {
             return .ext(id: match.nodeID, range: match.range, contentRange: match.contentRange,
                         markers: match.markers, parsesContent: match.parsesContent)
         }

--- a/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
@@ -19,12 +19,25 @@ public enum MarkdownHTMLRenderer {
     /// Render `markdown` to an HTML fragment (block elements joined by newlines).
     /// `extensions` render their spans (e.g. `<mark>` for highlight); an
     /// unregistered extension's syntax stays literal text.
-    public static func html(from markdown: String, extensions: [any MarkdownExtension] = []) -> String {
+    public static func html(
+        from markdown: String,
+        extensions: [any MarkdownExtension] = [],
+        directives: [any MarkdownDirective] = [],
+        directiveSettings: DirectiveRegistrySettings = .default
+    ) -> String {
         let ns = markdown as NSString
-        let env = Env(registry: ExtensionRegistry(extensions: extensions),
+        let env = Env(registry: ExtensionRegistry(
+                          extensions: extensions,
+                          directives: DirectiveRegistry(directives: directives, settings: directiveSettings)
+                      ),
                       byID: {
                           var out: [String: any MarkdownExtension] = [:]
                           for ext in extensions { out[ext.id] = ext }
+                          return out
+                      }(),
+                      directivesByID: {
+                          var out: [String: any MarkdownDirective] = [:]
+                          for directive in directives { out[directive.id] = directive }
                           return out
                       }())
         let blocks = DocumentAST.parse(markdown, registry: env.registry)
@@ -36,7 +49,32 @@ public enum MarkdownHTMLRenderer {
     private struct Env {
         let registry: ExtensionRegistry
         let byID: [String: any MarkdownExtension]
+        var directivesByID: [String: any MarkdownDirective] = [:]
         static let empty = Env(registry: .empty, byID: [:])
+
+        /// The directive behind an AST node id, or nil when the node is an
+        /// ordinary extension span.
+        func directive(forNodeID nodeID: String) -> (any MarkdownDirective)? {
+            DirectiveRegistry.directiveID(forNodeID: nodeID).flatMap { directivesByID[$0] }
+        }
+    }
+
+    /// Render a directive node: arguments are recovered from the prefix marker,
+    /// exactly as the styler does, so HTML and on-screen styling can never
+    /// disagree about what was passed.
+    private static func directiveHTML(
+        _ directive: any MarkdownDirective,
+        node: ExtensionInlineNode,
+        bodyHTML: String,
+        ns: NSString
+    ) -> String {
+        let prefix = node.markers.first ?? node.range
+        let arguments = DirectiveArguments(
+            parsing: DirectiveScanner.argumentsRange(inPrefix: prefix, of: ns),
+            in: ns,
+            schema: directive.syntax.parameters
+        )
+        return directive.html(arguments: arguments, bodyHTML: bodyHTML)
     }
 
     // MARK: - Blocks
@@ -231,6 +269,16 @@ public enum MarkdownHTMLRenderer {
             return "<img src=\"\(t)\" alt=\"\(t)\">"
 
         case .ext(let node):
+            // A self-contained directive has no body; a container's body is
+            // its content range.
+            if let directive = env.directive(forNodeID: node.extensionID) {
+                let inner = node.markers.isEmpty
+                    ? ""
+                    : (node.children.isEmpty
+                        ? escape(ns.substring(with: node.contentRange))
+                        : renderInlines(node.children, ns: ns, env: env))
+                return directiveHTML(directive, node: node, bodyHTML: inner, ns: ns)
+            }
             guard let ext = env.byID[node.extensionID] else {
                 return escape(ns.substring(with: node.range))   // unknown id → literal
             }

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler+Directives.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler+Directives.swift
@@ -1,0 +1,78 @@
+//
+//  MarkdownASTStyler+Directives.swift
+//  MarkdownEngine
+//
+//  Phase 2 of the directive seam: a container directive's body picks up the
+//  directive's style, and — the part that matters — its font TRANSFORM
+//  composes over the font inherited at that point in the tree.
+//
+//  That composition is why directives are tree-shaped. The styler already
+//  threads a font down the walk (heading font → +bold → +italic); a directive
+//  simply contributes another step, so every combination stacks instead of
+//  overwriting:
+//
+//      # @font(size: 18){**bold** and *italic*}
+//        └ heading font → 18pt → +bold / +italic
+//
+//  A "from here on" directive could not participate in that at all — it would
+//  have to mutate state between siblings, which is exactly what the
+//  compose-on-descent model has no place for.
+//
+//  Ranges all come from the parser. A directive supplies attributes and a font
+//  transform; it never sees or emits geometry, so a misbehaving directive can
+//  restyle its own body at worst.
+//
+
+import AppKit
+import Foundation
+
+extension MarkdownASTStyler {
+
+    /// Style a directive node and return the font its body's children must
+    /// inherit — or `nil` when `node` isn't a registered directive, in which
+    /// case the caller falls through to ordinary extension-span handling.
+    ///
+    /// Self-contained calls return their inherited font unchanged: they have
+    /// no body, and their glyph presentation lands in Phase 3.
+    static func directiveBodyFont(
+        for node: ExtensionInlineNode,
+        font: NSFont,
+        ctx: Ctx,
+        into attrs: inout [StyledRange]
+    ) -> NSFont? {
+        guard let directiveID = DirectiveRegistry.directiveID(forNodeID: node.extensionID) else { return nil }
+        // Linear scan, not a dictionary build: registries hold a handful of
+        // directives and this runs per directive NODE per restyle, so the
+        // allocation would cost more than the scan. A directive unregistered
+        // since the parse degrades to plain text rather than styling wrongly.
+        guard let directive = ctx.config.directives.first(where: { $0.id == directiveID }) else { return nil }
+
+        let marker = directive.syntax.marker ?? ctx.config.directiveSettings.defaultMarker
+        let context = DirectiveContext(
+            theme: ctx.theme,
+            inheritedFont: font,
+            isActive: ctx.isActive(node.range),
+            marker: marker
+        )
+
+        // A self-contained call is the whole node — no body to style.
+        guard !node.markers.isEmpty, node.contentRange.length > 0 else { return font }
+
+        let arguments = DirectiveArguments(
+            parsing: DirectiveScanner.argumentsRange(inPrefix: node.markers[0], of: ctx.ns),
+            in: ctx.ns,
+            schema: directive.syntax.parameters
+        )
+        let style = directive.style(arguments: arguments, context: context)
+        let bodyFont = style.font.apply(to: font)
+
+        if !style.attributes.isEmpty {
+            attrs.append((node.contentRange, style.attributes))
+        }
+        // Emit the font even when the transform is a no-op: the body inherits
+        // it explicitly, so a later pass can't leave part of the span on a
+        // stale font.
+        attrs.append((node.contentRange, [.font: bodyFont]))
+        return bodyFont
+    }
+}

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -521,7 +521,9 @@ enum MarkdownASTStyler {
     }
 
     /// Shared inputs threaded through the walk.
-    private struct Ctx {
+    /// Internal (not private) so per-construct styling can live in its own
+    /// file — see `MarkdownASTStyler+Directives.swift`.
+    struct Ctx {
         let ns: NSString
         let fontName: String
         let baseFont: NSFont
@@ -770,6 +772,18 @@ enum MarkdownASTStyler {
                 styleInlines(children, font: composed, ctx: ctx, into: &attrs)
 
             case .ext(let node):
+                // Directives come through the same node shape under a reserved
+                // id namespace. They compose a font TRANSFORM over the
+                // inherited font and hand it down, so emphasis nested in the
+                // body keeps both (`@font(size: 18){**bold**}` is bold AND
+                // 18pt). Non-directive nodes fall through unchanged.
+                if let bodyFont = directiveBodyFont(for: node, font: font, ctx: ctx, into: &attrs) {
+                    if ctx.isActive(node.range) {
+                        for marker in node.markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+                    }
+                    styleInlines(node.children, font: bodyFont, ctx: ctx, into: &attrs)
+                    break
+                }
                 // Extension-contributed span: the extension supplies content
                 // ATTRIBUTES only; every range comes from the parser, so a
                 // misbehaving extension can restyle its own span at worst.

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -825,6 +825,9 @@ enum MarkdownASTStyler {
             }
         }
         for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+        // The target is syntax, revealed with its brackets and muted like them —
+        // at body color it is louder than the label it belongs to.
+        if isActive { attrs.append((urlRange, [.foregroundColor: ctx.theme.mutedText])) }
         styleInlines(children, font: font, ctx: ctx, into: &attrs)
     }
 

--- a/Sources/MarkdownEngine/TextView/MarkdownPasteboardWriter.swift
+++ b/Sources/MarkdownEngine/TextView/MarkdownPasteboardWriter.swift
@@ -23,7 +23,9 @@ enum MarkdownPasteboardWriter {
 
     @MainActor
     static func write(markdown: String, to pasteboard: NSPasteboard,
-                      extensions: [any MarkdownExtension] = []) {
+                      extensions: [any MarkdownExtension] = [],
+                      directives: [any MarkdownDirective] = [],
+                      directiveSettings: DirectiveRegistrySettings = .default) {
         pasteboard.clearContents()
 
         // Always keep the raw markdown available as plain text.
@@ -34,7 +36,8 @@ enum MarkdownPasteboardWriter {
         pasteboard.setString(markdown, forType: Self.markdownType)
 
         // Render the selection to clean HTML.
-        let htmlBody = MarkdownHTMLRenderer.html(from: markdown, extensions: extensions)
+        let htmlBody = MarkdownHTMLRenderer.html(from: markdown, extensions: extensions,
+                                                 directives: directives, directiveSettings: directiveSettings)
         // Rich targets (web archive + RTF) show task items as plain bullets
         // (user's call); the .html flavor keeps the GFM checkbox markup so
         // markdown apps (Obsidian etc.) restore `- [ ]` on paste.

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Copy.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Copy.swift
@@ -21,6 +21,8 @@ extension NativeTextView {
             return
         }
         let raw = (string as NSString).substring(with: sel)
-        MarkdownPasteboardWriter.write(markdown: raw, to: .general, extensions: configuration.extensions)
+        MarkdownPasteboardWriter.write(markdown: raw, to: .general, extensions: configuration.extensions,
+                                       directives: configuration.directives,
+                                       directiveSettings: configuration.directiveSettings)
     }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -502,14 +502,22 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         // and no rebuild is needed for it to take effect.
         textView.configuration.lists = configuration.lists
         context.coordinator.configuration.lists = configuration.lists
-        // Sync registered extensions (inline spans + fenced blocks). A change alters the GRAMMAR
-        // (tokens differ under the new registry), so the coordinator's parsed
+        // Sync registered extensions (inline spans + fenced blocks) and directives. A change alters
+        // the GRAMMAR (tokens differ under the new registry), so the coordinator's parsed
         // cache must drop before the restyle — the parse-layer memos invalidate
         // themselves via the registry fingerprint.
+        //
+        // The fingerprint covers BOTH seams, so a directive-only change lands in this branch too —
+        // which means the directive list has to be copied here as well, or the restyle it triggers
+        // runs against the old one.
         let newExtensionFingerprint = configuration.extensionRegistry.fingerprint
         if newExtensionFingerprint != context.coordinator.configuration.extensionRegistry.fingerprint {
             context.coordinator.configuration.extensions = configuration.extensions
             textView.configuration.extensions = configuration.extensions
+            context.coordinator.configuration.directives = configuration.directives
+            textView.configuration.directives = configuration.directives
+            context.coordinator.configuration.directiveSettings = configuration.directiveSettings
+            textView.configuration.directiveSettings = configuration.directiveSettings
             context.coordinator.cachedParsedDocument = nil
             let fullRange = NSRange(location: 0, length: (textView.string as NSString).length)
             if fullRange.length > 0 {

--- a/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
@@ -1,0 +1,245 @@
+//
+//  DirectiveArgumentTests.swift
+//  MarkdownEngineTests
+//
+//  Schema-driven coercion of a directive's argument list: labelled and
+//  positional values, units, defaults, and one diagnostic per way a call can
+//  be wrong — without ever throwing or partially applying.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — arguments")
+struct DirectiveArgumentTests {
+
+    private let schema: [DirectiveParameter] = [
+        .init(label: "size", kind: .length),
+        .init(label: "family", kind: .string),
+        .init(label: "weight", kind: .keyword(["regular", "bold"]), defaultValue: .keyword("regular")),
+        .init(label: "wrap", kind: .boolean),
+        .init(label: "count", kind: .number),
+    ]
+
+    /// Parse the text between the parens of `@x(…)`.
+    private func parse(_ arguments: String, schema: [DirectiveParameter]? = nil) -> DirectiveArguments {
+        let text = "(\(arguments))" as NSString
+        let range = NSRange(location: 1, length: text.length - 2)
+        return DirectiveArguments(parsing: range, in: text, schema: schema ?? self.schema)
+    }
+
+    // MARK: - Labelled values
+
+    @Test("labelled values coerce by kind")
+    func labelledValues() {
+        let args = parse("size: 18, family: \"Menlo\", wrap: true, count: 3")
+        #expect(args.number("size") == 18)
+        #expect(args.string("family") == "Menlo")
+        #expect(args.bool("wrap") == true)
+        #expect(args.number("count") == 3)
+        #expect(args.isValid)
+    }
+
+    @Test("whitespace around labels and values is ignored")
+    func toleratesWhitespace() {
+        #expect(parse("  size :  18  ").number("size") == 18)
+    }
+
+    @Test("an unquoted string value is accepted")
+    func unquotedString() {
+        #expect(parse("family: Menlo").string("family") == "Menlo")
+    }
+
+    // MARK: - Units
+
+    @Test("units parse and resolve", arguments: [
+        ("size: 18", 18.0, 18.0),
+        ("size: 18pt", 18.0, 18.0),
+        ("size: 1.5em", 1.5, 18.0),
+        ("size: 50%", 50.0, 6.0),
+    ])
+    func units(input: String, raw: Double, resolved: Double) {
+        let args = parse(input)
+        #expect(args.number("size") == raw)
+        #expect(args.length("size", relativeTo: 12) == CGFloat(resolved))
+    }
+
+    // MARK: - Positional values
+
+    @Test("positional values fill the unlabelled slots in order")
+    func positionalValues() {
+        let schema: [DirectiveParameter] = [
+            .init(label: nil, kind: .keyword([])),
+            .init(label: nil, kind: .number),
+        ]
+        let args = parse("red, 3", schema: schema)
+        #expect(args.positional.count == 2)
+        #expect(args.positional[0].asString == "red")
+        #expect(args.positional[1].asDouble == 3)
+    }
+
+    @Test("a surplus positional value is a diagnostic, not a crash")
+    func tooManyPositional() {
+        let schema: [DirectiveParameter] = [.init(label: nil, kind: .keyword([]))]
+        let args = parse("red, blue", schema: schema)
+        #expect(args.positional.count == 1)
+        #expect(args.diagnostics.contains { $0.kind == .tooManyPositional })
+    }
+
+    // MARK: - Splitting
+
+    @Test("a comma inside a quoted value does not split the argument")
+    func quotedComma() {
+        #expect(parse("family: \"Helvetica, Neue\"").string("family") == "Helvetica, Neue")
+    }
+
+    @Test("a colon inside a quoted value is not a label separator")
+    func quotedColon() {
+        #expect(parse("family: \"12:30\"").string("family") == "12:30")
+    }
+
+    @Test("a comma inside nested parens does not split the argument")
+    func nestedComma() {
+        let args = parse("family: fn(a, b), size: 18")
+        #expect(args.number("size") == 18)
+    }
+
+    // MARK: - Defaults
+
+    @Test("an unsupplied parameter takes its default")
+    func appliesDefaults() {
+        #expect(parse("size: 18").string("weight") == "regular")
+    }
+
+    @Test("a supplied value beats the default")
+    func explicitBeatsDefault() {
+        #expect(parse("weight: bold").string("weight") == "bold")
+    }
+
+    @Test("an empty argument list still applies defaults")
+    func emptyListAppliesDefaults() {
+        let args = DirectiveArguments(parsing: nil, in: "" as NSString, schema: schema)
+        #expect(args.string("weight") == "regular")
+    }
+
+    // MARK: - Diagnostics
+
+    @Test("an unknown label is reported and dropped")
+    func unknownLabel() {
+        let args = parse("colour: red")
+        #expect(args.diagnostics.contains { $0.kind == .unknownLabel("colour") })
+        #expect(args["colour"] == nil)
+        #expect(!args.isValid)
+    }
+
+    @Test("a type mismatch is reported and dropped")
+    func typeMismatch() {
+        let args = parse("count: notanumber")
+        #expect(args.number("count") == nil)
+        #expect(args.diagnostics.contains {
+            if case .typeMismatch(let label, _) = $0.kind { return label == "count" }
+            return false
+        })
+    }
+
+    @Test("a keyword outside its closed set is a mismatch")
+    func keywordOutsideSet() {
+        let args = parse("weight: heavy")
+        // Falls back to the default rather than passing an unsupported value.
+        #expect(args.string("weight") == "regular")
+        #expect(!args.isValid)
+    }
+
+    @Test("a missing required parameter is reported")
+    func missingRequired() {
+        let schema: [DirectiveParameter] = [.init(label: "src", kind: .string, isRequired: true)]
+        let args = parse("", schema: schema)
+        #expect(args.diagnostics.contains { $0.kind == .missingRequired("src") })
+    }
+
+    @Test("a missing required positional is reported")
+    func missingRequiredPositional() {
+        let schema: [DirectiveParameter] = [.init(label: nil, kind: .keyword([]), isRequired: true)]
+        #expect(!parse("", schema: schema).isValid)
+    }
+
+    @Test("one bad argument does not discard the good ones")
+    func partialFailureIsContained() {
+        let args = parse("size: 18, colour: red")
+        #expect(args.number("size") == 18)
+        #expect(!args.isValid)
+    }
+
+    // MARK: - End to end
+
+    @Test("arguments read off a parsed directive node")
+    func readsFromParsedNode() {
+        let text = "@font(size: 1.5em, weight: bold){hi}" as NSString
+        let registry = DirectiveRegistry(directives: [SizedDirective()])
+        let match = DirectiveScanner.match(text, len: text.length, at: 0, registry: registry)
+        let args = DirectiveArguments(parsing: match?.argumentsRange, in: text,
+                                      schema: SizedDirective().syntax.parameters)
+        #expect(args.length("size", relativeTo: 12) == 18)
+        #expect(args.string("weight") == "bold")
+        #expect(args.isValid)
+    }
+
+    // MARK: - Defaults on positional parameters
+
+    /// A positional parameter carrying a default used to yield nothing:
+    /// `applyingDefaults` only filled labelled ones.
+    private func positionalString(_ args: DirectiveArguments, _ index: Int) -> String? {
+        index < args.positional.count ? args.positional[index].asString : nil
+    }
+
+    private var positionalSchema: [DirectiveParameter] {
+        [.init(label: nil, kind: .keyword([]), isRequired: true),
+         .init(label: nil, kind: .keyword([]), defaultValue: .keyword("medium"))]
+    }
+
+    private func arguments(_ source: String, schema: [DirectiveParameter]) -> DirectiveArguments {
+        let text = source as NSString
+        let registry = DirectiveRegistry(directives: [SelfContainedPair()])
+        let match = DirectiveScanner.match(text, len: text.length, at: 0, registry: registry)
+        return DirectiveArguments(parsing: match?.argumentsRange, in: text, schema: schema)
+    }
+
+    @Test("an unsupplied positional falls back to its default")
+    func positionalDefaultApplies() {
+        let args = arguments("@pair(star)", schema: positionalSchema)
+        #expect(positionalString(args, 0) == "star")
+        #expect(positionalString(args, 1) == "medium")
+        #expect(args.isValid)
+    }
+
+    @Test("a supplied positional wins over its default")
+    func positionalDefaultOverridden() {
+        let args = arguments("@pair(star, large)", schema: positionalSchema)
+        #expect(positionalString(args, 1) == "large")
+        #expect(args.isValid)
+    }
+
+    @Test("a required positional with no default is still reported missing")
+    func requiredPositionalStillMissing() {
+        let args = arguments("@pair", schema: positionalSchema)
+        #expect(!args.isValid)
+        #expect(args.diagnostics.contains { if case .missingRequired("#0") = $0.kind { return true }; return false })
+    }
+
+    /// Defaults fill a TAIL. There is no syntax for skipping one, so the first
+    /// positional without a default stops the fill and is reported instead.
+    @Test("a default cannot be skipped over to reach a later parameter")
+    func positionalDefaultsFillOnlyTheTail() {
+        let schema: [DirectiveParameter] = [
+            .init(label: nil, kind: .keyword([]), isRequired: true),
+            .init(label: nil, kind: .keyword([]), defaultValue: .keyword("mid")),
+            .init(label: nil, kind: .keyword([]), isRequired: true),
+        ]
+        let args = arguments("@pair(a)", schema: schema)
+        #expect(positionalString(args, 1) == "mid")
+        #expect(args.diagnostics.contains { if case .missingRequired("#2") = $0.kind { return true }; return false })
+    }
+
+}

--- a/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
@@ -1,0 +1,188 @@
+//
+//  DirectiveArgumentTests.swift
+//  MarkdownEngineTests
+//
+//  Schema-driven coercion of a directive's argument list: labelled and
+//  positional values, units, defaults, and one diagnostic per way a call can
+//  be wrong — without ever throwing or partially applying.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — arguments")
+struct DirectiveArgumentTests {
+
+    private let schema: [DirectiveParameter] = [
+        .init(label: "size", kind: .length),
+        .init(label: "family", kind: .string),
+        .init(label: "weight", kind: .keyword(["regular", "bold"]), defaultValue: .keyword("regular")),
+        .init(label: "wrap", kind: .boolean),
+        .init(label: "count", kind: .number),
+    ]
+
+    /// Parse the text between the parens of `@x(…)`.
+    private func parse(_ arguments: String, schema: [DirectiveParameter]? = nil) -> DirectiveArguments {
+        let text = "(\(arguments))" as NSString
+        let range = NSRange(location: 1, length: text.length - 2)
+        return DirectiveArguments(parsing: range, in: text, schema: schema ?? self.schema)
+    }
+
+    // MARK: - Labelled values
+
+    @Test("labelled values coerce by kind")
+    func labelledValues() {
+        let args = parse("size: 18, family: \"Menlo\", wrap: true, count: 3")
+        #expect(args.number("size") == 18)
+        #expect(args.string("family") == "Menlo")
+        #expect(args.bool("wrap") == true)
+        #expect(args.number("count") == 3)
+        #expect(args.isValid)
+    }
+
+    @Test("whitespace around labels and values is ignored")
+    func toleratesWhitespace() {
+        #expect(parse("  size :  18  ").number("size") == 18)
+    }
+
+    @Test("an unquoted string value is accepted")
+    func unquotedString() {
+        #expect(parse("family: Menlo").string("family") == "Menlo")
+    }
+
+    // MARK: - Units
+
+    @Test("units parse and resolve", arguments: [
+        ("size: 18", 18.0, 18.0),
+        ("size: 18pt", 18.0, 18.0),
+        ("size: 1.5em", 1.5, 18.0),
+        ("size: 50%", 50.0, 6.0),
+    ])
+    func units(input: String, raw: Double, resolved: Double) {
+        let args = parse(input)
+        #expect(args.number("size") == raw)
+        #expect(args.length("size", relativeTo: 12) == CGFloat(resolved))
+    }
+
+    // MARK: - Positional values
+
+    @Test("positional values fill the unlabelled slots in order")
+    func positionalValues() {
+        let schema: [DirectiveParameter] = [
+            .init(label: nil, kind: .keyword([])),
+            .init(label: nil, kind: .number),
+        ]
+        let args = parse("red, 3", schema: schema)
+        #expect(args.positional.count == 2)
+        #expect(args.positional[0].asString == "red")
+        #expect(args.positional[1].asDouble == 3)
+    }
+
+    @Test("a surplus positional value is a diagnostic, not a crash")
+    func tooManyPositional() {
+        let schema: [DirectiveParameter] = [.init(label: nil, kind: .keyword([]))]
+        let args = parse("red, blue", schema: schema)
+        #expect(args.positional.count == 1)
+        #expect(args.diagnostics.contains { $0.kind == .tooManyPositional })
+    }
+
+    // MARK: - Splitting
+
+    @Test("a comma inside a quoted value does not split the argument")
+    func quotedComma() {
+        #expect(parse("family: \"Helvetica, Neue\"").string("family") == "Helvetica, Neue")
+    }
+
+    @Test("a colon inside a quoted value is not a label separator")
+    func quotedColon() {
+        #expect(parse("family: \"12:30\"").string("family") == "12:30")
+    }
+
+    @Test("a comma inside nested parens does not split the argument")
+    func nestedComma() {
+        let args = parse("family: fn(a, b), size: 18")
+        #expect(args.number("size") == 18)
+    }
+
+    // MARK: - Defaults
+
+    @Test("an unsupplied parameter takes its default")
+    func appliesDefaults() {
+        #expect(parse("size: 18").string("weight") == "regular")
+    }
+
+    @Test("a supplied value beats the default")
+    func explicitBeatsDefault() {
+        #expect(parse("weight: bold").string("weight") == "bold")
+    }
+
+    @Test("an empty argument list still applies defaults")
+    func emptyListAppliesDefaults() {
+        let args = DirectiveArguments(parsing: nil, in: "" as NSString, schema: schema)
+        #expect(args.string("weight") == "regular")
+    }
+
+    // MARK: - Diagnostics
+
+    @Test("an unknown label is reported and dropped")
+    func unknownLabel() {
+        let args = parse("colour: red")
+        #expect(args.diagnostics.contains { $0.kind == .unknownLabel("colour") })
+        #expect(args["colour"] == nil)
+        #expect(!args.isValid)
+    }
+
+    @Test("a type mismatch is reported and dropped")
+    func typeMismatch() {
+        let args = parse("count: notanumber")
+        #expect(args.number("count") == nil)
+        #expect(args.diagnostics.contains {
+            if case .typeMismatch(let label, _) = $0.kind { return label == "count" }
+            return false
+        })
+    }
+
+    @Test("a keyword outside its closed set is a mismatch")
+    func keywordOutsideSet() {
+        let args = parse("weight: heavy")
+        // Falls back to the default rather than passing an unsupported value.
+        #expect(args.string("weight") == "regular")
+        #expect(!args.isValid)
+    }
+
+    @Test("a missing required parameter is reported")
+    func missingRequired() {
+        let schema: [DirectiveParameter] = [.init(label: "src", kind: .string, isRequired: true)]
+        let args = parse("", schema: schema)
+        #expect(args.diagnostics.contains { $0.kind == .missingRequired("src") })
+    }
+
+    @Test("a missing required positional is reported")
+    func missingRequiredPositional() {
+        let schema: [DirectiveParameter] = [.init(label: nil, kind: .keyword([]), isRequired: true)]
+        #expect(!parse("", schema: schema).isValid)
+    }
+
+    @Test("one bad argument does not discard the good ones")
+    func partialFailureIsContained() {
+        let args = parse("size: 18, colour: red")
+        #expect(args.number("size") == 18)
+        #expect(!args.isValid)
+    }
+
+    // MARK: - End to end
+
+    @Test("arguments read off a parsed directive node")
+    func readsFromParsedNode() {
+        let text = "@font(size: 1.5em, weight: bold){hi}" as NSString
+        let registry = DirectiveRegistry(directives: [SizedDirective()])
+        let match = DirectiveScanner.match(text, len: text.length, at: 0, registry: registry)
+        let args = DirectiveArguments(parsing: match?.argumentsRange, in: text,
+                                      schema: SizedDirective().syntax.parameters)
+        #expect(args.length("size", relativeTo: 12) == 18)
+        #expect(args.string("weight") == "bold")
+        #expect(args.isValid)
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
@@ -185,4 +185,61 @@ struct DirectiveArgumentTests {
         #expect(args.string("weight") == "bold")
         #expect(args.isValid)
     }
+
+    // MARK: - Defaults on positional parameters
+
+    /// A positional parameter carrying a default used to yield nothing:
+    /// `applyingDefaults` only filled labelled ones.
+    private func positionalString(_ args: DirectiveArguments, _ index: Int) -> String? {
+        index < args.positional.count ? args.positional[index].asString : nil
+    }
+
+    private var positionalSchema: [DirectiveParameter] {
+        [.init(label: nil, kind: .keyword([]), isRequired: true),
+         .init(label: nil, kind: .keyword([]), defaultValue: .keyword("medium"))]
+    }
+
+    private func arguments(_ source: String, schema: [DirectiveParameter]) -> DirectiveArguments {
+        let text = source as NSString
+        let registry = DirectiveRegistry(directives: [SelfContainedPair()])
+        let match = DirectiveScanner.match(text, len: text.length, at: 0, registry: registry)
+        return DirectiveArguments(parsing: match?.argumentsRange, in: text, schema: schema)
+    }
+
+    @Test("an unsupplied positional falls back to its default")
+    func positionalDefaultApplies() {
+        let args = arguments("@pair(star)", schema: positionalSchema)
+        #expect(positionalString(args, 0) == "star")
+        #expect(positionalString(args, 1) == "medium")
+        #expect(args.isValid)
+    }
+
+    @Test("a supplied positional wins over its default")
+    func positionalDefaultOverridden() {
+        let args = arguments("@pair(star, large)", schema: positionalSchema)
+        #expect(positionalString(args, 1) == "large")
+        #expect(args.isValid)
+    }
+
+    @Test("a required positional with no default is still reported missing")
+    func requiredPositionalStillMissing() {
+        let args = arguments("@pair", schema: positionalSchema)
+        #expect(!args.isValid)
+        #expect(args.diagnostics.contains { if case .missingRequired("#0") = $0.kind { return true }; return false })
+    }
+
+    /// Defaults fill a TAIL. There is no syntax for skipping one, so the first
+    /// positional without a default stops the fill and is reported instead.
+    @Test("a default cannot be skipped over to reach a later parameter")
+    func positionalDefaultsFillOnlyTheTail() {
+        let schema: [DirectiveParameter] = [
+            .init(label: nil, kind: .keyword([]), isRequired: true),
+            .init(label: nil, kind: .keyword([]), defaultValue: .keyword("mid")),
+            .init(label: nil, kind: .keyword([]), isRequired: true),
+        ]
+        let args = arguments("@pair(a)", schema: schema)
+        #expect(positionalString(args, 1) == "mid")
+        #expect(args.diagnostics.contains { if case .missingRequired("#2") = $0.kind { return true }; return false })
+    }
+
 }

--- a/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
@@ -1,0 +1,237 @@
+//
+//  DirectiveCompositionTests.swift
+//  MarkdownEngineTests
+//
+//  Phase 2 — a container directive's font transform COMPOSES over the font
+//  inherited at that point in the tree, in both directions: the body keeps the
+//  traits of everything enclosing it, and markup nested inside the body keeps
+//  the directive's font.
+//
+//  This is the property that makes directives tree-shaped rather than
+//  positional, so it gets tested from both ends and through nesting.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — font composition")
+struct DirectiveCompositionTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// A directive that only scales, to prove relative units compose.
+    private struct ScaleDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax {
+            DirectiveSyntax(name: "scale", form: .container,
+                            parameters: [.init(label: "by", kind: .number)])
+        }
+        func style(arguments: DirectiveArguments, context: DirectiveContext) -> DirectiveStyle {
+            guard let factor = arguments.number("by") else { return .inherit }
+            return DirectiveStyle(font: DirectiveFontTransform(size: .scale(CGFloat(factor))))
+        }
+    }
+
+    private var configuration: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(directives: [
+            FontDirective(), ColorDirective(), PageBreakDirective(), ScaleDirective(),
+        ])
+    }
+
+    private func style(_ text: String, caret: Int = -1) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            caretLocation: caret, configuration: configuration
+        )
+    }
+
+    /// Effective font at the first occurrence of `needle`.
+    private func font(_ text: String, at needle: String, caret: Int = -1) -> NSFont? {
+        let position = (text as NSString).range(of: needle).location
+        var result: NSFont?
+        for (range, attributes) in style(text, caret: caret) where NSLocationInRange(position, range) {
+            if let font = attributes[.font] as? NSFont { result = font }
+        }
+        return result
+    }
+
+    /// Effective foreground colour at the first occurrence of `needle`.
+    private func color(_ text: String, at needle: String) -> NSColor? {
+        let position = (text as NSString).range(of: needle).location
+        var result: NSColor?
+        for (range, attributes) in style(text) where NSLocationInRange(position, range) {
+            if let color = attributes[.foregroundColor] as? NSColor { result = color }
+        }
+        return result
+    }
+
+    // MARK: - The directive applies
+
+    @Test("an absolute size applies to the body")
+    func absoluteSize() {
+        #expect(font("@font(size: 18){hello}", at: "hello")?.pointSize == 18)
+    }
+
+    @Test("a relative size resolves against the inherited size")
+    func relativeSize() {
+        #expect(font("@font(size: 1.5em){hello}", at: "hello")?.pointSize == base * 1.5)
+        #expect(font("@font(size: 50%){hello}", at: "hello")?.pointSize == base * 0.5)
+    }
+
+    @Test("a weight argument applies")
+    func weightApplies() {
+        let traits = font("@font(weight: bold){hello}", at: "hello")?.fontDescriptor.symbolicTraits
+        #expect(traits?.contains(.bold) == true)
+    }
+
+    @Test("a non-font directive applies its attributes")
+    func attributesApply() {
+        // `@color` resolves through NSColor(named:), unavailable in tests — so
+        // assert the directive is reached and leaves the body's font alone.
+        #expect(font("@color(red){hello}", at: "hello")?.pointSize == base)
+    }
+
+    // MARK: - Composition outward: the body keeps its context
+
+    @Test("inside a heading, the directive keeps the heading's bold")
+    func composesWithHeading() {
+        let font = font("# @font(size: 18){hello}", at: "hello")
+        #expect(font?.pointSize == 18)
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test("inside emphasis, the directive keeps the italic")
+    func composesWithEmphasis() {
+        let font = font("*@font(size: 18){hello}*", at: "hello")
+        #expect(font?.pointSize == 18)
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.italic) == true)
+    }
+
+    // MARK: - Composition inward: nested markup keeps the directive's font
+
+    @Test("bold inside the body keeps the directive's size — the motivating case")
+    func boldInsideKeepsSize() {
+        let font = font("@font(size: 18){**bold**}", at: "bold")
+        #expect(font?.pointSize == 18)
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.bold) == true)
+    }
+
+    @Test("italic inside the body keeps the directive's size")
+    func italicInsideKeepsSize() {
+        let font = font("@font(size: 18){*it*}", at: "it")
+        #expect(font?.pointSize == 18)
+        #expect(font?.fontDescriptor.symbolicTraits.contains(.italic) == true)
+    }
+
+    @Test("bold and italic together keep the directive's size")
+    func boldItalicInsideKeepsSize() {
+        let font = font("@font(size: 18){***both***}", at: "both")
+        #expect(font?.pointSize == 18)
+        let traits = font?.fontDescriptor.symbolicTraits
+        #expect(traits?.contains(.bold) == true)
+        #expect(traits?.contains(.italic) == true)
+    }
+
+    // MARK: - Nesting
+
+    @Test("nested directives compose, innermost last")
+    func nestedDirectivesCompose() {
+        // 14 → ×2 = 28 → ×0.5 = 14
+        #expect(font("@scale(by: 2){@scale(by: 0.5){x}}", at: "x")?.pointSize == base)
+    }
+
+    @Test("a size directive inside a scale directive resolves against the scaled size")
+    func relativeInsideScaled() {
+        // 14 → ×2 = 28 → 1.5em of 28 = 42
+        #expect(font("@scale(by: 2){@font(size: 1.5em){x}}", at: "x")?.pointSize == 42)
+    }
+
+    // MARK: - Containment
+
+    @Test("the directive's font stops at its closing brace")
+    func effectStopsAtBody() {
+        let text = "@font(size: 18){big} small"
+        #expect(font(text, at: "big")?.pointSize == 18)
+        let tail = font(text, at: "small")
+        #expect(tail == nil || tail?.pointSize == base)
+    }
+
+    @Test("a directive does not leak into the next paragraph")
+    func effectStopsAtBlock() {
+        let text = "@font(size: 18){big}\n\nnext paragraph"
+        let tail = font(text, at: "next")
+        #expect(tail == nil || tail?.pointSize == base)
+    }
+
+    // MARK: - Invalid calls
+
+    @Test("an invalid argument mutes the body instead of restyling it")
+    func invalidCallMutes() {
+        // `size: huge` fails length coercion, so FontDirective mutes.
+        let text = "@font(size: huge){hello}"
+        #expect(color(text, at: "hello") == MarkdownEditorTheme.default.disabledText)
+        #expect(font(text, at: "hello")?.pointSize == base)
+    }
+
+    @Test("an unknown label is a diagnostic, and the body still renders")
+    func unknownLabelStillRenders() {
+        #expect(font("@font(colour: red){hello}", at: "hello")?.pointSize == base)
+    }
+
+    // MARK: - Caret behaviour
+
+    @Test("the syntax reveals with the caret inside and shrinks outside")
+    func syntaxRevealFlip() {
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        let text = "@font(size: 18){hello}"
+        #expect(font(text, at: "@font")?.pointSize == hidden)
+        #expect(font(text, at: "@font", caret: 3)?.pointSize != hidden)
+    }
+
+    @Test("the body keeps the directive's size while the syntax is revealed")
+    func bodyStaysStyledWhileActive() {
+        #expect(font("@font(size: 18){hello}", at: "hello", caret: 3)?.pointSize == 18)
+    }
+
+    // MARK: - Scoped restyle
+
+    @Test("scoped styling matches the full pass for a directive-bearing paragraph")
+    func scopedMatchesFull() {
+        let text = "intro\n\n# @font(size: 18){**big**} tail\n\noutro"
+        let ns = text as NSString
+        let paragraph = ns.paragraphRange(for: ns.range(of: "@font"))
+        func digest(_ scoped: [NSRange]?) -> String {
+            MarkdownASTStyler.styleAttributes(
+                text: text, fontName: fontName, fontSize: base,
+                scopedRanges: scoped, configuration: configuration
+            )
+            .filter { NSIntersectionRange($0.range, paragraph).length > 0 }
+            .map { entry in
+                let keys = entry.attributes.keys.map(\.rawValue).sorted().joined(separator: ",")
+                let size = (entry.attributes[.font] as? NSFont).map { "\($0.pointSize)" } ?? "-"
+                return "\(entry.range.location):\(entry.range.length)[\(keys)]\(size)"
+            }
+            .sorted()
+            .joined(separator: "\n")
+        }
+        #expect(digest([paragraph]) == digest(nil))
+    }
+
+    // MARK: - Unregistered
+
+    @Test("an unregistered directive leaves the text completely alone")
+    func unregisteredIsInert() {
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "@font(size: 18){hello}", fontName: fontName, fontSize: base,
+            caretLocation: -1, configuration: .default
+        )
+        let position = ("@font(size: 18){hello}" as NSString).range(of: "hello").location
+        var result: NSFont?
+        for (range, attributes) in attrs where NSLocationInRange(position, range) {
+            if let font = attributes[.font] as? NSFont { result = font }
+        }
+        #expect(result == nil || result?.pointSize == base)
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
@@ -36,7 +36,7 @@ struct DirectiveCompositionTests {
 
     private var configuration: MarkdownEditorConfiguration {
         MarkdownEditorConfiguration(directives: [
-            FontDirective(), ColorDirective(), PageBreakDirective(), ScaleDirective(),
+            FontDirective(), ColorDirective(), MarkerDirective(), ScaleDirective(),
         ])
     }
 

--- a/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
@@ -1,0 +1,76 @@
+//
+//  DirectiveHTMLTests.swift
+//  MarkdownEngineTests
+//
+//  The clean-copy path for directives. Arguments are recovered from the same
+//  prefix geometry the styler uses, so what gets copied can't disagree with
+//  what was on screen.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — HTML")
+struct DirectiveHTMLTests {
+
+    private let directives: [any MarkdownDirective] = [
+        FontDirective(), ColorDirective(), PageBreakDirective(),
+    ]
+
+    private func html(_ markdown: String) -> String {
+        MarkdownHTMLRenderer.html(from: markdown, directives: directives)
+    }
+
+    @Test("a container directive wraps its body")
+    func containerWraps() {
+        #expect(html("@font(size: 18){hello}").contains("font-size:18.0px"))
+        #expect(html("@font(size: 18){hello}").contains(">hello<"))
+    }
+
+    @Test("body markup renders inside the wrapper")
+    func bodyMarkupRenders() {
+        #expect(html("@font(size: 18){**bold**}").contains("<strong>bold</strong>"))
+    }
+
+    @Test("a self-contained directive renders its own markup")
+    func selfContainedRenders() {
+        #expect(html("@pagebreak").contains("<hr class=\"pagebreak\" />"))
+    }
+
+    @Test("a directive with no styling arguments still emits its body")
+    func noArgumentsStillEmitsBody() {
+        #expect(html("@font(){hello}").contains("hello"))
+    }
+
+    @Test("nested directives nest in the output")
+    func nestedDirectives() {
+        let out = html("@font(size: 18){@font(weight: bold){x}}")
+        #expect(out.contains("font-size:18.0px"))
+        #expect(out.contains("font-weight:bold"))
+    }
+
+    @Test("without registration the source copies literally")
+    func unregisteredCopiesLiterally() {
+        let out = MarkdownHTMLRenderer.html(from: "@font(size: 18){hello}")
+        #expect(out.contains("@font(size: 18){hello}"))
+    }
+
+    @Test("registering directives does not disturb ordinary markdown")
+    func ordinaryMarkdownUnchanged() {
+        let markdown = "# Title\n\nSome **bold** and a [link](https://example.com).\n"
+        #expect(html(markdown) == MarkdownHTMLRenderer.html(from: markdown))
+    }
+
+    @Test("an extension and a directive coexist in one render")
+    func extensionsAndDirectivesCoexist() {
+        let out = MarkdownHTMLRenderer.html(
+            from: "==hi== and @font(size: 18){there}",
+            extensions: [HighlightExtension()],
+            directives: directives
+        )
+        #expect(out.contains("<mark>hi</mark>"))
+        #expect(out.contains("font-size:18.0px"))
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
@@ -16,7 +16,7 @@ import Testing
 struct DirectiveHTMLTests {
 
     private let directives: [any MarkdownDirective] = [
-        FontDirective(), ColorDirective(), PageBreakDirective(),
+        FontDirective(), ColorDirective(), MarkerDirective(),
     ]
 
     private func html(_ markdown: String) -> String {
@@ -36,7 +36,7 @@ struct DirectiveHTMLTests {
 
     @Test("a self-contained directive renders its own markup")
     func selfContainedRenders() {
-        #expect(html("@pagebreak").contains("<hr class=\"pagebreak\" />"))
+        #expect(html("@marker").contains("<hr class=\"marker\" />"))
     }
 
     @Test("a directive with no styling arguments still emits its body")

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -1,0 +1,383 @@
+//
+//  DirectiveParserTests.swift
+//  MarkdownEngineTests
+//
+//  The directive seam's parser half: `@name(args){body}` matches only for
+//  registered names at a valid boundary, rejections stay literal text, and the
+//  resulting node carries the geometry the styler needs.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — parsing")
+struct DirectiveParserTests {
+
+    // A directive named after a domain label, so the email-boundary test is
+    // exercised against a name that WOULD otherwise match.
+    private struct WildthinkDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "wildthink", form: .selfContained) }
+    }
+
+    private struct OpaqueDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax {
+            DirectiveSyntax(name: "raw", form: .container, parsesBody: false)
+        }
+    }
+
+    private struct EitherDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "note", form: .either) }
+    }
+
+    private struct BackslashDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax {
+            DirectiveSyntax(name: "bigger", form: .container, marker: "\\")
+        }
+    }
+
+    private var registry: ExtensionRegistry {
+        ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [
+            SizedDirective(), TintDirective(), MarkerDirective(),
+            WildthinkDirective(), OpaqueDirective(), EitherDirective(),
+        ]))
+    }
+
+    // MARK: - Helpers
+
+    /// Every directive node in the parse, flattened (directives project as
+    /// extension-shaped nodes under the reserved id namespace).
+    private func directives(_ text: String, _ registry: ExtensionRegistry? = nil) -> [ExtensionInlineNode] {
+        var found: [ExtensionInlineNode] = []
+        func walk(_ nodes: [InlineNode]) {
+            for node in nodes {
+                switch node {
+                case .ext(let ext):
+                    if DirectiveRegistry.directiveID(forNodeID: ext.extensionID) != nil { found.append(ext) }
+                    walk(ext.children)
+                case .emphasis(_, _, _, let children), .link(_, _, _, _, let children):
+                    walk(children)
+                default:
+                    break
+                }
+            }
+        }
+        walk(InlineParser.parse(text, registry: registry ?? self.registry))
+        return found
+    }
+
+    private func ids(_ text: String, _ registry: ExtensionRegistry? = nil) -> [String] {
+        directives(text, registry).compactMap { DirectiveRegistry.directiveID(forNodeID: $0.extensionID) }
+    }
+
+    private func body(_ text: String) -> String? {
+        guard let node = directives(text).first else { return nil }
+        return (text as NSString).substring(with: node.contentRange)
+    }
+
+    // MARK: - Recognition
+
+    @Test("a registered container directive parses")
+    func containerParses() {
+        #expect(ids("@font(size: 18){hello}") == ["font"])
+        #expect(body("@font(size: 18){hello}") == "hello")
+    }
+
+    @Test("a registered self-contained directive parses")
+    func selfContainedParses() {
+        #expect(ids("text @marker more") == ["marker"])
+    }
+
+    @Test("without a registered directive, @name stays literal")
+    func unregisteredStaysLiteral() {
+        #expect(ids("@unknown(size: 18){hello}").isEmpty)
+        #expect(ids("@font(size: 18){hello}", .empty).isEmpty)
+    }
+
+    @Test("the whole call is claimed, markers plus body")
+    func claimsWholeCall() {
+        let text = "@font(size: 18){hello}"
+        let node = directives(text)[0]
+        #expect(node.range == NSRange(location: 0, length: (text as NSString).length))
+        #expect((text as NSString).substring(with: node.markers[0]) == "@font(size: 18){")
+        #expect((text as NSString).substring(with: node.markers[1]) == "}")
+    }
+
+    @Test("a self-contained call carries no markers in Phase 1 — it renders literally")
+    func selfContainedHasNoMarkers() {
+        #expect(directives("@marker")[0].markers.isEmpty)
+    }
+
+    // MARK: - Boundary rule
+
+    @Test("a directive must open at a boundary, not mid-word")
+    func rejectsMidWord() {
+        #expect(ids("a@marker").isEmpty)
+        #expect(ids("word@font(size: 18){x}").isEmpty)
+    }
+
+    @Test("an email address never opens a directive")
+    func rejectsEmail() {
+        // `wildthink` IS registered — only the boundary rule saves this.
+        #expect(ids("mail jason@example.com now").isEmpty)
+    }
+
+    @Test("a marker run stays literal")
+    func rejectsMarkerRun() {
+        #expect(ids("@@marker").isEmpty)
+    }
+
+    @Test("punctuation and line starts are valid boundaries")
+    func acceptsBoundaries() {
+        #expect(ids("(@marker)") == ["marker"])
+        #expect(ids("line one\n@marker") == ["marker"])
+        #expect(ids("> @marker") == ["marker"])
+    }
+
+    @Test("markup delimiters are boundaries — a directive can abut emphasis")
+    func acceptsMarkupBoundaries() {
+        // Regression: an allow-list of "opening punctuation" silently dropped
+        // every one of these, because the preceding character is a markup
+        // delimiter. Only word characters may reject.
+        #expect(ids("*@font(size: 18){x}*") == ["font"])
+        #expect(ids("**@font(size: 18){x}**") == ["font"])
+        #expect(ids("_@font(size: 18){x}_") == ["font"])
+        #expect(ids("- @marker") == ["marker"])
+        #expect(ids("1. @marker") == ["marker"])
+        #expect(ids("#@marker") == ["marker"])
+    }
+
+    @Test("a digit is a word character, so it rejects")
+    func rejectsAfterDigit() {
+        #expect(ids("v2@marker").isEmpty)
+    }
+
+    @Test("an escaped marker stays literal")
+    func rejectsEscapedMarker() {
+        #expect(ids("\\@marker").isEmpty)
+    }
+
+    // MARK: - Form enforcement
+
+    @Test("a container call without a body stays literal")
+    func containerNeedsBody() {
+        #expect(ids("@font(size: 18)").isEmpty)
+    }
+
+    @Test("a self-contained call with a body stays literal")
+    func selfContainedRejectsBody() {
+        #expect(ids("@marker{x}").isEmpty)
+    }
+
+    @Test("an either-form directive accepts both shapes")
+    func eitherAcceptsBoth() {
+        #expect(ids("@note") == ["note"])
+        #expect(ids("@note{body}") == ["note"])
+    }
+
+    // MARK: - Delimiter scanning
+
+    @Test("braces nest inside a body")
+    func nestedBraces() {
+        #expect(body("@font(size: 18){a {b} c}") == "a {b} c")
+    }
+
+    @Test("parens nest inside an argument list")
+    func nestedParens() {
+        #expect(body("@font(size: max(18, 20)){x}") == "x")
+    }
+
+    @Test("the scanner treats an escaped brace as body text, not a closer")
+    func scannerHonoursEscapedBrace() {
+        let text = "@font(size: 18){a \\} b}" as NSString
+        let match = DirectiveScanner.match(text, len: text.length, at: 0,
+                                           registry: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(match?.bodyRange.map { text.substring(with: $0) } == "a \\} b")
+    }
+
+    @Test("in the full parse an interior escape keeps the call literal — as it does for every construct")
+    func interiorEscapeStaysLiteral() {
+        // The escape pass claims `\}` before the link-family pass runs, and a
+        // candidate overlapping a claimed span is rejected. Directives inherit
+        // that rule verbatim: `[a \* b](url)` and `==a \* b==` are rejected the
+        // same way. The scanner still measures the body correctly (above), so
+        // the day escapes stop pre-claiming, directives need no change.
+        #expect(ids("@font(size: 18){a \\} b}").isEmpty)
+    }
+
+    @Test("a brace inside a quoted argument does not open a body")
+    func quotedBraceInArguments() {
+        #expect(body("@font(family: \"a{b\"){x}") == "x")
+    }
+
+    @Test("an unbalanced call stays literal")
+    func unbalancedStaysLiteral() {
+        #expect(ids("@font(size: 18{hello}").isEmpty)
+        #expect(ids("@font(size: 18){hello").isEmpty)
+    }
+
+    @Test("a directive never spans a line break")
+    func singleLineOnly() {
+        #expect(ids("@font(size: 18){a\nb}").isEmpty)
+        #expect(ids("@font(size:\n18){a}").isEmpty)
+    }
+
+    // MARK: - Precedence
+
+    @Test("a directive inside a code span never fires — built-ins claim first")
+    func codeSpanWins() {
+        #expect(ids("`@font(size: 18){x}`").isEmpty)
+    }
+
+    @Test("a directive inside inline LaTeX never fires")
+    func latexWins() {
+        #expect(ids("$@font(size: 18){x}$").isEmpty)
+    }
+
+    @Test("a directive inside a link's text still parses")
+    func nestsInsideLink() {
+        #expect(ids("[see @font(size: 18){this}](url)") == ["font"])
+    }
+
+    // MARK: - Body parsing
+
+    @Test("a container body is re-parsed as markdown")
+    func bodyIsReparsed() {
+        let node = directives("@font(size: 18){**bold**}")[0]
+        let hasEmphasis = node.children.contains {
+            if case .emphasis = $0 { return true }
+            return false
+        }
+        #expect(hasEmphasis)
+    }
+
+    @Test("an opaque directive keeps its body unparsed")
+    func opaqueBodyStaysFlat() {
+        #expect(directives("@raw{**bold**}")[0].children.isEmpty)
+    }
+
+    @Test("directives nest")
+    func directivesNest() {
+        #expect(ids("@font(size: 18){@color(red){x}}") == ["font", "color"])
+    }
+
+    // MARK: - Markers
+
+    @Test("an alternate marker can be registered")
+    func alternateMarker() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(
+            directives: [BackslashDirective()]
+        ))
+        #expect(ids("\\bigger{x}", registry) == ["bigger"])
+        // The default marker is inert for a directive that overrode it.
+        #expect(ids("@bigger{x}", registry).isEmpty)
+    }
+
+    @Test("a multi-scalar marker is rejected at registration, not half-matched")
+    func rejectsMultiScalarMarker() {
+        // Marker dispatch is one dictionary probe per character on the parse
+        // hot path, which requires a single UTF-16 code unit. An emoji marker
+        // must drop out at registration rather than matching a lone surrogate.
+        struct EmojiMarkerDirective: MarkdownDirective {
+            var syntax: DirectiveSyntax {
+                DirectiveSyntax(name: "rocket", form: .selfContained, marker: "🚀")
+            }
+        }
+        let registry = DirectiveRegistry(directives: [EmojiMarkerDirective()])
+        #expect(registry.isEmpty)
+        #expect(ids("🚀rocket", ExtensionRegistry(extensions: [], directives: registry)).isEmpty)
+    }
+
+    @Test("markers coexist")
+    func markersCoexist() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(
+            directives: [SizedDirective(), BackslashDirective()]
+        ))
+        #expect(ids("@font(size: 18){a} and \\bigger{b}", registry) == ["font", "bigger"])
+    }
+
+    // MARK: - Token projection
+
+    @Test("a directive projects a token, so caret reveal and copy see it")
+    func projectsToken() {
+        let text = "@font(size: 18){hello}"
+        let tokens = MarkdownTokenizer.parseTokensViaAST(in: text, registry: registry)
+        let match = tokens.contains { $0.kind == .extensionSpan("directive.font") }
+        #expect(match)
+    }
+
+    // MARK: - Grammar fingerprint
+
+    @Test("registering a directive changes the grammar fingerprint")
+    func fingerprintTracksDirectives() {
+        let without = ExtensionRegistry(extensions: [HighlightExtension()])
+        let with = ExtensionRegistry(extensions: [HighlightExtension()],
+                                     directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(without.fingerprint != with.fingerprint)
+    }
+
+    @Test("an equal directive set produces an equal fingerprint")
+    func fingerprintIsStable() {
+        let a = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        let b = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(a.fingerprint == b.fingerprint)
+    }
+
+    @Test("changing the marker changes the fingerprint")
+    func fingerprintTracksMarker() {
+        let atSign = DirectiveRegistry(directives: [SizedDirective()],
+                                       settings: DirectiveRegistrySettings(defaultMarker: "@"))
+        let slash = DirectiveRegistry(directives: [SizedDirective()],
+                                      settings: DirectiveRegistrySettings(defaultMarker: "/"))
+        #expect(atSign.fingerprint != slash.fingerprint)
+    }
+
+    @Test("a directive-free registry keeps the fingerprint it had before directives existed")
+    func fingerprintUnchangedWithoutDirectives() {
+        let registry = ExtensionRegistry(extensions: [HighlightExtension()])
+        #expect(!registry.fingerprint.contains("~"))
+    }
+
+    @Test("a directive-only registry is not empty")
+    func directiveOnlyRegistryIsNotEmpty() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(!registry.isEmpty)
+        #expect(!registry.fingerprint.isEmpty)
+    }
+
+    // MARK: - Known limitation: pre-claimed spans in a body
+
+    /// A body holding a span claimed by an EARLIER pass rejects the whole
+    /// directive. Pinned deliberately: this is the documented limitation, and
+    /// the follow-up that lifts it should flip these, not delete them.
+    @Test("a code span in the body keeps the whole directive literal")
+    func codeSpanInBodyRejects() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        let nodes = InlineParser.parse("@font(size: 18){a `b` c}", registry: registry)
+        #expect(!nodes.contains { if case .ext = $0 { return true }; return false })
+    }
+
+    @Test("a backslash escape in the body keeps the whole directive literal")
+    func escapeInBodyRejects() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        let nodes = InlineParser.parse(#"@font(size: 18){a \* c}"#, registry: registry)
+        #expect(!nodes.contains { if case .ext = $0 { return true }; return false })
+    }
+
+    /// The limitation is specific to spans claimed BEFORE this pass. Anything
+    /// claimed in the same pass or later composes normally, so the rejection
+    /// rule is narrower than "no other construct in a body".
+    @Test("inline math, links and emphasis all compose inside a body")
+    func samePassConstructsInBodyCompose() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        for source in ["@font(size: 18){a $x^2$ c}",
+                       "@font(size: 18){a [l](u) c}",
+                       "@font(size: 18){a *b* c}"] {
+            let nodes = InlineParser.parse(source, registry: registry)
+            #expect(nodes.contains { if case .ext = $0 { return true }; return false },
+                    "expected a directive for \(source)")
+        }
+    }
+
+}

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -153,6 +153,24 @@ struct DirectiveParserTests {
         #expect(ids("v2@marker").isEmpty)
     }
 
+    @Test("markup delimiters are boundaries — a directive can abut emphasis")
+    func acceptsMarkupBoundaries() {
+        // Regression: an allow-list of "opening punctuation" silently dropped
+        // every one of these, because the preceding character is a markup
+        // delimiter. Only word characters may reject.
+        #expect(ids("*@font(size: 18){x}*") == ["font"])
+        #expect(ids("**@font(size: 18){x}**") == ["font"])
+        #expect(ids("_@font(size: 18){x}_") == ["font"])
+        #expect(ids("- @pagebreak") == ["pagebreak"])
+        #expect(ids("1. @pagebreak") == ["pagebreak"])
+        #expect(ids("#@pagebreak") == ["pagebreak"])
+    }
+
+    @Test("a digit is a word character, so it rejects")
+    func rejectsAfterDigit() {
+        #expect(ids("v2@pagebreak").isEmpty)
+    }
+
     @Test("an escaped marker stays literal")
     func rejectsEscapedMarker() {
         #expect(ids("\\@marker").isEmpty)

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -345,4 +345,39 @@ struct DirectiveParserTests {
         #expect(!registry.isEmpty)
         #expect(!registry.fingerprint.isEmpty)
     }
+
+    // MARK: - Known limitation: pre-claimed spans in a body
+
+    /// A body holding a span claimed by an EARLIER pass rejects the whole
+    /// directive. Pinned deliberately: this is the documented limitation, and
+    /// the follow-up that lifts it should flip these, not delete them.
+    @Test("a code span in the body keeps the whole directive literal")
+    func codeSpanInBodyRejects() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        let nodes = InlineParser.parse("@font(size: 18){a `b` c}", registry: registry)
+        #expect(!nodes.contains { if case .ext = $0 { return true }; return false })
+    }
+
+    @Test("a backslash escape in the body keeps the whole directive literal")
+    func escapeInBodyRejects() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        let nodes = InlineParser.parse(#"@font(size: 18){a \* c}"#, registry: registry)
+        #expect(!nodes.contains { if case .ext = $0 { return true }; return false })
+    }
+
+    /// The limitation is specific to spans claimed BEFORE this pass. Anything
+    /// claimed in the same pass or later composes normally, so the rejection
+    /// rule is narrower than "no other construct in a body".
+    @Test("inline math, links and emphasis all compose inside a body")
+    func samePassConstructsInBodyCompose() {
+        let registry = MarkdownEditorConfiguration(directives: [SizedDirective()]).extensionRegistry
+        for source in ["@font(size: 18){a $x^2$ c}",
+                       "@font(size: 18){a [l](u) c}",
+                       "@font(size: 18){a *b* c}"] {
+            let nodes = InlineParser.parse(source, registry: registry)
+            #expect(nodes.contains { if case .ext = $0 { return true }; return false },
+                    "expected a directive for \(source)")
+        }
+    }
+
 }

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -153,24 +153,6 @@ struct DirectiveParserTests {
         #expect(ids("v2@marker").isEmpty)
     }
 
-    @Test("markup delimiters are boundaries — a directive can abut emphasis")
-    func acceptsMarkupBoundaries() {
-        // Regression: an allow-list of "opening punctuation" silently dropped
-        // every one of these, because the preceding character is a markup
-        // delimiter. Only word characters may reject.
-        #expect(ids("*@font(size: 18){x}*") == ["font"])
-        #expect(ids("**@font(size: 18){x}**") == ["font"])
-        #expect(ids("_@font(size: 18){x}_") == ["font"])
-        #expect(ids("- @pagebreak") == ["pagebreak"])
-        #expect(ids("1. @pagebreak") == ["pagebreak"])
-        #expect(ids("#@pagebreak") == ["pagebreak"])
-    }
-
-    @Test("a digit is a word character, so it rejects")
-    func rejectsAfterDigit() {
-        #expect(ids("v2@pagebreak").isEmpty)
-    }
-
     @Test("an escaped marker stays literal")
     func rejectsEscapedMarker() {
         #expect(ids("\\@marker").isEmpty)

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -1,0 +1,348 @@
+//
+//  DirectiveParserTests.swift
+//  MarkdownEngineTests
+//
+//  The directive seam's parser half: `@name(args){body}` matches only for
+//  registered names at a valid boundary, rejections stay literal text, and the
+//  resulting node carries the geometry the styler needs.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — parsing")
+struct DirectiveParserTests {
+
+    // A directive named after a domain label, so the email-boundary test is
+    // exercised against a name that WOULD otherwise match.
+    private struct WildthinkDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "wildthink", form: .selfContained) }
+    }
+
+    private struct OpaqueDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax {
+            DirectiveSyntax(name: "raw", form: .container, parsesBody: false)
+        }
+    }
+
+    private struct EitherDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax { DirectiveSyntax(name: "note", form: .either) }
+    }
+
+    private struct BackslashDirective: MarkdownDirective {
+        var syntax: DirectiveSyntax {
+            DirectiveSyntax(name: "bigger", form: .container, marker: "\\")
+        }
+    }
+
+    private var registry: ExtensionRegistry {
+        ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [
+            SizedDirective(), TintDirective(), MarkerDirective(),
+            WildthinkDirective(), OpaqueDirective(), EitherDirective(),
+        ]))
+    }
+
+    // MARK: - Helpers
+
+    /// Every directive node in the parse, flattened (directives project as
+    /// extension-shaped nodes under the reserved id namespace).
+    private func directives(_ text: String, _ registry: ExtensionRegistry? = nil) -> [ExtensionInlineNode] {
+        var found: [ExtensionInlineNode] = []
+        func walk(_ nodes: [InlineNode]) {
+            for node in nodes {
+                switch node {
+                case .ext(let ext):
+                    if DirectiveRegistry.directiveID(forNodeID: ext.extensionID) != nil { found.append(ext) }
+                    walk(ext.children)
+                case .emphasis(_, _, _, let children), .link(_, _, _, _, let children):
+                    walk(children)
+                default:
+                    break
+                }
+            }
+        }
+        walk(InlineParser.parse(text, registry: registry ?? self.registry))
+        return found
+    }
+
+    private func ids(_ text: String, _ registry: ExtensionRegistry? = nil) -> [String] {
+        directives(text, registry).compactMap { DirectiveRegistry.directiveID(forNodeID: $0.extensionID) }
+    }
+
+    private func body(_ text: String) -> String? {
+        guard let node = directives(text).first else { return nil }
+        return (text as NSString).substring(with: node.contentRange)
+    }
+
+    // MARK: - Recognition
+
+    @Test("a registered container directive parses")
+    func containerParses() {
+        #expect(ids("@font(size: 18){hello}") == ["font"])
+        #expect(body("@font(size: 18){hello}") == "hello")
+    }
+
+    @Test("a registered self-contained directive parses")
+    func selfContainedParses() {
+        #expect(ids("text @marker more") == ["marker"])
+    }
+
+    @Test("without a registered directive, @name stays literal")
+    func unregisteredStaysLiteral() {
+        #expect(ids("@unknown(size: 18){hello}").isEmpty)
+        #expect(ids("@font(size: 18){hello}", .empty).isEmpty)
+    }
+
+    @Test("the whole call is claimed, markers plus body")
+    func claimsWholeCall() {
+        let text = "@font(size: 18){hello}"
+        let node = directives(text)[0]
+        #expect(node.range == NSRange(location: 0, length: (text as NSString).length))
+        #expect((text as NSString).substring(with: node.markers[0]) == "@font(size: 18){")
+        #expect((text as NSString).substring(with: node.markers[1]) == "}")
+    }
+
+    @Test("a self-contained call carries no markers in Phase 1 — it renders literally")
+    func selfContainedHasNoMarkers() {
+        #expect(directives("@marker")[0].markers.isEmpty)
+    }
+
+    // MARK: - Boundary rule
+
+    @Test("a directive must open at a boundary, not mid-word")
+    func rejectsMidWord() {
+        #expect(ids("a@marker").isEmpty)
+        #expect(ids("word@font(size: 18){x}").isEmpty)
+    }
+
+    @Test("an email address never opens a directive")
+    func rejectsEmail() {
+        // `wildthink` IS registered — only the boundary rule saves this.
+        #expect(ids("mail jason@example.com now").isEmpty)
+    }
+
+    @Test("a marker run stays literal")
+    func rejectsMarkerRun() {
+        #expect(ids("@@marker").isEmpty)
+    }
+
+    @Test("punctuation and line starts are valid boundaries")
+    func acceptsBoundaries() {
+        #expect(ids("(@marker)") == ["marker"])
+        #expect(ids("line one\n@marker") == ["marker"])
+        #expect(ids("> @marker") == ["marker"])
+    }
+
+    @Test("markup delimiters are boundaries — a directive can abut emphasis")
+    func acceptsMarkupBoundaries() {
+        // Regression: an allow-list of "opening punctuation" silently dropped
+        // every one of these, because the preceding character is a markup
+        // delimiter. Only word characters may reject.
+        #expect(ids("*@font(size: 18){x}*") == ["font"])
+        #expect(ids("**@font(size: 18){x}**") == ["font"])
+        #expect(ids("_@font(size: 18){x}_") == ["font"])
+        #expect(ids("- @marker") == ["marker"])
+        #expect(ids("1. @marker") == ["marker"])
+        #expect(ids("#@marker") == ["marker"])
+    }
+
+    @Test("a digit is a word character, so it rejects")
+    func rejectsAfterDigit() {
+        #expect(ids("v2@marker").isEmpty)
+    }
+
+    @Test("an escaped marker stays literal")
+    func rejectsEscapedMarker() {
+        #expect(ids("\\@marker").isEmpty)
+    }
+
+    // MARK: - Form enforcement
+
+    @Test("a container call without a body stays literal")
+    func containerNeedsBody() {
+        #expect(ids("@font(size: 18)").isEmpty)
+    }
+
+    @Test("a self-contained call with a body stays literal")
+    func selfContainedRejectsBody() {
+        #expect(ids("@marker{x}").isEmpty)
+    }
+
+    @Test("an either-form directive accepts both shapes")
+    func eitherAcceptsBoth() {
+        #expect(ids("@note") == ["note"])
+        #expect(ids("@note{body}") == ["note"])
+    }
+
+    // MARK: - Delimiter scanning
+
+    @Test("braces nest inside a body")
+    func nestedBraces() {
+        #expect(body("@font(size: 18){a {b} c}") == "a {b} c")
+    }
+
+    @Test("parens nest inside an argument list")
+    func nestedParens() {
+        #expect(body("@font(size: max(18, 20)){x}") == "x")
+    }
+
+    @Test("the scanner treats an escaped brace as body text, not a closer")
+    func scannerHonoursEscapedBrace() {
+        let text = "@font(size: 18){a \\} b}" as NSString
+        let match = DirectiveScanner.match(text, len: text.length, at: 0,
+                                           registry: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(match?.bodyRange.map { text.substring(with: $0) } == "a \\} b")
+    }
+
+    @Test("in the full parse an interior escape keeps the call literal — as it does for every construct")
+    func interiorEscapeStaysLiteral() {
+        // The escape pass claims `\}` before the link-family pass runs, and a
+        // candidate overlapping a claimed span is rejected. Directives inherit
+        // that rule verbatim: `[a \* b](url)` and `==a \* b==` are rejected the
+        // same way. The scanner still measures the body correctly (above), so
+        // the day escapes stop pre-claiming, directives need no change.
+        #expect(ids("@font(size: 18){a \\} b}").isEmpty)
+    }
+
+    @Test("a brace inside a quoted argument does not open a body")
+    func quotedBraceInArguments() {
+        #expect(body("@font(family: \"a{b\"){x}") == "x")
+    }
+
+    @Test("an unbalanced call stays literal")
+    func unbalancedStaysLiteral() {
+        #expect(ids("@font(size: 18{hello}").isEmpty)
+        #expect(ids("@font(size: 18){hello").isEmpty)
+    }
+
+    @Test("a directive never spans a line break")
+    func singleLineOnly() {
+        #expect(ids("@font(size: 18){a\nb}").isEmpty)
+        #expect(ids("@font(size:\n18){a}").isEmpty)
+    }
+
+    // MARK: - Precedence
+
+    @Test("a directive inside a code span never fires — built-ins claim first")
+    func codeSpanWins() {
+        #expect(ids("`@font(size: 18){x}`").isEmpty)
+    }
+
+    @Test("a directive inside inline LaTeX never fires")
+    func latexWins() {
+        #expect(ids("$@font(size: 18){x}$").isEmpty)
+    }
+
+    @Test("a directive inside a link's text still parses")
+    func nestsInsideLink() {
+        #expect(ids("[see @font(size: 18){this}](url)") == ["font"])
+    }
+
+    // MARK: - Body parsing
+
+    @Test("a container body is re-parsed as markdown")
+    func bodyIsReparsed() {
+        let node = directives("@font(size: 18){**bold**}")[0]
+        let hasEmphasis = node.children.contains {
+            if case .emphasis = $0 { return true }
+            return false
+        }
+        #expect(hasEmphasis)
+    }
+
+    @Test("an opaque directive keeps its body unparsed")
+    func opaqueBodyStaysFlat() {
+        #expect(directives("@raw{**bold**}")[0].children.isEmpty)
+    }
+
+    @Test("directives nest")
+    func directivesNest() {
+        #expect(ids("@font(size: 18){@color(red){x}}") == ["font", "color"])
+    }
+
+    // MARK: - Markers
+
+    @Test("an alternate marker can be registered")
+    func alternateMarker() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(
+            directives: [BackslashDirective()]
+        ))
+        #expect(ids("\\bigger{x}", registry) == ["bigger"])
+        // The default marker is inert for a directive that overrode it.
+        #expect(ids("@bigger{x}", registry).isEmpty)
+    }
+
+    @Test("a multi-scalar marker is rejected at registration, not half-matched")
+    func rejectsMultiScalarMarker() {
+        // Marker dispatch is one dictionary probe per character on the parse
+        // hot path, which requires a single UTF-16 code unit. An emoji marker
+        // must drop out at registration rather than matching a lone surrogate.
+        struct EmojiMarkerDirective: MarkdownDirective {
+            var syntax: DirectiveSyntax {
+                DirectiveSyntax(name: "rocket", form: .selfContained, marker: "🚀")
+            }
+        }
+        let registry = DirectiveRegistry(directives: [EmojiMarkerDirective()])
+        #expect(registry.isEmpty)
+        #expect(ids("🚀rocket", ExtensionRegistry(extensions: [], directives: registry)).isEmpty)
+    }
+
+    @Test("markers coexist")
+    func markersCoexist() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(
+            directives: [SizedDirective(), BackslashDirective()]
+        ))
+        #expect(ids("@font(size: 18){a} and \\bigger{b}", registry) == ["font", "bigger"])
+    }
+
+    // MARK: - Token projection
+
+    @Test("a directive projects a token, so caret reveal and copy see it")
+    func projectsToken() {
+        let text = "@font(size: 18){hello}"
+        let tokens = MarkdownTokenizer.parseTokensViaAST(in: text, registry: registry)
+        let match = tokens.contains { $0.kind == .extensionSpan("directive.font") }
+        #expect(match)
+    }
+
+    // MARK: - Grammar fingerprint
+
+    @Test("registering a directive changes the grammar fingerprint")
+    func fingerprintTracksDirectives() {
+        let without = ExtensionRegistry(extensions: [HighlightExtension()])
+        let with = ExtensionRegistry(extensions: [HighlightExtension()],
+                                     directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(without.fingerprint != with.fingerprint)
+    }
+
+    @Test("an equal directive set produces an equal fingerprint")
+    func fingerprintIsStable() {
+        let a = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        let b = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(a.fingerprint == b.fingerprint)
+    }
+
+    @Test("changing the marker changes the fingerprint")
+    func fingerprintTracksMarker() {
+        let atSign = DirectiveRegistry(directives: [SizedDirective()],
+                                       settings: DirectiveRegistrySettings(defaultMarker: "@"))
+        let slash = DirectiveRegistry(directives: [SizedDirective()],
+                                      settings: DirectiveRegistrySettings(defaultMarker: "/"))
+        #expect(atSign.fingerprint != slash.fingerprint)
+    }
+
+    @Test("a directive-free registry keeps the fingerprint it had before directives existed")
+    func fingerprintUnchangedWithoutDirectives() {
+        let registry = ExtensionRegistry(extensions: [HighlightExtension()])
+        #expect(!registry.fingerprint.contains("~"))
+    }
+
+    @Test("a directive-only registry is not empty")
+    func directiveOnlyRegistryIsNotEmpty() {
+        let registry = ExtensionRegistry(extensions: [], directives: DirectiveRegistry(directives: [SizedDirective()]))
+        #expect(!registry.isEmpty)
+        #expect(!registry.fingerprint.isEmpty)
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectivePerformanceTests.swift
+++ b/Tests/MarkdownEngineTests/DirectivePerformanceTests.swift
@@ -1,0 +1,158 @@
+//
+//  DirectivePerformanceTests.swift
+//  MarkdownEngineTests
+//
+//  The invariant this guards: per-keystroke restyle cost stays O(edit) —
+//  independent of DOCUMENT SIZE — for a directive-heavy paragraph.
+//
+//  The load-bearing test here is STRUCTURAL, not timed:
+//  `scopedWorkIsIdenticalRegardlessOfDocumentSize` digests the styled output
+//  of the edited paragraph and requires it to be byte-identical in a
+//  40-paragraph and a 400-paragraph document. If any pass were walking the
+//  whole document, the in-scope output would differ. That holds on every
+//  machine, so it runs on CI.
+//
+//  The timed assertions next to it are OPT-IN via `MDE_PERF=1 swift test`.
+//  A wall-clock RATIO is not portable: the same code reads one number on an
+//  idle laptop and a much worse one on a contended runner, where `swift test`
+//  has every other suite competing for cores throughout the measurement
+//  window. A directive bound that looked comfortable locally turned `main`
+//  red once already (see 350b2d3), and no threshold fixes that — so these
+//  keep their numbers for local investigation and stay off CI.
+//
+//  On density: cost per span within the edited paragraph is a parser
+//  property, not a directive one, and #140 made it linear. What these tests
+//  still assert is the comparative claim — directives are not more expensive
+//  than equivalent built-in spans — which is the regression actually worth
+//  knowing about.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+/// Timed assertions are opt-in; the structural one always runs.
+private let directivePerfEnabled = ProcessInfo.processInfo.environment["MDE_PERF"] != nil
+
+@Suite("Directives — performance")
+struct DirectivePerformanceTests {
+
+    private var fontName: String { NSFont.systemFont(ofSize: 16).fontName }
+
+    private var configuration: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(directives: [FontDirective(), ColorDirective()])
+    }
+
+    /// A document of `paragraphs` paragraphs, one of which carries
+    /// `directives` directive calls.
+    private func document(paragraphs: Int, directives: Int) -> String {
+        (0..<paragraphs).map { index in
+            index == paragraphs / 2
+                ? "Heavy: " + (0..<directives).map {
+                    "@font(size: \(12 + $0 % 8)){word\($0)} @color(red){c\($0)}"
+                  }.joined(separator: " ")
+                : "Ordinary paragraph \(index) with **bold**, `code`, and a [link](https://example.com)."
+        }
+        .joined(separator: "\n\n")
+    }
+
+    private func heavyParagraph(in text: String) -> NSRange {
+        let ns = text as NSString
+        return ns.paragraphRange(for: ns.range(of: "Heavy:"))
+    }
+
+    private func styleScoped(_ text: String) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: 16,
+            scopedRanges: [heavyParagraph(in: text)], configuration: configuration
+        )
+    }
+
+    /// Mean milliseconds per iteration.
+    private func milliseconds(iterations: Int = 15, _ body: () -> Void) -> Double {
+        body()   // warm caches so the first run's lazies aren't in the sample
+        let start = DispatchTime.now().uptimeNanoseconds
+        for _ in 0..<iterations { body() }
+        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+        return Double(elapsed) / 1_000_000 / Double(iterations)
+    }
+
+    // MARK: - The invariant
+
+    @Test("scoped restyle cost does not grow with document size", .enabled(if: directivePerfEnabled))
+    func costIsIndependentOfDocumentSize() {
+        let small = document(paragraphs: 40, directives: 40)
+        let large = document(paragraphs: 400, directives: 40)
+        // Same edited paragraph, 10x the surrounding document.
+        let smallCost = milliseconds { _ = styleScoped(small) }
+        let largeCost = milliseconds { _ = styleScoped(large) }
+        // Measures ~1.0x; 3x is loose enough for a loaded CI machine while
+        // still catching a genuine O(document) regression, which would show
+        // up here as 10x.
+        #expect(largeCost < smallCost * 3,
+                "scoped restyle grew with document size: \(smallCost)ms → \(largeCost)ms")
+    }
+
+    @Test("scoped restyle produces identical attributes regardless of document size")
+    func scopedWorkIsIdenticalRegardlessOfDocumentSize() {
+        // The structural counterpart of the timing test: if any pass were
+        // walking the whole document, the in-scope output would differ.
+        func digest(_ text: String) -> String {
+            let paragraph = heavyParagraph(in: text)
+            return styleScoped(text)
+                .filter { NSIntersectionRange($0.range, paragraph).length > 0 }
+                .map { entry in
+                    let offset = entry.range.location - paragraph.location
+                    let keys = entry.attributes.keys.map(\.rawValue).sorted().joined(separator: ",")
+                    let size = (entry.attributes[.font] as? NSFont).map { "\($0.pointSize)" } ?? "-"
+                    return "\(offset):\(entry.range.length)[\(keys)]\(size)"
+                }
+                .sorted()
+                .joined(separator: "\n")
+        }
+        #expect(digest(document(paragraphs: 40, directives: 30))
+             == digest(document(paragraphs: 400, directives: 30)))
+    }
+
+    @Test("a directive-free document is unaffected by a registered directive set", .enabled(if: directivePerfEnabled))
+    func registrationDoesNotTaxOrdinaryDocuments() {
+        let text = (0..<300)
+            .map { "Ordinary paragraph \($0) with **bold**, `code`, and a [link](https://example.com)." }
+            .joined(separator: "\n\n")
+        // Deliberately a FULL restyle, not a scoped one: a scoped restyle of a
+        // single paragraph costs ~0.25ms, where run-to-run variance swamps any
+        // real difference and a ratio assertion just measures noise.
+        func cost(_ configuration: MarkdownEditorConfiguration) -> Double {
+            milliseconds {
+                _ = MarkdownASTStyler.styleAttributes(
+                    text: text, fontName: fontName, fontSize: 16, configuration: configuration
+                )
+            }
+        }
+        // Registering directives must not tax documents that use none: the
+        // scanner rejects on one dictionary probe per candidate character, and
+        // building the registry costs ~5µs.
+        #expect(cost(configuration) < cost(.default) * 1.5)
+    }
+
+    // MARK: - Density, for the record
+
+    @Test("directives are not more expensive than equivalent built-in spans", .enabled(if: directivePerfEnabled))
+    func directivesAreNotWorseThanOtherSpans() {
+        // Density cost belongs to the parser's span handling, not to
+        // directives. If this ever fails, directives have acquired a cost the
+        // other constructs don't have — which is the regression worth knowing.
+        let count = 120
+        let directiveText = (0..<count).map { "@font(size: 14){word\($0)}" }.joined(separator: " ")
+        let highlightText = (0..<count).map { "==word\($0)==" }.joined(separator: " ")
+
+        let directiveRegistry = configuration.extensionRegistry
+        let highlightRegistry = MarkdownEditorConfiguration(extensions: [HighlightExtension()]).extensionRegistry
+
+        let directiveCost = milliseconds { _ = DocumentAST.parse(directiveText, registry: directiveRegistry) }
+        let highlightCost = milliseconds { _ = DocumentAST.parse(highlightText, registry: highlightRegistry) }
+        #expect(directiveCost < highlightCost * 2,
+                "directives cost \(directiveCost)ms vs \(highlightCost)ms for \(count) spans")
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
@@ -29,7 +29,7 @@ struct DirectiveStylingTests {
     private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
 
     private var configuration: MarkdownEditorConfiguration {
-        MarkdownEditorConfiguration(directives: [FontDirective(), PageBreakDirective()])
+        MarkdownEditorConfiguration(directives: [FontDirective(), MarkerDirective()])
     }
 
     private func style(_ text: String, caret: Int = -1) -> [StyledRange] {
@@ -102,11 +102,11 @@ struct DirectiveStylingTests {
 
     @Test("a self-contained call renders as literal text — nothing collapses it")
     func selfContainedStaysVisible() {
-        let text = "before @pagebreak after"
+        let text = "before @marker after"
         let attrs = style(text)
-        let location = (text as NSString).range(of: "@pagebreak").location
+        let location = (text as NSString).range(of: "@marker").location
         // No shrink font and no negative kern anywhere in the call.
-        for (range, a) in attrs where NSIntersectionRange(range, NSRange(location: location, length: 10)).length > 0 {
+        for (range, a) in attrs where NSIntersectionRange(range, NSRange(location: location, length: 7)).length > 0 {
             #expect((a[.font] as? NSFont)?.pointSize != hiddenSize)
             #expect((a[.kern] as? CGFloat ?? 0) >= 0)
         }

--- a/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
@@ -1,0 +1,149 @@
+//
+//  DirectiveStylingTests.swift
+//  MarkdownEngineTests
+//
+//  STRUCTURAL styling behaviour for directives — what must hold regardless of
+//  what any given directive does with its body:
+//
+//    * a container's syntax shrinks when the caret leaves and reveals when it
+//      enters, and the shrink never bleeds into the body;
+//    * a self-contained call renders as plain literal text (no glyph until
+//      Phase 3, and crucially nothing that collapses it to nothing);
+//    * an unknown or unregistered directive id can't crash or restyle a
+//      neighbour;
+//    * a scoped restyle matches the full pass.
+//
+//  Font semantics — sizes, traits, composition — belong to
+//  `DirectiveCompositionTests`.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Directives — Phase 1 styling")
+struct DirectiveStylingTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    private var configuration: MarkdownEditorConfiguration {
+        MarkdownEditorConfiguration(directives: [FontDirective(), PageBreakDirective()])
+    }
+
+    private func style(_ text: String, caret: Int = -1) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            caretLocation: caret, configuration: configuration
+        )
+    }
+
+    /// Effective font at `pos`: the last styled range covering it that sets `.font`.
+    private func font(in attrs: [StyledRange], at pos: Int) -> NSFont? {
+        var result: NSFont?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let f = a[.font] as? NSFont { result = f }
+        }
+        return result
+    }
+
+    private var hiddenSize: CGFloat { MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize }
+
+    /// Canonical, order-independent digest of styled ranges, so two style runs
+    /// can be compared. Local twin of the one in `MarkdownASTStylerTests`
+    /// (that one is file-private).
+    private func digest(_ ranges: [StyledRange]) -> String {
+        ranges
+            .map { entry in
+                let keys = entry.attributes.keys.map(\.rawValue).sorted().joined(separator: ",")
+                return "\(entry.range.location):\(entry.range.length)[\(keys)]"
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
+    // MARK: - Container
+
+    @Test("a container's syntax shrinks when the caret is elsewhere")
+    func syntaxShrinksWhenInactive() {
+        let attrs = style("@font(size: 18){hello} tail")
+        // Inside the `@font(size: 18){` prefix.
+        #expect(font(in: attrs, at: 2)?.pointSize == hiddenSize)
+    }
+
+    @Test("the body never picks up the shrunk marker font")
+    func bodyIsNotShrunk() {
+        // The body's SIZE is the directive's business (see
+        // `DirectiveCompositionTests`); what must hold structurally is that the
+        // shrink applied to the syntax never bleeds into the body.
+        let text = "@font(size: 18){hello} tail"
+        let attrs = style(text)
+        let bodyStart = (text as NSString).range(of: "hello").location
+        #expect(font(in: attrs, at: bodyStart)?.pointSize != hiddenSize)
+    }
+
+    @Test("the caret inside the call reveals its syntax")
+    func syntaxRevealsWhenActive() {
+        let attrs = style("@font(size: 18){hello}", caret: 3)
+        #expect(font(in: attrs, at: 2)?.pointSize != hiddenSize)
+    }
+
+    @Test("markup inside the body still styles")
+    func bodyMarkupStillStyles() {
+        let text = "@font(size: 18){**bold**}"
+        let attrs = style(text)
+        let boldStart = (text as NSString).range(of: "bold").location
+        let traits = font(in: attrs, at: boldStart)?.fontDescriptor.symbolicTraits
+        #expect(traits?.contains(.bold) == true)
+    }
+
+    // MARK: - Self-contained
+
+    @Test("a self-contained call renders as literal text — nothing collapses it")
+    func selfContainedStaysVisible() {
+        let text = "before @pagebreak after"
+        let attrs = style(text)
+        let location = (text as NSString).range(of: "@pagebreak").location
+        // No shrink font and no negative kern anywhere in the call.
+        for (range, a) in attrs where NSIntersectionRange(range, NSRange(location: location, length: 10)).length > 0 {
+            #expect((a[.font] as? NSFont)?.pointSize != hiddenSize)
+            #expect((a[.kern] as? CGFloat ?? 0) >= 0)
+        }
+    }
+
+    // MARK: - Isolation
+
+    @Test("text after a directive is unaffected")
+    func neighbourUnaffected() {
+        let text = "@font(size: 18){hello} plain tail"
+        let attrs = style(text)
+        let tail = (text as NSString).range(of: "plain tail").location
+        let tailFont = font(in: attrs, at: tail)
+        #expect(tailFont == nil || tailFont?.pointSize == base)
+    }
+
+    @Test("an unregistered directive styles as ordinary text")
+    func unregisteredIsPlain() {
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "@font(size: 18){hello}", fontName: fontName, fontSize: base,
+            caretLocation: -1, configuration: .default
+        )
+        #expect(font(in: attrs, at: 2)?.pointSize != hiddenSize)
+    }
+
+    @Test("styling a directive-bearing document scoped to one paragraph matches the full pass")
+    func scopedMatchesFull() {
+        let text = "intro line\n\n@font(size: 18){hello} tail\n\noutro"
+        let ns = text as NSString
+        let paragraph = ns.paragraphRange(for: ns.range(of: "@font"))
+        func keys(_ scoped: [NSRange]?) -> String {
+            let ranges = MarkdownASTStyler.styleAttributes(
+                text: text, fontName: fontName, fontSize: base,
+                scopedRanges: scoped, configuration: configuration
+            ).filter { NSIntersectionRange($0.range, paragraph).length > 0 }
+            return digest(ranges)
+        }
+        #expect(keys([paragraph]) == keys(nil))
+    }
+}

--- a/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
+++ b/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
@@ -1,0 +1,56 @@
+//
+//  DirectiveTestFixtures.swift
+//  MarkdownEngineTests
+//
+//  Directives used across the directive suites.
+//
+//  Deliberately test-local: this change adds the seam, not any directive, so
+//  the parser tests declare the shapes they need rather than leaning on a
+//  bundled implementation. That keeps them testing the SEAM — a schema is a
+//  schema whether it came from the engine or from an embedder.
+//
+
+import Foundation
+@testable import MarkdownEngine
+
+/// Container form with a mixed labelled schema — the shape the parser has to
+/// carry through argument coercion.
+struct SizedDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: "font",
+            form: .container,
+            parameters: [
+                .init(label: "size", kind: .length,
+                      documentation: "Point size, or 1.5em / 120% relative to the surrounding text."),
+                .init(label: "family", kind: .string, documentation: "Font family name."),
+                .init(label: "weight", kind: .keyword(["regular", "bold"]),
+                      defaultValue: .keyword("regular"), documentation: "Font weight."),
+            ]
+        )
+    }
+}
+
+/// Container form with a required POSITIONAL argument.
+struct TintDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: "color",
+            form: .container,
+            parameters: [.init(label: nil, kind: .keyword([]), isRequired: true,
+                               documentation: "Colour name.")]
+        )
+    }
+}
+
+/// Self-contained form, no arguments.
+struct MarkerDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax { DirectiveSyntax(name: "marker", form: .selfContained) }
+    func html(arguments: DirectiveArguments, bodyHTML: String) -> String { "<hr class=\"marker\" />" }
+}
+
+/// Self-contained with two POSITIONAL parameters — the shape that exercises
+/// defaults on positionals, which labelled-only filling used to skip.
+struct SelfContainedPair: MarkdownDirective {
+    var syntax: DirectiveSyntax { DirectiveSyntax(name: "pair", form: .selfContained) }
+}

--- a/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
+++ b/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
@@ -48,3 +48,9 @@ struct MarkerDirective: MarkdownDirective {
     var syntax: DirectiveSyntax { DirectiveSyntax(name: "marker", form: .selfContained) }
     func html(arguments: DirectiveArguments, bodyHTML: String) -> String { "<hr class=\"marker\" />" }
 }
+
+/// Self-contained with two POSITIONAL parameters — the shape that exercises
+/// defaults on positionals, which labelled-only filling used to skip.
+struct SelfContainedPair: MarkdownDirective {
+    var syntax: DirectiveSyntax { DirectiveSyntax(name: "pair", form: .selfContained) }
+}

--- a/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
+++ b/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
@@ -1,0 +1,50 @@
+//
+//  DirectiveTestFixtures.swift
+//  MarkdownEngineTests
+//
+//  Directives used across the directive suites.
+//
+//  Deliberately test-local: this change adds the seam, not any directive, so
+//  the parser tests declare the shapes they need rather than leaning on a
+//  bundled implementation. That keeps them testing the SEAM — a schema is a
+//  schema whether it came from the engine or from an embedder.
+//
+
+import Foundation
+@testable import MarkdownEngine
+
+/// Container form with a mixed labelled schema — the shape the parser has to
+/// carry through argument coercion.
+struct SizedDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: "font",
+            form: .container,
+            parameters: [
+                .init(label: "size", kind: .length,
+                      documentation: "Point size, or 1.5em / 120% relative to the surrounding text."),
+                .init(label: "family", kind: .string, documentation: "Font family name."),
+                .init(label: "weight", kind: .keyword(["regular", "bold"]),
+                      defaultValue: .keyword("regular"), documentation: "Font weight."),
+            ]
+        )
+    }
+}
+
+/// Container form with a required POSITIONAL argument.
+struct TintDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax {
+        DirectiveSyntax(
+            name: "color",
+            form: .container,
+            parameters: [.init(label: nil, kind: .keyword([]), isRequired: true,
+                               documentation: "Colour name.")]
+        )
+    }
+}
+
+/// Self-contained form, no arguments.
+struct MarkerDirective: MarkdownDirective {
+    var syntax: DirectiveSyntax { DirectiveSyntax(name: "marker", form: .selfContained) }
+    func html(arguments: DirectiveArguments, bodyHTML: String) -> String { "<hr class=\"marker\" />" }
+}

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -192,6 +192,22 @@ struct MarkdownASTStylerTests {
         })
     }
 
+    @Test("a revealed link target is muted like its brackets")
+    func activeLinkTargetIsMuted() {
+        //          0123456789012345678901
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "see [Nodes](nodes.app) now",
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: 6
+        )
+        let muted = MarkdownEditorTheme.default.mutedText
+
+        #expect(color(in: attrs, at: 13) == muted)   // inside `nodes.app`
+        #expect(color(in: attrs, at: 11) == muted)   // the `(` beside it
+        #expect(color(in: attrs, at: 5) != muted)    // the label keeps the link ink
+    }
+
     /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
     private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
         var result: NSColor?


### PR DESCRIPTION
PR 2 of 4, and the other half of the pair you asked for in #120. **Based on `feat/directives-projection`, not on `main`** — review it as the diff on top of PR1, and it's ready to merge with PR1 whenever you are.

This is where the API from PR1 starts doing something: a registered directive now styles its body instead of rendering as plain text.

## Composition, and why `style` returns data

`style` returns a `DirectiveStyle` — a font transform as *data*, not a closure — which the styler composes over whatever font the enclosing tree already established. So `@font(size: 18){**bold**}` is bold *and* 18pt rather than one clobbering the other, and it stays inspectable and cheap on the per-keystroke path. `custom` is the escape hatch for the rare case that isn't expressible.

That composition is the whole reason for the tree-shaped scope decision back in #108: the transform derives from the enclosing node, never from document position, so it survives block-scoped restyle unchanged.

`FontDirective` and `ColorDirective` ship **off by default**, the same posture as `HighlightExtension`.

## What I moved out, deliberately

`DirectivePresentation` and `DirectiveCompletion` are **not** here, even though PR1's original branch defined them. Shipping their public API now would repeat exactly the objection that put PR1 and PR2 together — API arriving before the behaviour it exists for. They land with PR3 and PR4.

`PageBreakDirective` went with them: its only override is `presentation`. The core tests use a self-contained fixture instead, which is better hermetics anyway.

## Your PR2 requirements

- **`MarkdownHTMLRenderer.html(from:extensions:directives:)`** takes the registered set, so `MarkdownDirective.html(arguments:bodyHTML:)` is reachable and rich copy matches the screen. Covered by `DirectiveHTMLTests`.
- **The directive-heavy restyle perf scenario from #108** is here — with one change I want to flag.

## The perf scenario, changed on purpose

The scenario I wrote for #108 asserted wall-clock ratios. After watching a bound of mine turn `main` red in 350b2d3, shipping three more of those would be indefensible, so:

- **The load-bearing test is structural and runs on CI.** `scopedWorkIsIdenticalRegardlessOfDocumentSize` digests the styled output of the edited paragraph and requires it byte-identical in a 40-paragraph and a 400-paragraph document. If any pass walked the whole document the in-scope output would differ. That holds on every machine.
- **The timed assertions are opt-in** behind `MDE_PERF=1`, matching what you did to the span-density ones, and keep their numbers for local investigation.

I also rewrote that file's header, which still described the quadratic density behaviour #140 fixed.

The O(edit) answer itself is unchanged from #108: a directive-dense paragraph costs the same scoped restyle in a 400-paragraph document as in a 50-paragraph one. Nothing directive-related scales with the document.

## Testing

446 tests green, demo builds and runs. New coverage: font composition over inherited traits, colour resolution, nesting and neighbour isolation, the HTML/pasteboard path, and the perf scenario above.

## Still outstanding, not here

#154 — a directive body holding a pre-claimed span (code span or escape) rejects the whole construct. Documented and pinned by tests in PR1, and it belongs with `scanLinkFamily`'s overlap rule rather than with styling. Happy to take it once this pair lands.
