### PR TITLE
Let an embedder disable the https:// prepend for a bare href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.
+- `LinkStyle.bareHrefs` (`BareHrefPolicy`) lets an embedder opt out of the
+  styler's `https://` prepend for `[label](href)` links whose `href` does not
+  already carry a scheme. `.assumeHTTPS` is the default and reproduces the
+  historical behavior exactly — the guess is right when every href in the
+  document is web-shaped. `.preserveAsWritten` hands the source string
+  through to both the `.link` attribute on the styled text and any
+  embedder-side click handler, for embedders whose hrefs are meaningful
+  outside of the web: relative paths resolved against a base directory,
+  opaque ids the embedder looks up in its own model, custom schemes
+  registered elsewhere in the app. Standalone the opt-out only silences the
+  guess; AppKit's default click handler still runs for a link that carries a
+  `.link` attribute, so a preserved bare href there resolves against no base
+  and typically opens nothing. An embedder pairs this with its own click
+  hook to get the routing it wants.
 - `MarkdownEditorConfiguration.thematicBreak` (`ThematicBreakStyle`) gives each
   thematic-break marker its own look. CommonMark treats `---`, `***` and `___`
   as one construct with one rendering, so an embedder who wanted a novel-style

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -569,20 +569,64 @@ public struct BlockquoteStyle: Sendable {
 
 // MARK: - Links
 
-/// Foreground alpha values applied to link content in different states.
+/// Foreground alpha values applied to link content in different states, plus
+/// how the styler treats a link whose `href` does not carry its own scheme.
 public struct LinkStyle: Sendable {
     /// Foreground alpha for the visible label of an active markdown link.
     public var activeLinkAlpha: CGFloat
     /// Foreground alpha applied to "incomplete" link content (e.g. `[text]`
     /// without a target).
     public var incompleteLinkAlpha: CGFloat
+    /// How the styler treats an `[label](href)` link whose `href` does not
+    /// carry a scheme. Defaults to ``BareHrefPolicy/assumeHTTPS`` so existing
+    /// documents keep opening the way they always have — see ``BareHrefPolicy``
+    /// for the reason an embedder might want to preserve the source string
+    /// instead.
+    public var bareHrefs: BareHrefPolicy
 
-    public init(activeLinkAlpha: CGFloat = 0.55, incompleteLinkAlpha: CGFloat = 0.7) {
+    public init(
+        activeLinkAlpha: CGFloat = 0.55,
+        incompleteLinkAlpha: CGFloat = 0.7,
+        bareHrefs: BareHrefPolicy = .assumeHTTPS
+    ) {
         self.activeLinkAlpha = activeLinkAlpha
         self.incompleteLinkAlpha = incompleteLinkAlpha
+        self.bareHrefs = bareHrefs
     }
 
     public static let `default` = LinkStyle()
+}
+
+/// How the styler treats an `[label](href)` link whose `href` does not
+/// carry its own scheme.
+///
+/// CommonMark leaves the choice to the renderer. The engine's historical
+/// behavior is to prepend `https://` so that a bare href like `docs/` in
+/// `[docs](docs/)` falls through to the browser rather than to some non-URL
+/// handler, which is the right guess for a document whose hrefs are all
+/// web-shaped.
+///
+/// An embedder whose `href` values are meaningful outside of the web — a
+/// relative path resolved against a base directory, an opaque id looked up
+/// in the embedder's own model, a custom scheme registered elsewhere in the
+/// app — needs the source string through untouched so it can route the
+/// click itself. Setting this to ``preserveAsWritten`` skips the prepend,
+/// so both the `.link` attribute on the styled text and any embedder-side
+/// click handler receive the `href` as authored.
+///
+/// Note: without an embedder-supplied click hook, AppKit's default handler
+/// still runs for a link with a `.link` attribute — a preserved bare href
+/// there resolves against no base and typically opens nothing. Pair this
+/// with your own click hook for the routing you want.
+public enum BareHrefPolicy: Sendable, Equatable {
+    /// Prepend `https://` to any `href` that does not already contain `://`.
+    /// The historical behavior and the default.
+    case assumeHTTPS
+
+    /// Hand the source `href` to the styler and click delegate unchanged.
+    /// Use this when your hrefs are meaningful outside of the web (relative
+    /// paths, opaque ids, custom schemes registered elsewhere in your app).
+    case preserveAsWritten
 }
 
 // MARK: - Paragraphs

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -861,7 +861,10 @@ enum MarkdownASTStyler {
     ) {
         attrs.append((range, [.spellingState: 0]))
         var urlString = ctx.ns.substring(with: urlRange)
-        if !urlString.contains("://") { urlString = "https://\(urlString)" }
+        // Historical https:// prepend; see `BareHrefPolicy` for the opt-out.
+        if ctx.config.link.bareHrefs == .assumeHTTPS, !urlString.contains("://") {
+            urlString = "https://\(urlString)"
+        }
         let isActive = ctx.isActive(range)
         if let url = URL(string: urlString) {
             if isActive {

--- a/Tests/MarkdownEngineTests/BareHrefPolicyTests.swift
+++ b/Tests/MarkdownEngineTests/BareHrefPolicyTests.swift
@@ -1,0 +1,85 @@
+//
+//  BareHrefPolicyTests.swift
+//  MarkdownEngineTests
+//
+//  The styler used to unconditionally prepend `https://` to any `[label](href)`
+//  whose `href` did not already carry `://`, on the assumption that every href
+//  is web-shaped. `LinkStyle.bareHrefs` lets an embedder opt out of the guess
+//  when its hrefs are meaningful outside of the web (relative paths, opaque
+//  ids, custom schemes registered elsewhere in the app). These tests pin the
+//  default at the historical behavior and the opt-out at end-to-end pass-through.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("LinkStyle.bareHrefs")
+struct BareHrefPolicyTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    /// The `.link` NSAttributedString attribute the styler emits for the label
+    /// range of a link. Returns nil if no link ran there.
+    private func linkURL(in attrs: [StyledRange], covering location: Int) -> URL? {
+        for (range, dict) in attrs {
+            if NSLocationInRange(location, range), let url = dict[.link] as? URL {
+                return url
+            }
+        }
+        return nil
+    }
+
+    @Test("default preserves the historical https:// prepend for a bare href")
+    func defaultPolicyPrependsHTTPS() {
+        let text = "[docs](docs/)"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: .default
+        )
+        // Label starts after the `[`, so the .link attribute sits at index 1.
+        let url = linkURL(in: attrs, covering: 1)
+        #expect(url?.absoluteString == "https://docs/")
+    }
+
+    @Test("default leaves a scheme-carrying href alone")
+    func defaultPolicyLeavesSchemeHrefAlone() {
+        let text = "[docs](https://example.com/docs)"
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: .default
+        )
+        let url = linkURL(in: attrs, covering: 1)
+        #expect(url?.absoluteString == "https://example.com/docs")
+    }
+
+    @Test("preserveAsWritten hands the source href through untouched")
+    func preserveAsWrittenHandsSourceHrefThrough() {
+        let text = "[docs](docs/)"
+        var config = MarkdownEditorConfiguration.default
+        config.link = LinkStyle(bareHrefs: .preserveAsWritten)
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: config
+        )
+        let url = linkURL(in: attrs, covering: 1)
+        // No prepend: the URL is exactly the source href, and stays relative.
+        #expect(url?.absoluteString == "docs/")
+    }
+
+    @Test("preserveAsWritten still passes through a scheme-carrying href unchanged")
+    func preserveAsWrittenLeavesSchemeHrefAlone() {
+        let text = "[docs](https://example.com/docs)"
+        var config = MarkdownEditorConfiguration.default
+        config.link = LinkStyle(bareHrefs: .preserveAsWritten)
+        let attrs = MarkdownASTStyler.styleAttributes(
+            text: text, fontName: fontName, fontSize: base,
+            configuration: config
+        )
+        let url = linkURL(in: attrs, covering: 1)
+        #expect(url?.absoluteString == "https://example.com/docs")
+    }
+}


### PR DESCRIPTION
The styler rewrites `[label](href)` to `https://href` any time the href does not contain `://`. That is the right guess when every href in the document is a web URL. `[docs](docs/)` opens the browser instead of falling through to some non-URL handler.

The rewrite is wrong when an embedder uses hrefs that are not web URLs. Relative paths that resolve against a base directory, opaque ids looked up in the embedder's own model, and custom schemes registered elsewhere in the app all lose their original text. By the time the click delegate sees the value, the target is `https://<original>` rather than the string on disk. `[docs](docs/)` reaches the delegate as `https://docs/`.

## What's added

`LinkStyle.bareHrefs` (`BareHrefPolicy`) picks the behavior:

- `.assumeHTTPS` (default) prepends `https://` to any href that does
  not already contain `://`. Byte-identical to the previous behavior.
- `.preserveAsWritten` hands the source href through unchanged to
  both the `.link` attribute on the styled text and any embedder click handler. `[docs](docs/)` reaches the delegate as `docs/`.

The default keeps every current embedder's behavior. `.preserveAsWritten` alone does not stop AppKit's default handler from following the `.link` attribute, so a preserved bare href resolves against no base and typically opens nothing. Pair it with an embedder click hook to route the click.

## Tests

`Tests/MarkdownEngineTests/BareHrefPolicyTests.swift` covers each policy against a bare href and one that already includes a scheme.

`swift build` and `swift test` are green.
