### PR TITLE
Let an embedder route Markdown URL clicks through their own model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.
+- `NativeTextViewWrapper.onURLLinkClick` lets an embedder route a click on a
+  `[label](href)` link through its own model instead of falling straight
+  through to AppKit's `NSWorkspace.open`. The parallel to the existing
+  `onLinkClick` — which already covered wiki links — closes the gap for a
+  document whose Markdown URL hrefs are meaningful to the embedder (open
+  the target with the right app, navigate inside the app, resolve a
+  relative href against a base directory). The hook receives the URL the
+  styler attached to the label (see `LinkStyle.bareHrefs` for how bare
+  hrefs are shaped) and the label's range in the current display text, so
+  it can correlate the click with the embedder's own document model without
+  reaching into the text view. Returning `true` consumes the click;
+  returning `false` (or leaving the hook `nil`) falls back to the previous
+  behavior. Wiki-link clicks still go through `onLinkClick` — this hook is
+  Markdown-URL-links only.
 - `MarkdownEditorConfiguration.thematicBreak` (`ThematicBreakStyle`) gives each
   thematic-break marker its own look. CommonMark treats `---`, `***` and `___`
   as one construct with one rendering, so an embedder who wanted a novel-style

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -998,10 +998,23 @@ extension NativeTextViewCoordinator {
             }
         }
         guard let target = WikiLinkService.resolveIdentifier(link: link, textView: textView, at: charIndex) else {
-            // Web link (URL-valued): returning false lets AppKit open the URL
-            // (the mouseDown fallback mirrors that). Opening a link is navigation
-            // too — flag it so mouseDown restores the pre-click caret.
+            // Web link (URL-valued): offer it to the embedder first, then fall
+            // through to AppKit's default `NSWorkspace.open` when the embedder
+            // doesn't consume the click. The hook receives the same URL the
+            // styler wrote to the label's `.link` attribute and the label's
+            // range in the current display text, so it can route the click
+            // against its own document model without introspecting the view.
+            // Opening a link is navigation either way — flag it so mouseDown
+            // restores the pre-click caret.
             (textView as? NativeTextView)?.linkClickDidNavigate = true
+            if let onURLLinkClick, let url = link as? URL, let storage = textView.textStorage {
+                var linkRange = NSRange(location: NSNotFound, length: 0)
+                _ = storage.attribute(
+                    .link, at: charIndex, longestEffectiveRange: &linkRange,
+                    in: NSRange(location: 0, length: storage.length)
+                )
+                if onURLLinkClick(url, linkRange) { return true }
+            }
             return false
         }
         // Direkt deaktivieren, bevor der Navigation-Callback läuft.

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -77,6 +77,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     var layoutBridge: LayoutBridge?
     var layoutDelegate: MarkdownLayoutManagerDelegate?
     var onLinkClick: ((String) -> Void)?
+    var onURLLinkClick: ((URL, NSRange) -> Bool)?
     var onCaretRectChange: ((CGRect) -> Void)?
     var onTextMutation: ((MarkdownTextMutation) -> Void)?
     /// Embedder hook to build the right-click menu (the engine ships none). Gets the
@@ -283,12 +284,14 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
          fontSize: CGFloat,
          isWikiLinkActive: Binding<Bool>,
          onLinkClick: ((String) -> Void)?,
+         onURLLinkClick: ((URL, NSRange) -> Bool)? = nil,
          onInlineSelectionChange: ((InlineSelectionState?) -> Void)?) {
         _text = text
         self.fontName = fontName
         self.fontSize = fontSize
         _isWikiLinkActive = isWikiLinkActive
         self.onLinkClick = onLinkClick
+        self.onURLLinkClick = onURLLinkClick
         self.onCaretRectChange = nil
         self.onInlineSelectionChange = onInlineSelectionChange
         self.lastSyncedText = text.wrappedValue

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -80,6 +80,13 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     /// resolved opaque identifier (or the display name when no resolver
     /// was supplied).
     public var onLinkClick: ((String) -> Void)?
+    /// Fires when the user clicks a Markdown URL link (`[label](href)`), so
+    /// an embedder can route the click through its own model instead of
+    /// AppKit's default `NSWorkspace.open`. The URL is what the styler wrote
+    /// to `.link` (see ``LinkStyle/bareHrefs`` for how bare hrefs are shaped);
+    /// the range is the label's span in display text. Return `true` to
+    /// consume; `false` or `nil` falls back to AppKit.
+    public var onURLLinkClick: ((URL, NSRange) -> Bool)?
     /// Fires whenever the caret rect inside an active wiki-link changes,
     /// so embedders can position a follow-the-caret UI.
     public var onCaretRectChange: ((CGRect) -> Void)?
@@ -152,6 +159,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         isEditable: Bool = true,
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
+        onURLLinkClick: ((URL, NSRange) -> Bool)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
         onTextMutation: ((MarkdownTextMutation) -> Void)? = nil,
         onBuildContextMenu: ((NSMenu, NSRange) -> NSMenu)? = nil,
@@ -178,6 +186,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.isEditable = isEditable
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
+        self.onURLLinkClick = onURLLinkClick
         self.onCaretRectChange = onCaretRectChange
         self.onTextMutation = onTextMutation
         self.onBuildContextMenu = onBuildContextMenu
@@ -702,6 +711,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.onInlineSelectionChange = onInlineSelectionChange
         context.coordinator.onInlinePreviewKey = onInlinePreviewKey
         context.coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
+        // Refresh alongside the other callbacks so an embedder can swap the
+        // URL-click handler between updates without remounting the editor.
+        context.coordinator.onURLLinkClick = onURLLinkClick
         context.coordinator.didInitialFormatting = true
     }
 
@@ -712,6 +724,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             fontSize: fontSize,
             isWikiLinkActive: $isWikiLinkActive,
             onLinkClick: onLinkClick,
+            onURLLinkClick: onURLLinkClick,
             onInlineSelectionChange: onInlineSelectionChange
         )
         coordinator.documentId = documentId

--- a/Tests/MarkdownEngineTests/URLLinkClickCallbackTests.swift
+++ b/Tests/MarkdownEngineTests/URLLinkClickCallbackTests.swift
@@ -1,0 +1,120 @@
+//
+//  URLLinkClickCallbackTests.swift
+//  MarkdownEngineTests
+//
+//  `onLinkClick` already lets embedders route `[[Name]]` clicks through their
+//  own model. Regular `[label](href)` clicks used to fall straight through to
+//  AppKit's `NSWorkspace.open`, with no seam for an embedder that wanted to
+//  route them itself (open the target with the right app, navigate inside its
+//  own app, resolve a relative href against a base directory). These tests pin
+//  the new `onURLLinkClick` hook: it fires with the URL the styler attached
+//  and the label's range, its return value decides whether the click is
+//  consumed here or handed back to AppKit, and a wiki-link click still goes
+//  through `onLinkClick` — the URL hook is only for Markdown URL links.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("onURLLinkClick fires for `[label](href)` clicks")
+struct URLLinkClickCallbackTests {
+
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text), fontName: "SF Pro", fontSize: 16,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onURLLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        let tv = NativeTextView(frame: NSRect(x: 0, y: 0, width: 600, height: 400))
+        tv.isEditable = false     // read-only so the click delegate's edit-zone branch stays out of the way
+        tv.delegate = coordinator
+        coordinator.textView = tv
+        coordinator.rebuildTextStorageAndStyle(tv, from: text)
+        coordinator.lastSyncedText = text
+        return (coordinator, tv)
+    }
+
+    /// The range of the `.link` attribute at `location`, or `NSNotFound` when
+    /// nothing is styled as a link there.
+    private func linkRange(in tv: NSTextView, at location: Int) -> NSRange {
+        guard let storage = tv.textStorage else { return NSRange(location: NSNotFound, length: 0) }
+        var range = NSRange(location: NSNotFound, length: 0)
+        _ = storage.attribute(
+            .link, at: location, longestEffectiveRange: &range,
+            in: NSRange(location: 0, length: storage.length)
+        )
+        return range
+    }
+
+    @Test("returning true consumes the click and skips AppKit's default handler")
+    func handlerReturningTrueConsumesClick() {
+        let text = "[docs](https://example.com/docs)"
+        let (coordinator, tv) = makeEditor(text)
+        var received: (URL, NSRange)?
+        coordinator.onURLLinkClick = { url, range in
+            received = (url, range)
+            return true
+        }
+        let clickIndex = 1        // inside "docs"
+        let label = linkRange(in: tv, at: clickIndex)
+        let handled = coordinator.textView(
+            tv, clickedOnLink: URL(string: "https://example.com/docs")!, at: clickIndex
+        )
+        #expect(handled == true)
+        #expect(received?.0.absoluteString == "https://example.com/docs")
+        #expect(received?.1 == label)
+    }
+
+    @Test("returning false hands the click back to AppKit")
+    func handlerReturningFalseFallsThrough() {
+        let text = "[docs](https://example.com/docs)"
+        let (coordinator, tv) = makeEditor(text)
+        var fired = false
+        coordinator.onURLLinkClick = { _, _ in
+            fired = true
+            return false
+        }
+        let handled = coordinator.textView(
+            tv, clickedOnLink: URL(string: "https://example.com/docs")!, at: 1
+        )
+        #expect(fired == true)
+        #expect(handled == false)   // AppKit takes it from here
+    }
+
+    @Test("no handler leaves the historical AppKit-open behavior intact")
+    func noHandlerFallsThrough() {
+        let text = "[docs](https://example.com/docs)"
+        let (coordinator, tv) = makeEditor(text)
+        let handled = coordinator.textView(
+            tv, clickedOnLink: URL(string: "https://example.com/docs")!, at: 1
+        )
+        #expect(handled == false)
+    }
+
+    @Test("a wiki-link click ignores onURLLinkClick and goes through onLinkClick")
+    func wikiLinkClickBypassesURLHook() async {
+        let text = "[[Note]]"
+        let (coordinator, tv) = makeEditor(text)
+        var urlHookFired = false
+        var wikiTarget: String?
+        coordinator.onURLLinkClick = { _, _ in urlHookFired = true; return true }
+        coordinator.onLinkClick = { wikiTarget = $0 }
+        // WikiLinkService.resolveIdentifier trusts the storage's .wikiLink attribute,
+        // which the styler wrote to the label range.
+        let handled = coordinator.textView(
+            tv, clickedOnLink: NSString(string: "Note"), at: 2
+        )
+        // Wiki-link clicks resolve to true (the coordinator handles them itself).
+        #expect(handled == true)
+        // Wait one tick for the async dispatch inside the wiki-link branch.
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        #expect(urlHookFired == false)
+        #expect(wikiTarget == "Note")
+    }
+}


### PR DESCRIPTION
`NativeTextViewWrapper.onLinkClick` already covers `[[Name]]` clicks. A click on a regular `[label](href)` link falls through to AppKit's `NSWorkspace.open` with no seam for the embedder to intercept.

An embedder whose Markdown URLs mean something outside of the web has no way to route the click. Relative paths against a base directory, opaque ids, and custom schemes all require intercepting `textView(_:clickedOnLink:at:)` from outside the engine. The current workaround is to walk the view tree, find the underlying `NSTextView`, and install a proxy delegate that steals the method.

## What's added

`NativeTextViewWrapper.onURLLinkClick: ((URL, NSRange) -> Bool)?` closes the gap. The closure receives the URL that the styler wrote onto the label's `.link` attribute and the label's range in the current display text. The return value decides who handles the click. Returning `true` consumes it and skips AppKit's default handler. Returning `false` (or leaving the hook nil) falls back to the previous behavior. The closure runs synchronously because the delegate's return value has to travel back into AppKit on the same call.

`updateNSView` refreshes the hook alongside the other coordinator callbacks, so an embedder can swap it between updates without remounting.

Wiki links still route through `onLinkClick`. The URL hook only fires on `[label](href)`.

## Tests

`Tests/MarkdownEngineTests/URLLinkClickCallbackTests.swift` covers four behaviors:

- Returning `true` consumes the click and reports the URL plus the
  label range.
- Returning `false` hands the click back to AppKit.
- An unset hook preserves the previous behavior.
- A wiki-link click bypasses the URL hook and still routes through
  `onLinkClick`.

`swift build` and `swift test` are green.
