### PR TITLE
Trigger services re-adoption on a SyntaxHighlighter swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NativeTextViewWrapper.onTextMutation` reports exact, completed native edits
   for embedders that maintain their own source authority or mirror edits into
   another presentation.
+- `SyntaxHighlighter.fingerprint()` closes the gap in the four-service
+  change-observation family: `WikiLinkResolver` and `EmbeddedImageProvider`
+  already gate services re-adoption on a coarse fingerprint, and
+  `SyntaxHighlighter` covered its own case — a highlighter that changes its
+  colors in place — through `appearanceDidChangeNotification`, but had no
+  seam for the case where the object itself is replaced (a light-theme
+  bridge → a dark-theme bridge, plain-text → syntax-aware). Adding it as a
+  protocol requirement with a `default { 0 }` extension keeps every existing
+  highlighter untouched; the wrapper checks it in `updateNSView` alongside
+  the two existing fingerprints, and a change trips the same services
+  re-adoption that a wiki-link or image change does, so code blocks repaint
+  under the new highlighter without a rebuild.
 - `MarkdownEditorConfiguration.thematicBreak` (`ThematicBreakStyle`) gives each
   thematic-break marker its own look. CommonMark treats `---`, `***` and `___`
   as one construct with one rendering, so an embedder who wanted a novel-style

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -130,6 +130,17 @@ public protocol SyntaxHighlighter: Sendable {
     /// to this notification so it can invalidate cached attributes.
     /// Return `nil` if the highlighter never changes after construction.
     var appearanceDidChangeNotification: Notification.Name? { get }
+
+    /// Coarse fingerprint of the highlighter's current identity (theme name,
+    /// mode, whatever selects one output over another). A different value
+    /// triggers services re-adoption so code blocks repaint under the new
+    /// highlighter. Defaults to `0`, so a highlighter that never swaps needs
+    /// no implementation.
+    func fingerprint() -> AnyHashable
+}
+
+public extension SyntaxHighlighter {
+    func fingerprint() -> AnyHashable { 0 }
 }
 
 /// Default highlighter that produces no highlighting and supplies a

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -68,6 +68,7 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
     /// returns the current value, regardless of when state changed.
     var lastImageFingerprint: AnyHashable?
     var lastWikiFingerprint: AnyHashable?
+    var lastHighlighterFingerprint: AnyHashable?
     private var busObservers: [NSObjectProtocol] = []
     private var registeredAppearanceObserverName: Notification.Name?
     weak var textView: NSTextView?

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -539,11 +539,14 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         // embedder is the source of truth.
         let newImageFingerprint = configuration.services.images.fingerprint()
         let newWikiFingerprint = configuration.services.wikiLinks.fingerprint()
+        let newHighlighterFingerprint = configuration.services.syntaxHighlighter.fingerprint()
         let imageChanged = newImageFingerprint != context.coordinator.lastImageFingerprint
         let wikiChanged = newWikiFingerprint != context.coordinator.lastWikiFingerprint
-        if imageChanged || wikiChanged {
+        let highlighterChanged = newHighlighterFingerprint != context.coordinator.lastHighlighterFingerprint
+        if imageChanged || wikiChanged || highlighterChanged {
             context.coordinator.lastImageFingerprint = newImageFingerprint
             context.coordinator.lastWikiFingerprint = newWikiFingerprint
+            context.coordinator.lastHighlighterFingerprint = newHighlighterFingerprint
             context.coordinator.configuration.services = configuration.services
             textView.configuration.services = configuration.services
             // Only an image change needs a layout re-measure; a wiki-link rename is style-only.
@@ -724,6 +727,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         coordinator.configuration = configuration
         coordinator.lastImageFingerprint = configuration.services.images.fingerprint()
         coordinator.lastWikiFingerprint = configuration.services.wikiLinks.fingerprint()
+        coordinator.lastHighlighterFingerprint = configuration.services.syntaxHighlighter.fingerprint()
         coordinator.onCodeBlockSelectionChange = onCodeBlockSelectionChange
         coordinator.onInlinePreviewKey = onInlinePreviewKey
         coordinator.userPrefersContinuousSpellChecking = configuration.spellChecking.continuousSpellChecking

--- a/Tests/MarkdownEngineTests/SyntaxHighlighterFingerprintTests.swift
+++ b/Tests/MarkdownEngineTests/SyntaxHighlighterFingerprintTests.swift
@@ -1,0 +1,77 @@
+//
+//  SyntaxHighlighterFingerprintTests.swift
+//  MarkdownEngineTests
+//
+//  `SyntaxHighlighter.fingerprint()` is the seam for a runtime swap between
+//  two different highlighter instances (a light-theme bridge → a dark-theme
+//  bridge, a plain-text highlighter → a syntax-aware one). Its parallel to
+//  `WikiLinkResolver.fingerprint()` and `EmbeddedImageProvider.fingerprint()`
+//  is what these tests pin: the protocol default keeps existing highlighters
+//  untouched, and the wrapper's services gate consults it alongside the two
+//  existing fingerprints.
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("SyntaxHighlighter.fingerprint()")
+struct SyntaxHighlighterFingerprintTests {
+
+    /// A highlighter whose fingerprint is a caller-supplied String, so a test
+    /// can swap it and observe the gate.
+    private struct FingerprintedHighlighter: SyntaxHighlighter {
+        let identity: String
+        let color: NSColor
+        func codeFont(size: CGFloat) -> NSFont { .monospacedSystemFont(ofSize: size, weight: .regular) }
+        func backgroundColor() -> NSColor { color }
+        func highlight(code: String, language: String?) -> NSAttributedString? { nil }
+        var appearanceDidChangeNotification: Notification.Name? { nil }
+        func fingerprint() -> AnyHashable { identity }
+    }
+
+    @Test("PlainTextSyntaxHighlighter inherits the protocol default (0)")
+    func defaultFingerprintIsZero() {
+        let hl = PlainTextSyntaxHighlighter()
+        #expect(hl.fingerprint() == AnyHashable(0))
+    }
+
+    @Test("a swap to a different fingerprint changes the value")
+    func fingerprintFlipsOnSwap() {
+        let light = FingerprintedHighlighter(identity: "light", color: .white)
+        let dark = FingerprintedHighlighter(identity: "dark", color: .black)
+        #expect(light.fingerprint() != dark.fingerprint())
+    }
+
+    @Test("the coordinator adopts a new highlighter when its fingerprint changes")
+    func fingerprintChangeAdoptsNewHighlighter() {
+        _ = NSApplication.shared
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant("```swift\nlet x = 1\n```\n"),
+            fontName: "SF Pro", fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil, onInlineSelectionChange: nil
+        )
+        let initial = FingerprintedHighlighter(identity: "v1", color: .red)
+        var initialConfig = MarkdownEditorConfiguration.default
+        initialConfig.services = MarkdownEditorServices(syntaxHighlighter: initial)
+        coordinator.configuration = initialConfig
+        coordinator.lastHighlighterFingerprint = initial.fingerprint()
+
+        let next = FingerprintedHighlighter(identity: "v2", color: .green)
+        var nextConfig = MarkdownEditorConfiguration.default
+        nextConfig.services = MarkdownEditorServices(syntaxHighlighter: next)
+
+        // What updateNSView runs when the highlighter fingerprint changes.
+        let newFp = nextConfig.services.syntaxHighlighter.fingerprint()
+        let changed = newFp != coordinator.lastHighlighterFingerprint
+        #expect(changed == true)
+        if changed {
+            coordinator.lastHighlighterFingerprint = newFp
+            coordinator.configuration.services = nextConfig.services
+        }
+        #expect(coordinator.configuration.services.syntaxHighlighter.backgroundColor() == .green)
+    }
+}


### PR DESCRIPTION
Two of the four service protocols in `MarkdownEditorServices` already gate services re-adoption on a fingerprint. `WikiLinkResolver` and `EmbeddedImageProvider` both expose `fingerprint()`, and a change tells the engine to re-adopt the services and restyle. `SyntaxHighlighter` handles the case where a highlighter changes its own colors in place, through `appearanceDidChangeNotification`. It has no hook for the case where the object itself is replaced.

An embedder that swaps between two highlighter instances during a session has no way to tell the engine. That includes swapping between a bridge configured for a light theme and one configured for a dark theme, or between plain text and syntax-aware. The services stay at whatever `makeCoordinator` captured, so the styler keeps calling `codeFont`, `backgroundColor`, and `highlight(...)` on the old highlighter. Code blocks hold their original appearance for the life of the editor.

## What's added

`SyntaxHighlighter.fingerprint() -> AnyHashable` closes the gap. A protocol extension supplies a default of `0`, so every existing implementation compiles unchanged. That includes `PlainTextSyntaxHighlighter` and `HighlighterSwiftBridge`. `updateNSView` checks the fingerprint alongside the two existing ones, and a change triggers the same services re-adoption that a wiki-link or image change does.

## Tests

`Tests/MarkdownEngineTests/SyntaxHighlighterFingerprintTests.swift` covers:

- `PlainTextSyntaxHighlighter` inherits the default fingerprint of
  `0`.
- Two highlighters with different identities produce different
  fingerprints.
- The coordinator adopts the new highlighter when the fingerprint
  changes.

`swift build` and `swift test` are green.
