### PR TITLE
Make a table survive its own source

### DIFF
--- a/Sources/MarkdownEngine/Input/MarkdownInputHandler.swift
+++ b/Sources/MarkdownEngine/Input/MarkdownInputHandler.swift
@@ -59,6 +59,38 @@ enum MarkdownInputHandler {
                                    replacementString: replacementString, tokens: resolvedTokens)
     }
 
+    /// Return inside a table row inserts `<br>` instead of splitting the row.
+    ///
+    /// A GFM row is ONE source line, so a bare newline tears the table in half.
+    /// `<br>` is the format's only in-cell line break, and the renderer draws
+    /// it as one. Covers ⇧↵ too: AppKit sends the same `insertNewline:` for
+    /// both, so both arrive here as a `"\n"` replacement.
+    ///
+    /// Deliberately NOT handled at the token's outer edges — Return at the very
+    /// start or end of the table stays a normal newline, which is the only way
+    /// out of a table that reaches the end of the document.
+    static func handleTableCellNewline(
+        textView: NSTextView,
+        affectedCharRange: NSRange,
+        replacementString: String?,
+        tableTokens: [MarkdownToken]
+    ) -> Bool {
+        guard replacementString == "\n" else { return false }
+        let start = affectedCharRange.location
+        let end = NSMaxRange(affectedCharRange)
+        guard tableTokens.contains(where: { start > $0.range.location && end < NSMaxRange($0.range) })
+        else { return false }
+
+        let insertion = "<br>"
+        insertTextProgrammatically(
+            textView,
+            text: insertion,
+            at: affectedCharRange,
+            cursorAfter: start + (insertion as NSString).length
+        )
+        return true
+    }
+
     /// Ensures image embeds (![[...]]) stay on their own line by automatically inserting newlines.
     static func handleImageEmbedAutoWrap(
         textView: NSTextView,

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -310,13 +310,37 @@ extension MarkdownStyler {
         return ParsedTable(header: paddedHeader, alignments: paddedAlign, rows: rows)
     }
 
+    /// Splits on UNESCAPED `|` only. GFM escapes the delimiter as `\\|`, and
+    /// the escape wins over every inline context (a table row is split before
+    /// inline parsing runs) — so a cell holding `` `a \\| b` `` is one cell, not
+    /// two. Splitting on the raw character silently truncated such a row to the
+    /// header's column count.
     private static func parseTableRow(_ line: String) -> [String] {
-        var s = line.trimmingCharacters(in: .whitespaces)
-        if s.hasPrefix("|") { s.removeFirst() }
-        if s.hasSuffix("|") { s.removeLast() }
-        return s.split(separator: "|", omittingEmptySubsequences: false).map {
-            $0.trimmingCharacters(in: .whitespaces)
+        var s = Substring(line.trimmingCharacters(in: .whitespaces))
+        if s.hasPrefix("|") { s = s.dropFirst() }
+        if s.hasSuffix("|"), !s.dropLast().hasSuffix("\\") { s = s.dropLast() }
+
+        var cells: [String] = []
+        var current = ""
+        var escaped = false
+        for ch in s {
+            if escaped {
+                // Only the delimiter escape is resolved here; every other `\x`
+                // stays intact so inline parsing still owns its own escapes.
+                if ch == "|" { current.append("|") } else { current.append("\\"); current.append(ch) }
+                escaped = false
+            } else if ch == "\\" {
+                escaped = true
+            } else if ch == "|" {
+                cells.append(current.trimmingCharacters(in: .whitespaces))
+                current = ""
+            } else {
+                current.append(ch)
+            }
         }
+        if escaped { current.append("\\") }
+        cells.append(current.trimmingCharacters(in: .whitespaces))
+        return cells
     }
 
     private static func parseTableAlignments(_ line: String) -> [TableAlignment] {
@@ -334,6 +358,16 @@ extension MarkdownStyler {
     }
 
     // MARK: - Inline-formatted cell strings
+
+    /// `<br>` → a real newline. A GFM row IS one source line, so `<br>` is the
+    /// only in-cell line break the format has; without this it drew literally.
+    static func expandCellLineBreaks(_ raw: String) -> String {
+        raw.replacingOccurrences(
+            of: #"<br\s*/?>"#,
+            with: "\n",
+            options: [.regularExpression, .caseInsensitive]
+        )
+    }
 
     /// Raw cell → `NSAttributedString`: inline markdown applied, markers stripped, LaTeX as attachments.
     static func formattedCellString(
@@ -354,6 +388,9 @@ extension MarkdownStyler {
         let out = NSMutableAttributedString()
         var extensionsByID: [String: any MarkdownExtension] = [:]
         for ext in extensions { extensionsByID[ext.id] = ext }
+        // Substituted BEFORE inline parsing so the AST offsets index the same
+        // string that gets drawn.
+        let raw = expandCellLineBreaks(raw)
         appendInlineCell(
             InlineParser.parse(raw, registry: ExtensionRegistry(extensions: extensions)),
             in: raw as NSString, into: out,
@@ -528,8 +565,17 @@ extension MarkdownStyler {
         }
         var maxWidths = [CGFloat](repeating: minColumnContentWidth, count: columnCount)
         var minWidths = [CGFloat](repeating: minColumnContentWidth, count: columnCount)
+        // `size()` lays a cell out as ONE line, so a cell broken by `<br>`
+        // would report the sum of its lines as its natural width.
+        func naturalWidth(_ cell: NSAttributedString) -> CGFloat {
+            guard cell.string.contains("\n") else { return ceil(cell.size().width) }
+            return ceil(cell.boundingRect(
+                with: NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude),
+                options: [.usesLineFragmentOrigin]
+            ).width)
+        }
         func considerCell(_ cell: NSAttributedString, col: Int) {
-            maxWidths[col] = max(maxWidths[col], ceil(cell.size().width))
+            maxWidths[col] = max(maxWidths[col], naturalWidth(cell))
             minWidths[col] = max(minWidths[col], widestUnbreakableSegment(cell))
         }
         for (i, cell) in headerCells.enumerated() where i < columnCount {

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -372,6 +372,20 @@ extension MarkdownStyler {
         return true
     }
 
+    /// Per-character kern that collapses a hidden run to zero width.
+    ///
+    /// `.kern` is applied to EVERY character in the range, so a run of `n`
+    /// characters ends up `width + n * kern` wide — feeding it the whole run's
+    /// width made a long run `(n - 1)` widths too NEGATIVE. AppKit clamps most
+    /// such lines to zero, but a line holding a composed character sequence
+    /// (e.g. `z` + U+0304) instead laid out at x = +1783 with width -1783,
+    /// which poisoned `usageBoundsForTextContainer` for the whole document
+    /// (measured -1778…695 instead of 5…695 on a 14-line table).
+    static func hiddenRunKern(_ text: String, font: NSFont) -> CGFloat {
+        let count = max(1, (text as NSString).length)
+        return HeadingHelpers.textWidth(text, font: font) / CGFloat(count)
+    }
+
     /// Shared body for collapsed-source modes; hides raw source, plants image on anchor.
     private static func emitCollapsedAttrs(
         token: MarkdownToken,
@@ -423,7 +437,7 @@ extension MarkdownStyler {
             attrs.append((leadingRange, [
                 .foregroundColor: NSColor.clear,
                 .font: ctx.latexMarkerFont,
-                .kern: -HeadingHelpers.textWidth(leadingText, font: ctx.latexMarkerFont)
+                .kern: -hiddenRunKern(leadingText, font: ctx.latexMarkerFont)
             ]))
         }
 
@@ -448,7 +462,7 @@ extension MarkdownStyler {
             attrs.append((trailingRange, [
                 .foregroundColor: NSColor.clear,
                 .font: ctx.latexMarkerFont,
-                .kern: -HeadingHelpers.textWidth(trailingText, font: ctx.latexMarkerFont)
+                .kern: -hiddenRunKern(trailingText, font: ctx.latexMarkerFont)
             ]))
         }
 
@@ -459,7 +473,7 @@ extension MarkdownStyler {
             attrs.append((markerRange, [
                 .foregroundColor: NSColor.clear,
                 .font: ctx.latexMarkerFont,
-                .kern: -HeadingHelpers.textWidth(markerText, font: ctx.latexMarkerFont)
+                .kern: -hiddenRunKern(markerText, font: ctx.latexMarkerFont)
             ]))
         }
 
@@ -470,7 +484,7 @@ extension MarkdownStyler {
             attrs.append((preTokenRange, [
                 .foregroundColor: NSColor.clear,
                 .font: ctx.latexMarkerFont,
-                .kern: -HeadingHelpers.textWidth(preTokenText, font: ctx.latexMarkerFont)
+                .kern: -hiddenRunKern(preTokenText, font: ctx.latexMarkerFont)
             ]))
         }
     }

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -926,6 +926,15 @@ extension NativeTextViewCoordinator {
                 return false
             }
 
+            if MarkdownInputHandler.handleTableCellNewline(
+                textView: textView,
+                affectedCharRange: affectedCharRange,
+                replacementString: replacementString,
+                tableTokens: parsed.tableTokens
+            ) {
+                return false
+            }
+
             return MarkdownInputHandler.handleListInsertion(textView: textView, affectedCharRange: affectedCharRange,
                                                             replacementString: replacementString, codeTokens: parsed.codeTokens)
         }

--- a/Tests/MarkdownEngineTests/TableCellSourceTests.swift
+++ b/Tests/MarkdownEngineTests/TableCellSourceTests.swift
@@ -1,0 +1,129 @@
+//
+//  TableCellSourceTests.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 18.08.26.
+//
+//  What a GFM row can and cannot hold: the delimiter is escapable, and `<br>`
+//  is the only line break a cell has — a row IS one source line.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Table cell source")
+@MainActor
+struct TableCellSourceTests {
+
+    // MARK: - Escaped delimiters
+
+    @Test func escapedPipeKeepsTheRowInOneCell() throws {
+        let source = """
+        | Statement | Verdict |
+        |---|---|
+        | `P(k)` does not depend on `z̄` | **TRUE**. `Var[x(1) \\| z(1:3)]`-style claims go by *index* |
+        """
+        let parsed = try #require(MarkdownStyler.parseTableSource(source))
+        let row = try #require(parsed.rows.first)
+        #expect(row.count == 2)
+        // Everything past the first `\|` used to be dropped on the floor.
+        #expect(row[1].hasSuffix("by *index*"))
+        // …and the escape resolves to the literal character GFM promises.
+        #expect(row[1].contains("Var[x(1) | z(1:3)]"))
+        #expect(!row[1].contains("\\|"))
+    }
+
+    // MARK: - In-cell line breaks
+
+    @Test func brRendersAsALineBreakInsteadOfLiteralText() {
+        let cell = MarkdownStyler.formattedCellString(
+            "first<br>second",
+            baseFont: .systemFont(ofSize: 15),
+            header: false,
+            theme: MarkdownEditorConfiguration.default.theme,
+            codeBackgroundColor: .windowBackgroundColor,
+            latex: NoOpLatexRenderer()
+        )
+        #expect(cell.string == "first\nsecond")
+    }
+
+    @Test func aCellBrokenByBrMakesItsRowTaller() throws {
+        func height(_ source: String) throws -> CGFloat {
+            let parsed = try #require(MarkdownStyler.parseTableSource(source))
+            let font = NSFont.systemFont(ofSize: 15)
+            var ctx = MarkdownStyler.StylingContext(
+                nsText: source as NSString,
+                tokens: [], codeTokens: [], activeTokenIndices: [],
+                baseFont: font, layoutBridge: nil, baseDefaultLineHeight: 18,
+                codeBackgroundColor: .windowBackgroundColor, latexMarkerFont: font,
+                configuration: .default, wikiLinkIDProvider: { _ in nil }
+            )
+            ctx.scopeBounds = nil
+            let aqua = try #require(NSAppearance(named: .aqua))
+            return MarkdownStyler.tableImage(
+                for: source, parsed: parsed, ctx: ctx, appearance: aqua, availableWidth: 650
+            ).image.size.height
+        }
+        let flat = try height("| A | B |\n|---|---|\n| one | two |")
+        let broken = try height("| A | B |\n|---|---|\n| one | two<br>three |")
+        #expect(broken > flat + 5)
+    }
+
+    // MARK: - Return inside a row
+
+    private func textView(_ text: String) -> NSTextView {
+        let tv = NSTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.string = text
+        return tv
+    }
+
+    @Test func returnInsideARowInsertsABreakInsteadOfSplittingIt() throws {
+        let source = "| A | B |\n|---|---|\n| one | two |"
+        let tv = textView(source)
+        let tables = MarkdownTokenizer.parseTokensViaAST(in: source).filter { $0.kind == .table }
+        let caret = (source as NSString).range(of: "two").upperBound
+
+        let handled = MarkdownInputHandler.handleTableCellNewline(
+            textView: tv,
+            affectedCharRange: NSRange(location: caret, length: 0),
+            replacementString: "\n",
+            tableTokens: tables
+        )
+        #expect(handled)
+        #expect(tv.string == "| A | B |\n|---|---|\n| one | two<br> |")
+        #expect(tv.selectedRange().location == caret + 4)
+    }
+
+    /// The table's outer edges stay a plain newline — otherwise a table that
+    /// reaches the end of the document has no way out.
+    @Test func returnAtTheTableEdgesStaysANormalNewline() {
+        let source = "| A | B |\n|---|---|\n| one | two |"
+        let tables = MarkdownTokenizer.parseTokensViaAST(in: source).filter { $0.kind == .table }
+        for caret in [0, (source as NSString).length] {
+            let tv = textView(source)
+            let handled = MarkdownInputHandler.handleTableCellNewline(
+                textView: tv,
+                affectedCharRange: NSRange(location: caret, length: 0),
+                replacementString: "\n",
+                tableTokens: tables
+            )
+            #expect(!handled)
+            #expect(tv.string == source)
+        }
+    }
+
+    @Test func returnOutsideAnyTableIsUntouched() {
+        let source = "just prose\n\n| A | B |\n|---|---|\n| one | two |"
+        let tv = textView(source)
+        let tables = MarkdownTokenizer.parseTokensViaAST(in: source).filter { $0.kind == .table }
+        let handled = MarkdownInputHandler.handleTableCellNewline(
+            textView: tv,
+            affectedCharRange: NSRange(location: 4, length: 0),
+            replacementString: "\n",
+            tableTokens: tables
+        )
+        #expect(!handled)
+        #expect(tv.string == source)
+    }
+}

--- a/Tests/MarkdownEngineTests/TableHiddenSourceGeometryTests.swift
+++ b/Tests/MarkdownEngineTests/TableHiddenSourceGeometryTests.swift
@@ -1,0 +1,62 @@
+//
+//  TableHiddenSourceGeometryTests.swift
+//  MarkdownEngine
+//
+//  Created by Luca Chen on 18.08.26.
+//
+//  A collapsed block hides its raw source by shrinking it to a near-zero font
+//  and kerning the rest of its width away. Getting that kern wrong does not
+//  just leave a sliver behind — it can throw the whole document out of the
+//  text container.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Hidden source geometry")
+@MainActor
+struct TableHiddenSourceGeometryTests {
+
+    // MARK: - Hidden-source geometry
+
+    /// `.kern` applies to EVERY character in its range, so hiding a run with the
+    /// run's FULL width made a long run `(n - 1)` widths too negative. Most such
+    /// lines clamp to zero width; a line carrying `z` + U+0304 instead laid out
+    /// at x = +1783 with width -1783 and poisoned the container's usage bounds,
+    /// which is what made the note render blank.
+    @Test func collapsedTableWithACombiningMarkStaysInsideTheContainer() throws {
+        let viewport = NSSize(width: 700, height: 900)
+        let source = """
+        | Statement | Verdict |
+        |---|---|
+        | `P(k)` and `K(k)` do not depend on the measured values `z̄` | **TRUE** (linear KF) |
+        | Detectability is implied by observability | **TRUE** |
+        """
+        let stack = HeightBehaviorStack(viewport: viewport)
+        let tv = stack.textView
+        tv.string = source
+        let bridge = tv.textLayoutManager.map { LayoutBridge($0) }
+        tv.layoutBridge = bridge
+        let (font, style) = TextStylingService.makeBaseFontAndStyle(
+            fontName: "Helvetica", fontSize: 15, configuration: .default
+        )
+        TextStylingService.restyle(
+            textView: tv,
+            layoutBridge: bridge,
+            paragraphCandidates: [NSRange(location: 0, length: (source as NSString).length)],
+            baseFont: font,
+            paragraphStyle: style,
+            caretLocation: (source as NSString).length,
+            activeTokenIndices: [],
+            wikiLinkIDProvider: { _ in nil }
+        )
+        let tlm = try #require(tv.textLayoutManager)
+        let tcm = try #require(tlm.textContentManager)
+        tlm.ensureLayout(for: tcm.documentRange)
+
+        let usage = tlm.usageBoundsForTextContainer
+        #expect(usage.minX >= -0.5)
+        #expect(usage.width <= viewport.width + 0.5)
+    }
+}


### PR DESCRIPTION
One real note surfaced three defects in the same subsystem: it rendered as a completely blank page.

## The blank page

The note's only content was a 14-line table, so the whole document collapsed into one hidden source run. A collapsed block hides its raw text by shrinking it to a near-zero font and kerning the rest of its width away — but `.kern` applies to **every character** in its range, so a run of *n* characters ends up `width + n * kern` wide. Feeding it the run's FULL width overshot by (n − 1) widths.

AppKit clamps most such lines to zero width, which is why this never showed. One line in that note held `z̄` — a `z` plus U+0304 — and that line did not clamp: it laid out at x = **+1783** with width **−1783**, dragging `usageBoundsForTextContainer` to **−1778…695** on a 700pt container.

Measured, one variable at a time:

| document | usage bounds |
|---|---|
| the note | `(-1778.2, 0, 2473.2, 655.5)` |
| same note, combining mark removed | `(5.0, 0, 690.0, 655.5)` |
| same note, after this fix | `(5.0, 0, 690.0, 673.5)` |

## Two more the same note found

**`\|` truncated its row.** GFM escapes the delimiter, and the escape beats every inline context because rows are split before inline parsing runs — so `` `Var[x(1) \| z(1:3)]` `` is one cell. Splitting on the raw character cut the row short at the header's column count and silently dropped the rest of the line.

**`<br>` had no meaning.** It is the only in-cell line break the format has (a row *is* one source line), and it drew literally. Return inside a row could therefore only tear the table in half.

## Return in a table

Return — and ⇧↵, which AppKit sends as the same `insertNewline:` — now inserts `<br>` instead of splitting the row. The table's outer edges deliberately stay a plain newline: that is the only way out of a table sitting at the end of a document.

## Tests

7 new tests across `TableHiddenSourceGeometryTests` and `TableCellSourceTests`; each was confirmed red against the unfixed sources. Full suite: 454 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)