### PR TITLE
Fix crash: stale code-block token cache after a programmatic content swap

### DIFF
--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
@@ -75,6 +75,12 @@ extension NativeTextViewCoordinator {
 
         let selections: [CodeBlockSelection] = cachedCodeBlockTokens.compactMap { originalIndex, token in
             guard !activeTokenIndices.contains(originalIndex) else { return nil }
+            // Last line of defence: cached ranges can briefly outlive the text
+            // they were parsed from (any caller may race a content mutation on
+            // the main queue). A block that no longer fits the current text is
+            // stale by definition — skip it; the next parse re-delivers it.
+            guard NSMaxRange(token.range) <= nsText.length,
+                  NSMaxRange(token.contentRange) <= nsText.length else { return nil }
             if let visibleRange, NSIntersectionRange(token.range, visibleRange).length == 0 { return nil }
             guard var boundingRect = textView.viewRect(forCharacterRange: token.range, using: layoutBridge) else { return nil }
 

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -91,9 +91,23 @@ extension NativeTextViewCoordinator {
         if rawMode {
             // Base attributes only — the source stays verbatim and unstyled.
             activeTokenIndices = []
+            // Raw mode draws no code-block overlays; drop the styled document's
+            // tokens so a later no-`parsed` refresh doesn't substring this text
+            // with them.
+            cachedCodeBlockTokens = []
+            lastCodeSelKey = nil
         } else {
             let parsed = parsedDocument(for: displayText)
             parsedForReplay = parsed
+            // A rebuild replaces the text under the code-block token cache, but
+            // only the typing/caret delegate paths refresh that cache — a
+            // programmatic swap (document switch, external binding change) never
+            // does. The deferred no-`parsed` refresh in `updateNSView` then cut
+            // substrings out of THIS text with the PREVIOUS document's ranges:
+            // out of range on any shorter text → NSRangeException → abort. This
+            // parse is the current text's, so hand its tokens over here.
+            cachedCodeBlockTokens = parsed.codeBlockTokensWithIndices
+            lastCodeSelKey = nil
             let tokens = parsed.tokens
             // Hide caret from styling when read-only, else clicks reveal raw token syntax.
             let caretLocation = textView.isEditable ? textView.selectedRange().location : -1

--- a/Tests/MarkdownEngineTests/CodeBlockSelectionStaleCacheTests.swift
+++ b/Tests/MarkdownEngineTests/CodeBlockSelectionStaleCacheTests.swift
@@ -1,0 +1,88 @@
+//
+//  CodeBlockSelectionStaleCacheTests.swift
+//  MarkdownEngineTests
+//
+//  `updateCodeBlockSelection` cuts each block's code out of the CURRENT text
+//  with ranges from `cachedCodeBlockTokens` — a cache only the typing/caret
+//  delegate paths refresh. A programmatic content swap (document switch, an
+//  external binding change) goes through `rebuildTextStorageAndStyle`, which
+//  used to leave the cache untouched; the deferred no-`parsed` refresh in
+//  `updateNSView` then indexed the new (shorter) string with the old
+//  document's ranges and died in `-[NSString substringWithRange:]`.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Code block selection survives a programmatic content swap")
+struct CodeBlockSelectionStaleCacheTests {
+
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false), onLinkClick: nil, onInlineSelectionChange: nil
+        )
+        let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.isEditable = true
+        tv.delegate = coordinator
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        scrollView.documentView = tv
+        coordinator.textView = tv
+        // The wrapper wires a layout bridge in makeNSView; without it,
+        // `viewRect(forCharacterRange:)` bails to nil and the substring under
+        // test is never reached.
+        if let tlm = tv.textLayoutManager {
+            let bridge = LayoutBridge(tlm)
+            coordinator.layoutBridge = bridge
+            tv.layoutBridge = bridge
+        }
+        coordinator.rebuildTextStorageAndStyle(tv, from: text)
+        coordinator.lastSyncedText = text
+        coordinator.lastComputedStorage = text
+        coordinator.previousDisplayLength = (text as NSString).length
+        return (coordinator, tv)
+    }
+
+    @Test("rebuild refreshes the token cache, so the deferred refresh reads the new document")
+    func rebuildRefreshesCache() {
+        let docA = "intro\n```swift\nlet alpha = 1\n```\ntrailing prose that pads the old document out well beyond the next one"
+        let docB = "```python\nbeta = 2\n```\n"
+        let (coordinator, tv) = makeEditor(docA)
+        coordinator.updateCodeBlockSelection(textView: tv, parsed: coordinator.parsedDocument(for: docA))
+
+        // The programmatic swap `updateNSView` performs, followed by its
+        // deferred no-`parsed` refresh (closure #7 in the crash report).
+        coordinator.rebuildTextStorageAndStyle(tv, from: docB)
+        var received: [CodeBlockSelection]?
+        coordinator.onCodeBlockSelectionChange = { received = $0 }
+        coordinator.updateCodeBlockSelection(textView: tv)
+
+        let codes = (received ?? []).map(\.code)
+        #expect(codes.contains(where: { $0.contains("beta") }))
+        #expect(!codes.contains(where: { $0.contains("alpha") }))
+    }
+
+    @Test("a stale range past the end of the text is skipped, not substringed")
+    func staleRangeIsSkipped() {
+        let (coordinator, tv) = makeEditor("short")
+        // A cache entry whose contentRange outlives the text it was parsed
+        // from: block starts inside the current string, content runs past it.
+        coordinator.cachedCodeBlockTokens = [(
+            index: 0,
+            token: MarkdownToken(
+                kind: .codeBlock,
+                range: NSRange(location: 0, length: 5),
+                contentRange: NSRange(location: 2, length: 200),
+                markerRanges: []
+            )
+        )]
+        var received: [CodeBlockSelection]?
+        coordinator.onCodeBlockSelectionChange = { received = $0 }
+        coordinator.updateCodeBlockSelection(textView: tv)
+        #expect(received?.isEmpty == true)
+    }
+}


### PR DESCRIPTION
## Crash

`updateCodeBlockSelection` cuts each fenced block's code out of the current text with ranges from `cachedCodeBlockTokens`:

```swift
code: nsText.substring(with: token.contentRange)
```

That cache is only refreshed by the typing/caret delegate paths. A **programmatic content swap** — a document switch, or the SwiftUI `text` binding changing externally — goes through `rebuildTextStorageAndStyle`, which never touches the cache. The deferred refresh in `updateNSView`:

```swift
DispatchQueue.main.async {
    context.coordinator.updateCodeBlockSelection(textView: textView)
}
```

then runs with no `parsed`, indexes the new (shorter) string with the previous document's ranges, and `-[NSString substringWithRange:]` throws `NSRangeException`. Uncaught ObjC exception in a main-queue dispatch block → `abort()`. We hit this in production (macOS app embedding the engine, document with a fenced code block replaced by shorter content via sync) — crash report points exactly at `NativeTextViewCoordinator.updateCodeBlockSelection` ← `closure #7 in NativeTextViewWrapper.updateNSView`. Reproduced in a unit test (included); still present on 0.12.0 (the file is unchanged).

## Fix (two layers)

1. **Root cause** — `rebuildTextStorageAndStyle` already computes a parse of the incoming text; hand its `codeBlockTokensWithIndices` to the cache there (and clear the cache in raw source mode), so the deferred refresh always reads ranges parsed from the text it is shown with.
2. **Defence in depth** — `updateCodeBlockSelection` skips any cached block whose `range`/`contentRange` no longer fits the current text instead of substringing it, so no caller racing a content mutation can abort the process. The next parse re-delivers the block.

Includes a regression test suite (`CodeBlockSelectionStaleCacheTests`) that reproduces the abort on unpatched code and verifies both layers. Full package suite passes (298 tests).

The branch is based on the 0.11.0 tag (the version we ship); happy to rebase onto `main` if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)