### PR TITLE
Lay an extension span out as a fixed-width control box (InlineSyntax.inlineBoxWidth)

### DIFF
--- a/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
@@ -54,6 +54,22 @@ public struct InlineSyntax: Sendable, Equatable {
     /// Reject when the character after `close` equals `close`'s last character.
     /// `~~` uses this (strict GFM-ish run handling); `==` does not. Default `false`.
     public var rejectsCloserRun: Bool
+    /// Lay the span out as a fixed-width box instead of as text: markers and
+    /// content collapse to nothing and this many points of line space are kept
+    /// in their place, wrapping with the paragraph like any other run.
+    ///
+    /// For a construct that reads as a control rather than as prose — a
+    /// citation playhead, a chip, a token — where the embedder draws the box
+    /// itself and needs the text to make room for it. The reserved space is
+    /// what makes that possible: an embedder cannot reserve it through
+    /// ``MarkdownExtension/contentAttributes(theme:)``, because those
+    /// attributes cover the whole content range uniformly and cannot carry a
+    /// width that is independent of the character count.
+    ///
+    /// A box's markers never reveal at the caret and its inner markup is not
+    /// laid out; the box is the span's entire visual form. `nil` (the default)
+    /// lays the span out as text with the usual marker mute/reveal.
+    public var inlineBoxWidth: CGFloat?
 
     public init(
         open: String,
@@ -61,7 +77,8 @@ public struct InlineSyntax: Sendable, Equatable {
         parsesContent: Bool = true,
         requiresNonEmptyContent: Bool = true,
         rejectsOpenerRun: Bool = true,
-        rejectsCloserRun: Bool = false
+        rejectsCloserRun: Bool = false,
+        inlineBoxWidth: CGFloat? = nil
     ) {
         self.open = open
         self.close = close
@@ -69,6 +86,7 @@ public struct InlineSyntax: Sendable, Equatable {
         self.requiresNonEmptyContent = requiresNonEmptyContent
         self.rejectsOpenerRun = rejectsOpenerRun
         self.rejectsCloserRun = rejectsCloserRun
+        self.inlineBoxWidth = inlineBoxWidth
     }
 }
 
@@ -198,7 +216,8 @@ struct ExtensionRegistry {
                 if let s = ext.inline {
                     parts += ["i", framed(s.open), framed(s.close),
                               "\(s.parsesContent)", "\(s.requiresNonEmptyContent)",
-                              "\(s.rejectsOpenerRun)", "\(s.rejectsCloserRun)"]
+                              "\(s.rejectsOpenerRun)", "\(s.rejectsCloserRun)",
+                              s.inlineBoxWidth.map { "\($0)" } ?? "-"]
                 }
                 if let b = ext.block {
                     parts += ["b", framed(b.fence)]

--- a/Sources/MarkdownEngine/Input/InlineBoxCaret.swift
+++ b/Sources/MarkdownEngine/Input/InlineBoxCaret.swift
@@ -1,0 +1,129 @@
+//
+//  InlineBoxCaret.swift
+//  MarkdownEngine
+//
+//  Treats a span laid out as a box (`InlineSyntax.inlineBoxWidth`) as one
+//  indivisible thing for the caret, the selection, and delete.
+//
+//  A box has no glyphs of its own: its characters are collapsed and its
+//  reserved space rides on the first one. So every position inside it draws at
+//  the same place, and without this an arrow key stops a dozen times in a spot
+//  that never moves, a click can drop the caret inside the construct, and one
+//  backspace shaves a delimiter off it — turning the box back into raw text in
+//  the middle of a sentence.
+//
+//  Boxes are found through the `.inlineExtensionBox` attribute the styler
+//  leaves on the span. Two boxes of the same extension placed directly against
+//  each other read as one box here; every construct that wants a box in
+//  practice is separated by at least a space.
+//
+
+import AppKit
+
+enum InlineBoxCaret {
+
+    // MARK: Lookup
+
+    /// The box whose interior holds `location` — strictly inside, so a position
+    /// on either edge is not in a box.
+    static func box(strictlyContaining location: Int, in storage: NSAttributedString) -> NSRange? {
+        guard location > 0, let box = box(coveringCharacterAt: location - 1, in: storage),
+              location < NSMaxRange(box)
+        else { return nil }
+        return box
+    }
+
+    /// The box that ends exactly at `location`, which is where a backspace
+    /// would otherwise eat its closing delimiter.
+    static func box(endingAt location: Int, in storage: NSAttributedString) -> NSRange? {
+        guard location > 0, let box = box(coveringCharacterAt: location - 1, in: storage),
+              NSMaxRange(box) == location
+        else { return nil }
+        return box
+    }
+
+    /// The box that starts exactly at `location`.
+    static func box(startingAt location: Int, in storage: NSAttributedString) -> NSRange? {
+        guard let box = box(coveringCharacterAt: location, in: storage),
+              box.location == location
+        else { return nil }
+        return box
+    }
+
+    private static func box(coveringCharacterAt index: Int, in storage: NSAttributedString) -> NSRange? {
+        guard index >= 0, index < storage.length else { return nil }
+        var range = NSRange(location: NSNotFound, length: 0)
+        guard storage.attribute(
+            .inlineExtensionBox,
+            at: index,
+            longestEffectiveRange: &range,
+            in: NSRange(location: 0, length: storage.length)
+        ) != nil else { return nil }
+        return range
+    }
+
+    // MARK: Selection
+
+    /// `proposed` with no edge left inside a box.
+    ///
+    /// A caret is pushed out to one side; a range grows to cover every box it
+    /// only partly holds, so a selection can never carry half a construct into
+    /// a copy or a deletion.
+    ///
+    /// - Parameter previous: Where the caret was, which is what tells a step
+    ///   apart from a jump. Stepping off an edge continues in that direction —
+    ///   otherwise the caret would bounce back to where it came from and the
+    ///   box would be a wall. Anything else (a click, a programmatic set) takes
+    ///   the nearer edge.
+    static func normalized(
+        _ proposed: NSRange,
+        movingFrom previous: Int,
+        in storage: NSAttributedString
+    ) -> NSRange {
+        guard storage.length > 0 else { return proposed }
+        guard proposed.length > 0 else {
+            guard let box = box(strictlyContaining: proposed.location, in: storage) else { return proposed }
+            return NSRange(location: exit(of: box, from: previous, toward: proposed.location), length: 0)
+        }
+        var result = proposed
+        for edge in [proposed.location, NSMaxRange(proposed)] {
+            guard let box = box(strictlyContaining: edge, in: storage) else { continue }
+            result = NSUnionRange(result, box)
+        }
+        return result
+    }
+
+    private static func exit(of box: NSRange, from previous: Int, toward proposed: Int) -> Int {
+        if previous == box.location { return NSMaxRange(box) }
+        if previous == NSMaxRange(box) { return box.location }
+        let fromStart = proposed - box.location
+        let fromEnd = NSMaxRange(box) - proposed
+        return fromStart <= fromEnd ? box.location : NSMaxRange(box)
+    }
+
+    // MARK: Delete
+
+    /// Backspace directly behind a box removes the whole box.
+    static func handleDeleteBackward(textView: NSTextView) -> Bool {
+        guard let storage = textView.textStorage else { return false }
+        let selection = textView.selectedRange()
+        guard selection.length == 0,
+              let box = box(endingAt: selection.location, in: storage) else { return false }
+        return delete(box, in: textView)
+    }
+
+    /// Forward delete directly in front of a box removes the whole box.
+    static func handleDeleteForward(textView: NSTextView) -> Bool {
+        guard let storage = textView.textStorage else { return false }
+        let selection = textView.selectedRange()
+        guard selection.length == 0,
+              let box = box(startingAt: selection.location, in: storage) else { return false }
+        return delete(box, in: textView)
+    }
+
+    private static func delete(_ box: NSRange, in textView: NSTextView) -> Bool {
+        MarkdownLists.performEdit(textView, replace: box, with: "")
+        textView.setSelectedRange(NSRange(location: box.location, length: 0))
+        return true
+    }
+}

--- a/Sources/MarkdownEngine/Parser/MarkdownToken.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownToken.swift
@@ -13,6 +13,11 @@ import Foundation
 extension NSAttributedString.Key {
     public static let wikiLinkID = NSAttributedString.Key("NodeLinkID")
     public static let taskCheckbox = NSAttributedString.Key("TaskCheckbox")
+    /// Extension id of a span laid out as a fixed-width box
+    /// (`InlineSyntax.inlineBoxWidth`). The span has no glyphs of its own, so
+    /// this is how the text view recognizes a box under the pointer, under the
+    /// caret, or in front of a delete.
+    static let inlineExtensionBox = NSAttributedString.Key("InlineExtensionBox")
 }
 
 enum MarkdownTokenKind: Equatable {

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -83,8 +83,16 @@ enum MarkdownASTStyler {
         let codeRanges = collectCodeRanges(in: blocks)
         let checkboxRanges = collectCheckboxRanges(in: blocks)
         let linkRanges = collectLinkRanges(in: blocks)
-        styleAutoLinks(ctx: ctx, codeRanges: codeRanges, linkRanges: linkRanges, into: &attrs)
-        styleIncompleteLinkBrackets(ctx: ctx, codeRanges: codeRanges, checkboxRanges: checkboxRanges, into: &attrs)
+        // A box span is a control, not text, so the text passes must not paint
+        // link ink into it — `[t=…]` reads as an incomplete link otherwise.
+        let boxRanges = collectInlineBoxRanges(in: blocks, ctx: ctx)
+        styleAutoLinks(ctx: ctx, codeRanges: codeRanges, linkRanges: linkRanges + boxRanges, into: &attrs)
+        styleIncompleteLinkBrackets(
+            ctx: ctx,
+            codeRanges: codeRanges + boxRanges,
+            checkboxRanges: checkboxRanges,
+            into: &attrs
+        )
         return attrs
     }
 
@@ -113,6 +121,42 @@ enum MarkdownASTStyler {
             case .ext(let node):
                 walk(node.inlines)
             default: break
+            }
+        }
+        return ranges
+    }
+
+    /// Full ranges of extension spans laid out as boxes
+    /// (`InlineSyntax.inlineBoxWidth`), which the text/regex passes skip.
+    private static func collectInlineBoxRanges(in blocks: [BlockNode], ctx: Ctx) -> [NSRange] {
+        guard ctx.extensionsByID.values.contains(where: { $0.inline?.inlineBoxWidth != nil }) else { return [] }
+        var ranges: [NSRange] = []
+        func walk(_ nodes: [InlineNode]) {
+            for node in nodes {
+                switch node {
+                case .ext(let node):
+                    if ctx.extensionsByID[node.extensionID]?.inline?.inlineBoxWidth != nil {
+                        ranges.append(node.range)
+                    }
+                    walk(node.children)
+                case .emphasis(_, _, _, let children),
+                     .link(_, _, _, _, let children):
+                    walk(children)
+                default:
+                    break
+                }
+            }
+        }
+        for block in blocks {
+            switch block {
+            case .paragraph(_, let inlines), .heading(_, _, _, let inlines), .blockquote(_, let inlines):
+                walk(inlines)
+            case .list(_, let items):
+                for item in items { walk(item.inlines) }
+            case .ext(let node):
+                walk(node.inlines)
+            default:
+                break
             }
         }
         return ranges
@@ -741,13 +785,22 @@ enum MarkdownASTStyler {
                 // Extension-contributed span: the extension supplies content
                 // ATTRIBUTES only; every range comes from the parser, so a
                 // misbehaving extension can restyle its own span at worst.
-                if let ext = ctx.extensionsByID[node.extensionID] {
+                let ext = ctx.extensionsByID[node.extensionID]
+                let boxWidth = ext?.inline?.inlineBoxWidth
+                if let ext {
                     attrs.append((node.contentRange, ext.contentAttributes(theme: ctx.theme)))
                 }
-                if ctx.isActive(node.range) {
+                // A box has no text to reveal: the delimiters stay inside it,
+                // so the caret moving in and out of the span changes nothing.
+                if boxWidth == nil, ctx.isActive(node.range) {
                     for marker in node.markers { attrs.append((marker, [.foregroundColor: ctx.theme.mutedText])) }
                 }
                 styleInlines(node.children, font: font, ctx: ctx, into: &attrs)
+                // Last, so the reserved space wins over the content and child
+                // attributes above: a box IS the span's visual form.
+                if let boxWidth {
+                    reserveInlineBox(width: boxWidth, over: node.range, ctx: ctx, into: &attrs)
+                }
 
             case .code(let range, let contentRange):
                 attrs.append((contentRange, [.font: ctx.codeFont, .backgroundColor: ctx.codeBackground]))
@@ -769,6 +822,31 @@ enum MarkdownASTStyler {
                 break   // ported in later increments
             }
         }
+    }
+
+    /// Collapse a construct's own characters and keep `width` points of line
+    /// space where they were, so the paragraph lays out and wraps around a box
+    /// the embedder draws into (`InlineSyntax.inlineBoxWidth`).
+    ///
+    /// The whole span goes to the hidden marker font, then the space rides as
+    /// kerning on its FIRST character: the box is one advance, so a caret
+    /// stepping through the span never lands inside it and the line's height is
+    /// the paragraph's, not the box's.
+    private static func reserveInlineBox(
+        width: CGFloat, over range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]
+    ) {
+        guard range.length > 0, width > 0 else { return }
+        let hidden = ctx.inlineMarkerFont
+        attrs.append((range, [
+            .font: hidden,
+            .foregroundColor: NSColor.clear,
+            .kern: -hidden.pointSize,
+        ]))
+        attrs.append((NSRange(location: range.location, length: 1), [
+            .font: hidden,
+            .foregroundColor: NSColor.clear,
+            .kern: width - hidden.pointSize,
+        ]))
     }
 
     private static func styleLink(
@@ -848,6 +926,9 @@ enum MarkdownASTStyler {
                 if !active { shrink(markers, ctx: ctx, into: &attrs) }
                 shrinkInlineMarkers(children, ctx: ctx, forceReveal: active, into: &attrs)
             case .ext(let node):
+                // A box span is already collapsed, and its reserved advance
+                // rides on a marker character — shrinking would overwrite it.
+                if ctx.extensionsByID[node.extensionID]?.inline?.inlineBoxWidth != nil { continue }
                 let active = forceReveal || ctx.isActive(node.range)
                 if !active { shrink(node.markers, ctx: ctx, into: &attrs) }
                 shrinkInlineMarkers(node.children, ctx: ctx, forceReveal: active, into: &attrs)

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -799,7 +799,9 @@ enum MarkdownASTStyler {
                 // Last, so the reserved space wins over the content and child
                 // attributes above: a box IS the span's visual form.
                 if let boxWidth {
-                    reserveInlineBox(width: boxWidth, over: node.range, ctx: ctx, into: &attrs)
+                    reserveInlineBox(
+                        width: boxWidth, id: node.extensionID, over: node.range, ctx: ctx, into: &attrs
+                    )
                 }
 
             case .code(let range, let contentRange):
@@ -833,7 +835,7 @@ enum MarkdownASTStyler {
     /// stepping through the span never lands inside it and the line's height is
     /// the paragraph's, not the box's.
     private static func reserveInlineBox(
-        width: CGFloat, over range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]
+        width: CGFloat, id: String, over range: NSRange, ctx: Ctx, into attrs: inout [StyledRange]
     ) {
         guard range.length > 0, width > 0 else { return }
         let hidden = ctx.inlineMarkerFont
@@ -841,6 +843,9 @@ enum MarkdownASTStyler {
             .font: hidden,
             .foregroundColor: NSColor.clear,
             .kern: -hidden.pointSize,
+            // The span keeps no glyphs of its own, so mark it: pointer, caret,
+            // and delete handling all need to recognize the box afterwards.
+            .inlineExtensionBox: id,
         ]))
         attrs.append((NSRange(location: range.location, length: 1), [
             .font: hidden,

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -850,6 +850,15 @@ extension NativeTextViewCoordinator {
         if commandSelector == #selector(NSResponder.insertBacktab(_:)) {
             return handleBacktab(textView)
         }
+        // A box is invisible in the line, so deleting it one character at a
+        // time would peel it back into raw syntax mid-sentence: a box on
+        // either side of the caret goes in one keystroke.
+        if commandSelector == #selector(NSResponder.deleteBackward(_:)) {
+            if InlineBoxCaret.handleDeleteBackward(textView: textView) { return true }
+        }
+        if commandSelector == #selector(NSResponder.deleteForward(_:)) {
+            if InlineBoxCaret.handleDeleteForward(textView: textView) { return true }
+        }
         // While an inline [[…]] / ![[…]] preview is open, route ↑/↓/Enter/Esc to the embedder's
         // autocomplete list (it returns true to consume the key; false → normal editor handling).
         if (isWikiLinkActive || isImageEmbedActive), let handler = onInlinePreviewKey {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -18,6 +18,11 @@ extension NativeTextView {
             // the cursor; stay silent — our tracking areas fire beneath it and
             // any set here fights the overlay's cursor (flicker).
             if isEditable { NSCursor.arrow.set() }
+        } else if isOverInlineBox(event) {
+            // A box is an embedder-drawn control sitting in the line. Its own
+            // view sets the cursor it wants; ours must not fight it, and super
+            // sets the I-beam on every move.
+            NSCursor.pointingHand.set()
         } else if isEditable, isOverTaskCheckboxBox(event) {
             // The box is a clickable control, not text. super sets the I-beam
             // on every move, so setting the arrow after it flickers — skip
@@ -39,6 +44,8 @@ extension NativeTextView {
     override func mouseEntered(with event: NSEvent) {
         if isInCursorExclusionZone(event) {
             if isEditable { NSCursor.arrow.set() }
+        } else if isOverInlineBox(event) {
+            NSCursor.pointingHand.set()
         } else if isEditable, isOverTaskCheckboxBox(event) {
             NSCursor.arrow.set()
         } else if isEditable, isOverWideTableOverlay(event) {

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+InlineBox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+InlineBox.swift
@@ -1,0 +1,84 @@
+//
+//  NativeTextView+InlineBox.swift
+//  MarkdownEngine
+//
+//  Where the text view meets a span laid out as a box
+//  (`InlineSyntax.inlineBoxWidth`): the caret stays out of it and the pointer
+//  reads it as a control.
+//
+//  Every selection the view takes goes through `setSelectedRanges`, so
+//  normalizing there covers arrow keys, shift-arrows, clicks, drags, and
+//  double-click word selection in one place — a box is either fully selected or
+//  not selected at all, and the caret only ever rests on its edges.
+//
+
+import AppKit
+
+extension NativeTextView {
+
+    override func setSelectedRanges(
+        _ ranges: [NSValue],
+        affinity: NSSelectionAffinity,
+        stillSelecting: Bool
+    ) {
+        guard let storage = textStorage, storage.length > 0 else {
+            super.setSelectedRanges(ranges, affinity: affinity, stillSelecting: stillSelecting)
+            return
+        }
+        let previous = selectedRange().location
+        let normalized = ranges.map { value in
+            NSValue(range: InlineBoxCaret.normalized(value.rangeValue, movingFrom: previous, in: storage))
+        }
+        super.setSelectedRanges(normalized, affinity: affinity, stillSelecting: stillSelecting)
+    }
+
+    /// True when the pointer is over a box. The box is an embedder-drawn
+    /// control, not text, so the edit-mode I-beam has no business there — the
+    /// same reasoning as the drawn task checkbox, and read-only mode included,
+    /// because a box is a control in both.
+    func isOverInlineBox(_ event: NSEvent) -> Bool {
+        isOverInlineBox(atViewPoint: convert(event.locationInWindow, from: nil))
+    }
+
+    /// The pointer test itself, in the view's own coordinates.
+    func isOverInlineBox(atViewPoint viewPoint: CGPoint) -> Bool {
+        guard let storage = textStorage, storage.length > 0,
+              let container = textContainer,
+              let bridge = layoutBridge else { return false }
+        let containerPoint = CGPoint(
+            x: viewPoint.x - textContainerOrigin.x,
+            y: viewPoint.y - textContainerOrigin.y
+        )
+        guard let line = lineRange(forContainerPoint: containerPoint) else { return false }
+        var isOver = false
+        storage.enumerateAttribute(.inlineExtensionBox, in: line, options: []) { value, range, stop in
+            guard value != nil else { return }
+            // The reserved space rides on the span's first character, so its
+            // own bounding rect IS the box.
+            if bridge.boundingRect(forCharacterRange: range, in: container).contains(containerPoint) {
+                isOver = true
+                stop.pointee = true
+            }
+        }
+        return isOver
+    }
+
+    /// Character range of the line fragment under a point in container
+    /// coordinates. Bounds the attribute scan to the hovered line, so a
+    /// mouse-move never walks the whole document.
+    private func lineRange(forContainerPoint point: CGPoint) -> NSRange? {
+        guard let layoutManager = textLayoutManager,
+              let contentStorage = layoutManager.textContentManager as? NSTextContentStorage,
+              let fragment = layoutManager.textLayoutFragment(for: point) else { return nil }
+        let start = contentStorage.offset(
+            from: contentStorage.documentRange.location,
+            to: fragment.rangeInElement.location
+        )
+        let end = contentStorage.offset(
+            from: contentStorage.documentRange.location,
+            to: fragment.rangeInElement.endLocation
+        )
+        guard start != NSNotFound, end > start else { return nil }
+        return NSRange(location: start, length: end - start)
+    }
+}

--- a/Tests/MarkdownEngineTests/InlineBoxCaretTests.swift
+++ b/Tests/MarkdownEngineTests/InlineBoxCaretTests.swift
@@ -1,0 +1,285 @@
+//
+//  InlineBoxCaretTests.swift
+//  MarkdownEngineTests
+//
+//  A box (`InlineSyntax.inlineBoxWidth`) behaves as one thing: the caret steps
+//  over it, a selection takes all of it or none, delete removes it whole, and
+//  its laid-out rect is the box the pointer can be tested against.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Inline box caret")
+struct InlineBoxCaretTests {
+
+    private let boxWidth: CGFloat = 20
+    private let document = "- Ship it [t=12.0-15.5] tomorrow"
+
+    private struct BoxExtension: MarkdownExtension {
+        var width: CGFloat
+        var id: String { "box" }
+        var inline: InlineSyntax? {
+            InlineSyntax(open: "[t=", close: "]", parsesContent: false, inlineBoxWidth: width)
+        }
+
+        func contentAttributes(theme _: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] { [:] }
+        func html(childrenHTML _: String) -> String { "" }
+    }
+
+    /// Same syntax laid out as text, to show the caret rules are the box's and
+    /// not the extension's.
+    private struct PlainExtension: MarkdownExtension {
+        var id: String { "box" }
+        var inline: InlineSyntax? {
+            InlineSyntax(open: "[t=", close: "]", parsesContent: false)
+        }
+
+        func contentAttributes(theme _: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] { [:] }
+        func html(childrenHTML _: String) -> String { "" }
+    }
+
+    /// Span of `[t=12.0-15.5]`, which is what the styler boxes.
+    private var box: NSRange {
+        let ns = document as NSString
+        let start = ns.range(of: "[t=").location
+        let end = NSMaxRange(ns.range(of: "]"))
+        return NSRange(location: start, length: end - start)
+    }
+
+    /// Holds the editor's collaborators for the length of a test. The text view
+    /// keeps the coordinator and the layout bridge weakly, exactly as it does in
+    /// the app, where the wrapper owns both.
+    private final class Editor {
+        let textView: NativeTextView
+        let coordinator: NativeTextViewCoordinator
+        let bridge: LayoutBridge?
+
+        init(textView: NativeTextView, coordinator: NativeTextViewCoordinator, bridge: LayoutBridge?) {
+            self.textView = textView
+            self.coordinator = coordinator
+            self.bridge = bridge
+        }
+    }
+
+    /// A text view carrying the styled document, applied the way the
+    /// coordinator applies it (flattened runs, one `setAttributes` per run).
+    private func makeEditor(boxed: Bool = true) -> Editor {
+        _ = NSApplication.shared
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 200))
+        textView.isEditable = true
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.extensions = boxed ? [BoxExtension(width: boxWidth)] : [PlainExtension()]
+        textView.configuration = configuration
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(document),
+            fontName: "SF Pro Text",
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        coordinator.configuration = configuration
+        coordinator.textView = textView
+        textView.delegate = coordinator
+        textView.string = document
+        coordinator.lastSyncedText = document
+        coordinator.lastComputedStorage = document
+        coordinator.previousDisplayLength = (document as NSString).length
+        let bridge = textView.textLayoutManager.map(LayoutBridge.init)
+        coordinator.layoutBridge = bridge
+        textView.layoutBridge = bridge
+
+        let font = NSFont(name: "SF Pro Text", size: 14) ?? .systemFont(ofSize: 14)
+        let full = NSRange(location: 0, length: (document as NSString).length)
+        let ranges = MarkdownStyler.styleAttributes(
+            text: document,
+            fontName: font.fontName,
+            fontSize: 14,
+            caretLocation: -1,
+            activeTokenIndices: [],
+            configuration: configuration
+        )
+        let runs = MarkdownStyler.flattenedRuns(ranges, base: [.font: font], documentLength: full.length)
+        textView.textStorage?.beginEditing()
+        for (range, attributes) in runs {
+            textView.textStorage?.setAttributes(attributes, range: range)
+        }
+        textView.textStorage?.endEditing()
+        return Editor(textView: textView, coordinator: coordinator, bridge: bridge)
+    }
+
+    // MARK: - Stepping
+
+    @Test("the right arrow steps from in front of the box to behind it")
+    func rightArrowStepsOverTheBox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: box.location, length: 0))
+        textView.moveRight(nil)
+        #expect(textView.selectedRange() == NSRange(location: NSMaxRange(box), length: 0))
+    }
+
+    @Test("the left arrow steps from behind the box to in front of it")
+    func leftArrowStepsBackOverTheBox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: NSMaxRange(box), length: 0))
+        textView.moveLeft(nil)
+        #expect(textView.selectedRange() == NSRange(location: box.location, length: 0))
+    }
+
+    @Test("stepping into the box from either side never rests inside it")
+    func steppingNeverRestsInside() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        for start in [box.location - 1, NSMaxRange(box) + 1] {
+            textView.setSelectedRange(NSRange(location: start, length: 0))
+            textView.moveRight(nil)
+            #expect(InlineBoxCaret.box(strictlyContaining: textView.selectedRange().location,
+                                       in: textView.textStorage!) == nil)
+            textView.moveLeft(nil)
+            #expect(InlineBoxCaret.box(strictlyContaining: textView.selectedRange().location,
+                                       in: textView.textStorage!) == nil)
+        }
+    }
+
+    /// A click has no direction to continue in, so it takes the edge it landed
+    /// nearest — jumping to the far side would move the caret away from the tap.
+    @Test("a caret dropped inside the box takes the nearer edge")
+    func droppedCaretTakesTheNearerEdge() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        textView.setSelectedRange(NSRange(location: box.location + 2, length: 0))
+        #expect(textView.selectedRange() == NSRange(location: box.location, length: 0))
+
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+        textView.setSelectedRange(NSRange(location: NSMaxRange(box) - 2, length: 0))
+        #expect(textView.selectedRange() == NSRange(location: NSMaxRange(box), length: 0))
+    }
+
+    // MARK: - Selection
+
+    @Test("extending the selection into the box takes all of it")
+    func shiftArrowSelectsTheWholeBox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: box.location, length: 0))
+        textView.moveRightAndModifySelection(nil)
+        #expect(textView.selectedRange() == box)
+    }
+
+    @Test("a selection ending inside the box grows to cover it")
+    func selectionNeverCarriesHalfABox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        let from = 2
+        textView.setSelectedRange(NSRange(location: from, length: box.location + 3 - from))
+        let selection = textView.selectedRange()
+        #expect(selection == NSRange(location: from, length: NSMaxRange(box) - from))
+    }
+
+    // MARK: - Delete
+
+    @Test("backspace behind the box removes the whole box")
+    func backspaceRemovesTheWholeBox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: NSMaxRange(box), length: 0))
+        #expect(InlineBoxCaret.handleDeleteBackward(textView: textView))
+        #expect(textView.string == "- Ship it  tomorrow")
+        #expect(textView.selectedRange() == NSRange(location: box.location, length: 0))
+    }
+
+    @Test("forward delete in front of the box removes the whole box")
+    func forwardDeleteRemovesTheWholeBox() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: box.location, length: 0))
+        #expect(InlineBoxCaret.handleDeleteForward(textView: textView))
+        #expect(textView.string == "- Ship it  tomorrow")
+    }
+
+    @Test("delete away from a box is left to AppKit")
+    func deleteElsewhereIsInert() {
+        let editor = makeEditor()
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: 5, length: 0))
+        #expect(!InlineBoxCaret.handleDeleteBackward(textView: textView))
+        #expect(!InlineBoxCaret.handleDeleteForward(textView: textView))
+        #expect(textView.string == document)
+    }
+
+    // MARK: - Without a box
+
+    @Test("the same span laid out as text keeps ordinary caret and delete")
+    func plainSpanIsUntouched() {
+        let editor = makeEditor(boxed: false)
+        let textView = editor.textView
+        textView.setSelectedRange(NSRange(location: box.location, length: 0))
+        textView.moveRight(nil)
+        #expect(textView.selectedRange() == NSRange(location: box.location + 1, length: 0))
+
+        textView.setSelectedRange(NSRange(location: NSMaxRange(box), length: 0))
+        #expect(!InlineBoxCaret.handleDeleteBackward(textView: textView))
+    }
+
+    // MARK: - Pointer
+
+    /// What the pointer is tested against: the span's laid-out rect has to BE
+    /// the box, or the hand cursor and the embedder's control would disagree
+    /// about where the box is.
+    @Test("the box's laid-out rect is the reserved width")
+    func laidOutRectIsTheBox() {
+        let editor = makeEditor()
+        let rect = boxRect(in: editor)
+        #expect(abs(rect.width - boxWidth) < 0.5)
+        #expect(rect.height > 0)
+    }
+
+    /// The whole box answers to the pointer, not just the middle of it: the
+    /// control the embedder draws fills the reserved space edge to edge.
+    @Test("every point of the box reads as a control, and no point beside it does")
+    func theWholeBoxIsTheTarget() {
+        let editor = makeEditor()
+        let rect = boxRect(in: editor)
+        let inset: CGFloat = 0.5
+        for x in [rect.minX + inset, rect.midX, rect.maxX - inset] {
+            let point = viewPoint(x: x, y: rect.midY, in: editor.textView)
+            #expect(editor.textView.isOverInlineBox(atViewPoint: point), "x=\(x) is inside the box")
+        }
+        for x in [rect.minX - 3, rect.maxX + 3] {
+            let point = viewPoint(x: x, y: rect.midY, in: editor.textView)
+            #expect(!editor.textView.isOverInlineBox(atViewPoint: point), "x=\(x) is beside the box")
+        }
+    }
+
+    /// The same span as text is text: the pointer keeps the I-beam over it.
+    @Test("a span without a box is never a pointer target")
+    func plainSpanIsNotATarget() {
+        let editor = makeEditor(boxed: false)
+        let rect = boxRect(in: editor)
+        let point = viewPoint(x: rect.midX, y: rect.midY, in: editor.textView)
+        #expect(!editor.textView.isOverInlineBox(atViewPoint: point))
+    }
+
+    /// Laid-out rect of the span, in text-container coordinates.
+    private func boxRect(in editor: Editor) -> CGRect {
+        guard let container = editor.textView.textContainer,
+              let bridge = editor.bridge,
+              let layoutManager = editor.textView.textLayoutManager
+        else {
+            Issue.record("the editor has no TextKit 2 layout")
+            return .zero
+        }
+        layoutManager.ensureLayout(for: layoutManager.documentRange)
+        return bridge.boundingRect(forCharacterRange: box, in: container)
+    }
+
+    private func viewPoint(x: CGFloat, y: CGFloat, in textView: NativeTextView) -> CGPoint {
+        CGPoint(x: x + textView.textContainerOrigin.x, y: y + textView.textContainerOrigin.y)
+    }
+}

--- a/Tests/MarkdownEngineTests/InlineExtensionBoxTests.swift
+++ b/Tests/MarkdownEngineTests/InlineExtensionBoxTests.swift
@@ -1,0 +1,158 @@
+//
+//  InlineExtensionBoxTests.swift
+//  MarkdownEngineTests
+//
+//  `InlineSyntax.inlineBoxWidth`: a span laid out as a fixed-width box the
+//  embedder draws into, instead of as text. The engine's job is the space —
+//  reserved on one character, kept whatever the caret is doing, and never
+//  reclaimed by the marker-shrink pass.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Inline extension boxes")
+struct InlineExtensionBoxTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// A span rendered as a control: opaque content, no reveal, 26pt wide.
+    private struct BoxExtension: MarkdownExtension {
+        var id: String { "box" }
+        var inline: InlineSyntax? {
+            InlineSyntax(open: "[t=", close: "]", parsesContent: false, inlineBoxWidth: 26)
+        }
+
+        func contentAttributes(theme _: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] {
+            [.foregroundColor: NSColor.systemPink]
+        }
+
+        func html(childrenHTML _: String) -> String { "" }
+    }
+
+    /// Same syntax without a box, so the difference under test is the knob.
+    private struct PlainExtension: MarkdownExtension {
+        var id: String { "box" }
+        var inline: InlineSyntax? {
+            InlineSyntax(open: "[t=", close: "]", parsesContent: false)
+        }
+
+        func contentAttributes(theme _: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] {
+            [.foregroundColor: NSColor.systemPink]
+        }
+
+        func html(childrenHTML _: String) -> String { "" }
+    }
+
+    private func attributes(
+        _ text: String,
+        extensions: [any MarkdownExtension],
+        caret: Int = 0
+    ) -> [StyledRange] {
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.extensions = extensions
+        return MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: base,
+            caretLocation: caret,
+            configuration: configuration
+        )
+    }
+
+    /// Order-independent digest of the styled ranges touching the span under
+    /// test, so two style runs can be compared for equality. Scoped to the span
+    /// because the caret also drives line-level chrome (the bullet marker).
+    private func snapshot(_ ranges: [StyledRange]) -> String {
+        ranges
+            .filter { NSIntersectionRange($0.range, NSRange(location: boxStart, length: 17)).length > 0 }
+            .map { range, values in
+                let keys = values.keys
+                    .map { "\($0.rawValue)=\(String(describing: values[$0]!))" }
+                    .sorted()
+                return "\(range.location)+\(range.length):\(keys.joined(separator: ","))"
+            }
+            .sorted()
+            .joined(separator: "\n")
+    }
+
+    /// Effective value of `key` at `position`: the last styled range wins, the
+    /// same way the text storage applies them.
+    private func effective(
+        _ key: NSAttributedString.Key,
+        in attrs: [StyledRange],
+        at position: Int
+    ) -> Any? {
+        var result: Any?
+        for (range, values) in attrs where NSLocationInRange(position, range) {
+            if let value = values[key] { result = value }
+        }
+        return result
+    }
+
+    private let document = "- Team agreed to postpone the launch [t=1284.3-1291.7]"
+    /// Offset of the span's `[`, and of a digit inside its content.
+    private var boxStart: Int { (document as NSString).range(of: "[t=").location }
+    private var contentPosition: Int { boxStart + 4 }
+
+    @Test("the box's width is reserved on the span's first character")
+    func boxWidthRidesOnTheFirstCharacter() {
+        let attrs = attributes(document, extensions: [BoxExtension()])
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+
+        let kern = effective(.kern, in: attrs, at: boxStart) as? CGFloat
+        #expect(kern == 26 - hidden)
+        #expect((effective(.font, in: attrs, at: boxStart) as? NSFont)?.pointSize == hidden)
+    }
+
+    @Test("every other character of the span collapses to nothing")
+    func remainingCharactersCollapse() {
+        let attrs = attributes(document, extensions: [BoxExtension()])
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+
+        #expect((effective(.kern, in: attrs, at: contentPosition) as? CGFloat) == -hidden)
+        #expect((effective(.font, in: attrs, at: contentPosition) as? NSFont)?.pointSize == hidden)
+        #expect((effective(.foregroundColor, in: attrs, at: contentPosition) as? NSColor) == .clear)
+    }
+
+    /// The point of the knob: the box holds its shape while the user types in
+    /// the line it sits on. Revealing the delimiters would shove the box aside.
+    @Test("a caret inside the span neither reveals it nor moves the box")
+    func caretInsideTheSpanChangesNothing() {
+        let resting = attributes(document, extensions: [BoxExtension()])
+        let caretInside = attributes(document, extensions: [BoxExtension()], caret: contentPosition)
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+
+        #expect((effective(.kern, in: caretInside, at: boxStart) as? CGFloat) == 26 - hidden)
+        #expect((effective(.foregroundColor, in: caretInside, at: boxStart) as? NSColor) == .clear)
+        #expect(snapshot(resting) == snapshot(caretInside))
+    }
+
+    @Test("without the knob the span still lays out as text and reveals at the caret")
+    func plainSpanKeepsUpstreamBehavior() {
+        let resting = attributes(document, extensions: [PlainExtension()])
+        let caretInside = attributes(document, extensions: [PlainExtension()], caret: contentPosition)
+        let hidden = MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+
+        // The content keeps the view's own font and advance: nothing collapses
+        // it, which is exactly what a box changes.
+        #expect(effective(.font, in: resting, at: contentPosition) == nil)
+        #expect(effective(.kern, in: resting, at: contentPosition) == nil)
+        #expect((effective(.font, in: resting, at: boxStart) as? NSFont)?.pointSize == hidden)
+        #expect(
+            effective(.font, in: caretInside, at: boxStart) == nil,
+            "the caret drops the shrink, so a plain span's delimiters return to the body font"
+        )
+        #expect(snapshot(resting) != snapshot(caretInside))
+    }
+
+    @Test("two registries differing only in the box width parse under distinct keys")
+    func fingerprintCoversTheBoxWidth() {
+        let boxed = ExtensionRegistry(extensions: [BoxExtension()])
+        let plain = ExtensionRegistry(extensions: [PlainExtension()])
+        #expect(boxed.fingerprint != plain.fingerprint)
+    }
+}

--- a/Tests/MarkdownEngineTests/InlineExtensionBoxTests.swift
+++ b/Tests/MarkdownEngineTests/InlineExtensionBoxTests.swift
@@ -21,9 +21,11 @@ struct InlineExtensionBoxTests {
 
     /// A span rendered as a control: opaque content, no reveal, 26pt wide.
     private struct BoxExtension: MarkdownExtension {
+        var width: CGFloat = 26
+
         var id: String { "box" }
         var inline: InlineSyntax? {
-            InlineSyntax(open: "[t=", close: "]", parsesContent: false, inlineBoxWidth: 26)
+            InlineSyntax(open: "[t=", close: "]", parsesContent: false, inlineBoxWidth: width)
         }
 
         func contentAttributes(theme _: MarkdownEditorTheme) -> [NSAttributedString.Key: Any] {
@@ -147,6 +149,34 @@ struct InlineExtensionBoxTests {
             "the caret drops the shrink, so a plain span's delimiters return to the body font"
         )
         #expect(snapshot(resting) != snapshot(caretInside))
+    }
+
+    /// The attribute tests above say what the styler asks for; this one says
+    /// TextKit grants it. Two widths of the same document differ by exactly the
+    /// difference in widths, so a reserved point is a laid-out point.
+    @Test("the reserved width is the width the line gains")
+    func reservedSpaceBecomesLaidOutSpace() {
+        let wide = laidOutWidth(document, extensions: [BoxExtension(width: 26)])
+        let narrow = laidOutWidth(document, extensions: [BoxExtension(width: 6)])
+        #expect(abs((wide - narrow) - 20) < 0.01)
+    }
+
+    /// Width of the document's single line once the styler's attributes are on
+    /// it, measured by TextKit rather than derived from the attributes.
+    private func laidOutWidth(_ text: String, extensions: [any MarkdownExtension]) -> CGFloat {
+        let storage = NSTextStorage(string: text)
+        let full = NSRange(location: 0, length: storage.length)
+        storage.addAttribute(.font, value: NSFont(name: fontName, size: base) ?? .systemFont(ofSize: base), range: full)
+        for (range, values) in attributes(text, extensions: extensions) {
+            storage.addAttributes(values, range: range)
+        }
+        let container = NSTextContainer(size: CGSize(width: 10_000, height: 10_000))
+        container.lineFragmentPadding = 0
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(container)
+        storage.addLayoutManager(layoutManager)
+        layoutManager.ensureLayout(for: container)
+        return layoutManager.usedRect(for: container).width
     }
 
     @Test("two registries differing only in the box width parse under distinct keys")


### PR DESCRIPTION
## What

Adds `InlineSyntax.inlineBoxWidth: CGFloat?`. When set, the extension's span is
laid out as a fixed-width box instead of as text: markers and content collapse,
that many points of line space are kept in their place, and the span behaves as
one control for the caret, the selection, delete, and the pointer.

## Why

An extension supplies syntax and content attributes today, which is enough for
a construct that reads as prose but not for one that reads as a control — a
citation playhead, a chip, a token. `contentAttributes(theme:)` applies to the
whole content range uniformly, so an embedder cannot reserve a width that is
independent of the character count. Without reserved space the only option is
to draw the control over the text, where it overlaps whatever follows and does
not wrap with the paragraph.

Reserved space alone is not enough, though: a span with no glyphs of its own is
a hole in the line. An arrow key stops a dozen times in a spot that never
moves, a click drops the caret inside the construct, one backspace shaves off a
delimiter and turns the box back into raw text mid-sentence, and the pointer
keeps the I-beam over something drawn as a button.

## How

- The reserved space rides as kerning on the span's FIRST character, so the box
  is a single advance: the line's height stays the paragraph's rather than the
  box's.
- `shrinkInactiveMarkers` skips a box span — its shrink would overwrite the
  reserved advance, which sits on a marker character.
- A box's delimiters no longer reveal at the caret. There is no text to reveal,
  and revealing them would shove the box sideways while the user types in the
  line it sits on.
- The auto-link and incomplete-bracket text passes skip box spans, so a
  bracketed construct like `[t=12.0-19.5]` is not painted as a broken link.
- The styler marks the span with `.inlineExtensionBox`. `NativeTextView`
  normalizes every selection through `InlineBoxCaret`, so the caret rests only
  on the box's edges and a selection takes all of it or none; backward and
  forward delete remove the whole span in one keystroke; and the pointer reads
  the span's laid-out rect as a control and shows the hand, the way the drawn
  task checkbox already does.

## Compatibility

`nil` by default: every existing extension parses, styles, and navigates
exactly as before — covered by a plain-span counterpart in each test. The
registry fingerprint includes the new field, so two registries differing only
in it cannot share cached parses.

## Test plan

- [x] `InlineExtensionBoxTests`: the width lands on the first character, the
      rest of the span collapses, a caret inside the span changes nothing in it,
      a span without the knob keeps upstream layout and caret reveal, the
      fingerprint separates the two registries, and TextKit grants exactly the
      reserved width (same document laid out at two widths).
- [x] `InlineBoxCaretTests`: arrows step over the box from either side and never
      rest inside it, a dropped caret takes the nearer edge, shift-arrow and a
      partial range take the whole box, backspace and forward delete remove it
      whole, the laid-out rect is the reserved width, and every point of that
      rect reads as a control while points beside it do not.
- [x] Full suite green.

Made with [Cursor](https://cursor.com)