### PR TITLE
Carry the theme's link decoration through to the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line-break, programmatic, and undo/redo edits still widen ordered-list runs
   when downstream display numbers can change.
 
+### Fixed
+- `MarkdownEditorTheme.link` reaches the screen. `NSTextView` layers its
+  `linkTextAttributes` over every `.link` range at display time — on top of
+  whatever foreground the styler emitted — and AppKit's default paints
+  those with `.linkColor` blue, so an embedder's custom link ink was
+  silently overridden after being computed and emitted. `MarkdownEditorTheme`
+  now exposes a computed `linkTextAttributes` (theme link ink + theme
+  underline + pointing-hand cursor — the same decoration AppKit's default
+  carries), and `NativeTextViewWrapper` assigns it to the text view in
+  `makeNSView` and refreshes it in `updateNSView` alongside the
+  `insertionPointColor` refresh. The theme owns the underline too:
+  `MarkdownEditorTheme.linkUnderlineStyle` defaults to `.single` (AppKit's
+  stock look), and `[]` drops it entirely for palettes where an underlined
+  link reads as clutter. With the default theme, `link` is `.linkColor`
+  and `linkUnderlineStyle` is `.single`, so the rendered result is
+  pixel-identical to before. Custom palettes finally get both configured.
+
 ## [0.12.0] - 2026-08-10
 
 ### Added

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -79,6 +79,14 @@ public struct MarkdownEditorTheme: Sendable {
     /// Background color used for `==highlight==` inline markup.
     public var highlightColor: NSColor
 
+    // MARK: Link decoration
+
+    /// Underline style AppKit paints over every `.link` range. Defaults to
+    /// `.single` to match AppKit's stock link look; `[]` drops the underline
+    /// for palettes where an underlined link reads as clutter (a Mono canvas,
+    /// a poster-style page). Composes into ``linkTextAttributes``.
+    public var linkUnderlineStyle: NSUnderlineStyle
+
     // MARK: Init
 
     public init(
@@ -93,7 +101,8 @@ public struct MarkdownEditorTheme: Sendable {
         latexLightModeText: NSColor = .black,
         latexDarkModeText: NSColor = .white,
         strikethroughColor: NSColor = .labelColor,
-        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4)
+        highlightColor: NSColor = .systemOrange.withAlphaComponent(0.4),
+        linkUnderlineStyle: NSUnderlineStyle = .single
     ) {
         self.bodyText = bodyText
         self.mutedText = mutedText
@@ -107,6 +116,7 @@ public struct MarkdownEditorTheme: Sendable {
         self.latexDarkModeText = latexDarkModeText
         self.strikethroughColor = strikethroughColor
         self.highlightColor = highlightColor
+        self.linkUnderlineStyle = linkUnderlineStyle
     }
 
     /// System-native palette built from `NSColor` dynamic system colors.
@@ -114,4 +124,23 @@ public struct MarkdownEditorTheme: Sendable {
     /// Use this if you want the engine to look like a stock macOS
     /// `NSTextView`. It's also the default when no theme is supplied.
     public static let `default` = MarkdownEditorTheme()
+
+    /// Attributes AppKit paints over every `.link` range at display time.
+    ///
+    /// `NSTextView` layers `linkTextAttributes` on top of whatever
+    /// foreground the styler set, so a custom `link` color computed and
+    /// emitted upstream still gets overwritten by AppKit's stock
+    /// `.linkColor` blue at draw. Assigning this to `textView.linkTextAttributes`
+    /// (which the wrapper does) carries the theme's link decoration —
+    /// `link` color and `linkUnderlineStyle` — through to the screen along
+    /// with the pointing-hand cursor AppKit's default carries. For the
+    /// default theme, `link` is `.linkColor` and `linkUnderlineStyle` is
+    /// `.single`, so the rendered result is pixel-identical to before.
+    public var linkTextAttributes: [NSAttributedString.Key: Any] {
+        [
+            .foregroundColor: link,
+            .underlineStyle: linkUnderlineStyle.rawValue,
+            .cursor: NSCursor.pointingHand,
+        ]
+    }
 }

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -263,6 +263,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.minOverscrollPoints = configuration.overscroll.minPoints
         context.coordinator.configuration = configuration
         textView.insertionPointColor = configuration.theme.bodyText
+        textView.linkTextAttributes = configuration.theme.linkTextAttributes
         textView.isEditable = isEditable
         textView.isSelectable = true
         textView.isRichText = true
@@ -563,6 +564,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.insertionPointColor = isEditable
             ? (context.coordinator.resolvedCaretColor ?? context.coordinator.configuration.theme.bodyText)
             : .clear
+        textView.linkTextAttributes = context.coordinator.configuration.theme.linkTextAttributes
         let fontChanged = (context.coordinator.fontName != fontName) || (context.coordinator.fontSize != fontSize)
         if let pendingInlineReplacement {
             if pendingInlineReplacement.documentId == documentId,

--- a/Tests/MarkdownEngineTests/LinkTextAttributesTests.swift
+++ b/Tests/MarkdownEngineTests/LinkTextAttributesTests.swift
@@ -1,0 +1,43 @@
+//
+//  LinkTextAttributesTests.swift
+//  MarkdownEngineTests
+//
+//  `NSTextView.linkTextAttributes` layers over every `.link` range at
+//  display time, so a theme's `link` color emitted upstream is repainted
+//  by AppKit's stock `.linkColor` blue unless the wrapper carries the
+//  theme through this attribute too. These tests pin the default at
+//  AppKit's stock look and a custom theme at the color it configures.
+//
+
+import AppKit
+import Testing
+@testable import MarkdownEngine
+
+@Suite("Theme.linkTextAttributes")
+struct LinkTextAttributesTests {
+
+    @Test("default theme matches AppKit's stock link look")
+    func defaultThemeMatchesAppKitStock() {
+        let attrs = MarkdownEditorTheme.default.linkTextAttributes
+        #expect(attrs[.foregroundColor] as? NSColor == .linkColor)
+        #expect(attrs[.underlineStyle] as? Int == NSUnderlineStyle.single.rawValue)
+        #expect(attrs[.cursor] as? NSCursor == NSCursor.pointingHand)
+    }
+
+    @Test("a custom link color reaches linkTextAttributes")
+    func customLinkColorReachesLinkTextAttributes() {
+        let theme = MarkdownEditorTheme(link: .white)
+        let attrs = theme.linkTextAttributes
+        #expect(attrs[.foregroundColor] as? NSColor == .white)
+        #expect(attrs[.underlineStyle] as? Int == NSUnderlineStyle.single.rawValue)
+    }
+
+    @Test("linkUnderlineStyle = [] drops the underline")
+    func customLinkUnderlineStyleReachesLinkTextAttributes() {
+        let none = MarkdownEditorTheme(linkUnderlineStyle: [])
+        #expect(none.linkTextAttributes[.underlineStyle] as? Int == 0)
+
+        let thick = MarkdownEditorTheme(linkUnderlineStyle: .thick)
+        #expect(thick.linkTextAttributes[.underlineStyle] as? Int == NSUnderlineStyle.thick.rawValue)
+    }
+}


### PR DESCRIPTION
Setting `MarkdownEditorTheme.link` has no visible effect. `NSTextView` layers its `linkTextAttributes` over every `.link` range at display time, on top of whatever foreground the styler set. AppKit's default paints them with `.linkColor` (system blue). A custom link color gets computed, emitted into `[StyledRange]`, applied to the text storage, and then silently overridden on screen.

An embedder that sets `theme.link = .white` on a dark canvas still sees a blue link. This makes building color themes difficult.

## What's fixed

`MarkdownEditorTheme` now exposes a computed `linkTextAttributes`. It carries the theme's link color, a configurable underline style, and the same pointing-hand cursor AppKit's default carries. `NativeTextViewWrapper` assigns it in `makeNSView` and refreshes it in `updateNSView` alongside the existing `insertionPointColor` refresh.

The theme also controls the underline through `MarkdownEditorTheme.linkUnderlineStyle`, which defaults to `.single`. That matches AppKit's stock look. Setting it to `[]` drops the underline for palettes where it reads as clutter, such as a monospace canvas or a poster-style page.

Passing a theme built with defaults leaves the rendered result pixel-identical to before.

## Tests

`Tests/MarkdownEngineTests/LinkTextAttributesTests.swift` covers:

- The default theme's attributes match AppKit's stock link look:
  `.linkColor`, `.single` underline, pointing-hand cursor.
- A custom `link` color reaches the attributes.
- Setting `linkUnderlineStyle` to `[]` or `.thick` propagates
  through.

`swift build` and `swift test` are green.
