### PR TITLE
Mute a link's revealed target

### DIFF
--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -825,6 +825,9 @@ enum MarkdownASTStyler {
             }
         }
         for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+        // The target is syntax, revealed with its brackets and muted like them —
+        // at body color it is louder than the label it belongs to.
+        if isActive { attrs.append((urlRange, [.foregroundColor: ctx.theme.mutedText])) }
         styleInlines(children, font: font, ctx: ctx, into: &attrs)
     }
 

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -192,6 +192,22 @@ struct MarkdownASTStylerTests {
         })
     }
 
+    @Test("a revealed link target is muted like its brackets")
+    func activeLinkTargetIsMuted() {
+        //          0123456789012345678901
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: "see [Nodes](nodes.app) now",
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: 6
+        )
+        let muted = MarkdownEditorTheme.default.mutedText
+
+        #expect(color(in: attrs, at: 13) == muted)   // inside `nodes.app`
+        #expect(color(in: attrs, at: 11) == muted)   // the `(` beside it
+        #expect(color(in: attrs, at: 5) != muted)    // the label keeps the link ink
+    }
+
     /// Effective color at `pos`: the last styled range covering it that sets `.foregroundColor`.
     private func color(in attrs: [StyledRange], at pos: Int) -> NSColor? {
         var result: NSColor?


### PR DESCRIPTION
With the caret inside `[text](url)`, the four brackets are tinted `mutedText` while the target between two of them keeps body colour. So the loudest ink in the document lands on the one run that is machine-readable rather than prose — and that disappears again the moment the caret leaves.

Every other construct mutes its syntax when it reveals it: the `#` of a heading, the `>` of a quote, the list markers, and — in this very function — the brackets themselves. The target was the exception.

```swift
for marker in markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
+ // The target is syntax, revealed with its brackets and muted like them —
+ // at body color it is louder than the label it belongs to.
+ if isActive { attrs.append((urlRange, [.foregroundColor: ctx.theme.mutedText])) }
```

`mutedText` is `secondaryLabelColor`, so the target stays readable for editing — recessed, not hidden. The label keeps the faded link ink, and as before carries no `.link` attribute while active, so nothing inside an active link is followable.

Inactive links are untouched: the target is still collapsed to the hidden-marker font and cleared.

**Tests** — 345 pass. The new one is mutation-proved: removing the added line makes `activeLinkTargetIsMuted` fail.

This mirrors a change made in the iOS port (`nodes-app/Nodes-Mobile`), so both editors reveal a link the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)