### PR TITLE
MarkdownEditorConfiguration.hidesInactiveMarkers: keep syntax markers visible in a styled document (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`MarkdownEditorConfiguration.hidesInactiveMarkers`** (default `true`, the
+  current behavior): set it to `false` for a source-style pane that keeps every
+  syntax marker on screen — headings, emphasis, fences, blockquote `>`, link
+  brackets — while the document stays fully styled, code blocks included. It is
+  not `rawSourceMode`, which turns styling off and gives up smart input and the
+  wiki-link display transform. Markers standing in for drawn content (task
+  checkboxes, bullets, thematic breaks, image embeds, LaTeX) keep hiding either
+  way, since revealing them would draw the glyph and its source at once.
 - **Directive seam (parsing)**: opt-in named inline commands with typed
   arguments, for constructs that need a name and parameters rather than
   delimiters. A `MarkdownDirective` declares a name, a form — self-contained

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -71,6 +71,24 @@ public struct MarkdownEditorConfiguration: Sendable {
     /// Runtime-switchable; a flip rebuilds immediately and drops the document's
     /// undo stack (actions from the other mode would replay at stale ranges).
     public var rawSourceMode: Bool
+    /// Hide a syntax marker (`#`, `**`, `` ` ``, `>`, link brackets) once the
+    /// caret leaves its span. `true` — the default — is the live-styling look
+    /// the engine is built around.
+    ///
+    /// Set it to `false` for a source-style pane that keeps every marker on
+    /// screen while still styling the document: headings stay large, code
+    /// blocks keep their background and syntax highlighting, and the markers
+    /// render in ``MarkdownEditorTheme/mutedText`` at their normal size —
+    /// exactly what an active span already looks like, applied everywhere.
+    ///
+    /// This is not ``rawSourceMode``: styling stays on, so the two differ in
+    /// what they cost you. ``rawSourceMode`` also drops smart input and the
+    /// wiki-link display transform; this leaves both intact.
+    ///
+    /// Markers that stand in for drawn content — task checkboxes, list
+    /// bullets, thematic breaks, image embeds, LaTeX — keep hiding either way.
+    /// Revealing them would double-draw the glyph and its source.
+    public var hidesInactiveMarkers: Bool
     /// Opt-in constructs beyond pure markdown (e.g. `==highlight==`). Empty by
     /// default: unregistered syntax stays literal text. Order defines match
     /// precedence among extensions; built-in constructs always win first.
@@ -117,6 +135,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         spellChecking: SpellCheckingPolicy = .default,
         heightBehavior: HeightBehavior = .scrolls,
         rawSourceMode: Bool = false,
+        hidesInactiveMarkers: Bool = true,
         extensions: [any MarkdownExtension] = [],
         cursorFollowsSpanInk: Bool = false,
         directives: [any MarkdownDirective] = [],
@@ -146,6 +165,7 @@ public struct MarkdownEditorConfiguration: Sendable {
         self.spellChecking = spellChecking
         self.heightBehavior = heightBehavior
         self.rawSourceMode = rawSourceMode
+        self.hidesInactiveMarkers = hidesInactiveMarkers
         self.extensions = extensions
         self.cursorFollowsSpanInk = cursorFollowsSpanInk
         self.directives = directives

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -77,7 +77,11 @@ enum MarkdownASTStyler {
         for block in blocks where ctx.inScope(block.range) {
             styleBlock(block, font: baseFont, ctx: ctx, into: &attrs)
         }
-        shrinkInactiveMarkers(in: blocks, ctx: ctx, into: &attrs)
+        // The one pass that hides heading and inline markers; skipping it is what
+        // `hidesInactiveMarkers: false` means. Everything else still styles.
+        if configuration.hidesInactiveMarkers {
+            shrinkInactiveMarkers(in: blocks, ctx: ctx, into: &attrs)
+        }
 
         // Text/regex passes (AST-agnostic); AST code ranges drive the "skip inside code" checks.
         let codeRanges = collectCodeRanges(in: blocks)
@@ -599,6 +603,11 @@ enum MarkdownASTStyler {
             let last = ns.character(at: caret - 1)
             return last != 0x0A && last != 0x0D
         }
+        /// Whether a marker span shows its source: because the caret is in it,
+        /// or because the embedder asked for every marker to stay visible.
+        func revealsMarkers(_ range: NSRange) -> Bool {
+            !config.hidesInactiveMarkers || isActive(range)
+        }
         var theme: MarkdownEditorTheme { config.theme }
         var text: String { ns as String }
         var fullRange: NSRange { NSRange(location: 0, length: ns.length) }
@@ -679,7 +688,7 @@ enum MarkdownASTStyler {
                 attrs.append((block, ext.contentAttributes(theme: ctx.theme)))
             }
         }
-        let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(node.range)
+        let markerAttrs: [NSAttributedString.Key: Any] = ctx.revealsMarkers(node.range)
             ? [.foregroundColor: ctx.theme.mutedText]
             : [.foregroundColor: NSColor.clear]
         attrs.append((node.openFence, markerAttrs))
@@ -734,7 +743,7 @@ enum MarkdownASTStyler {
             if contentRange.length > 0 {
                 attrs.append((contentRange, [.foregroundColor: ctx.theme.mutedText]))
             }
-            if ctx.isActive(tokenRange) {
+            if ctx.revealsMarkers(tokenRange) {
                 attrs.append((markerRange, [.foregroundColor: ctx.theme.mutedText]))
             } else {
                 attrs.append((markerRange, [.foregroundColor: NSColor.clear, .font: ctx.inlineMarkerFont]))
@@ -760,7 +769,7 @@ enum MarkdownASTStyler {
             }
         }
         // Use the whole block range (not codeRange): an incomplete fence collapses codeRange to the ```.
-        let markerAttrs: [NSAttributedString.Key: Any] = ctx.isActive(range)
+        let markerAttrs: [NSAttributedString.Key: Any] = ctx.revealsMarkers(range)
             ? [.foregroundColor: ctx.theme.mutedText, .font: ctx.codeFont]
             : [.foregroundColor: NSColor.clear, .font: ctx.codeFont]   // hiddenMarkerFont == codeFont
         attrs.append((parts.openFence, markerAttrs))

--- a/Tests/MarkdownEngineTests/InactiveMarkerVisibilityTests.swift
+++ b/Tests/MarkdownEngineTests/InactiveMarkerVisibilityTests.swift
@@ -1,0 +1,146 @@
+//
+//  InactiveMarkerVisibilityTests.swift
+//  MarkdownEngineTests
+//
+//  `hidesInactiveMarkers`: a source-style pane keeps every syntax marker on
+//  screen while the document stays fully styled. The distinction that matters
+//  is against `rawSourceMode`, which drops styling altogether — here headings
+//  stay large and code blocks keep their run, so the two are not interchangeable.
+//  Markers that stand in for drawn content keep hiding regardless. Headless.
+//
+
+import AppKit
+import Foundation
+import Testing
+@testable import MarkdownEngine
+
+@Suite("hidesInactiveMarkers — a styled document that still shows its source")
+struct InactiveMarkerVisibilityTests {
+
+    private let base: CGFloat = 14
+    private var fontName: String { NSFont.systemFont(ofSize: 14).fontName }
+
+    private var revealing: MarkdownEditorConfiguration {
+        var config = MarkdownEditorConfiguration.default
+        config.hidesInactiveMarkers = false
+        return config
+    }
+
+    private func style(
+        _ text: String,
+        configuration: MarkdownEditorConfiguration = .default
+    ) -> [StyledRange] {
+        MarkdownASTStyler.styleAttributes(
+            text: text,
+            fontName: fontName,
+            fontSize: base,
+            configuration: configuration
+        )
+    }
+
+    /// Effective value for `key` at `pos`: the last styled range covering it that sets it.
+    private func attribute(
+        _ key: NSAttributedString.Key,
+        in attrs: [StyledRange],
+        at pos: Int
+    ) -> Any? {
+        var result: Any?
+        for (range, a) in attrs where NSLocationInRange(pos, range) {
+            if let value = a[key] { result = value }
+        }
+        return result
+    }
+
+    private func font(_ attrs: [StyledRange], at pos: Int) -> NSFont? {
+        attribute(.font, in: attrs, at: pos) as? NSFont
+    }
+
+    private func color(_ attrs: [StyledRange], at pos: Int) -> NSColor? {
+        attribute(.foregroundColor, in: attrs, at: pos) as? NSColor
+    }
+
+    // MARK: - The default is untouched
+
+    @Test("default: an inactive heading marker still shrinks away")
+    func defaultStillHidesHeadingMarker() {
+        let attrs = style("# Title")
+        #expect(
+            font(attrs, at: 0)?.pointSize
+                == MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        )
+    }
+
+    @Test("default: an inactive fence still renders clear")
+    func defaultStillHidesCodeFence() {
+        let attrs = style("```swift\nlet x = 1\n```\n")
+        #expect(color(attrs, at: 0) == .clear)
+    }
+
+    // MARK: - Revealed
+
+    @Test("revealed: a heading marker keeps the heading font instead of shrinking")
+    func revealedHeadingMarkerKeepsHeadingFont() {
+        let attrs = style("# Title", configuration: revealing)
+        let marker = font(attrs, at: 0)?.pointSize
+        let content = font(attrs, at: 2)?.pointSize
+
+        #expect(marker == content)
+        #expect((marker ?? 0) > base)
+    }
+
+    @Test("revealed: fence and quote markers take mutedText, never clear")
+    func revealedBlockMarkersUseMutedText() {
+        let text = "> quoted\n\n```swift\nlet x = 1\n```\n"
+        let ns = text as NSString
+        let attrs = style(text, configuration: revealing)
+        let muted = MarkdownEditorTheme.default.mutedText
+
+        #expect(color(attrs, at: 0) == muted)                              // `>`
+        #expect(color(attrs, at: ns.range(of: "```").location) == muted)   // opening fence
+    }
+
+    @Test("revealed: an inline emphasis marker is never shrunk")
+    func revealedEmphasisMarkerIsNotShrunk() {
+        let hidden = style("a **bold** word")
+        let shown = style("a **bold** word", configuration: revealing)
+
+        #expect(
+            font(hidden, at: 2)?.pointSize
+                == MarkdownEditorConfiguration.default.markers.hiddenMarkerFontSize
+        )
+        // No font override at all: the marker inherits the body font it sits in.
+        #expect(font(shown, at: 2) == nil)
+    }
+
+    // MARK: - Not rawSourceMode
+
+    @Test("revealed: the document is still styled — headings and bold survive")
+    func revealedDocumentIsStillStyled() {
+        let attrs = style("# Title\n\nsome **bold** text\n", configuration: revealing)
+        let ns = "# Title\n\nsome **bold** text\n" as NSString
+        let boldContent = ns.range(of: "bold").location
+
+        #expect((font(attrs, at: 2)?.pointSize ?? 0) > base)
+        #expect(
+            font(attrs, at: boldContent)?.fontDescriptor
+                .symbolicTraits.contains(.bold) == true
+        )
+    }
+
+    // MARK: - Drawn substitutes are not markers
+
+    @Test("revealed: a thematic break still hides its source behind the drawn rule")
+    func revealedThematicBreakStaysHidden() {
+        let attrs = style("para\n\n---\n\npara\n", configuration: revealing)
+        let pos = ("para\n\n---\n\npara\n" as NSString).range(of: "---").location
+
+        #expect(attribute(.thematicBreak, in: attrs, at: pos) as? Bool == true)
+        #expect(color(attrs, at: pos) == .clear)
+    }
+
+    @Test("revealed: a task checkbox still hides its source behind the drawn box")
+    func revealedTaskCheckboxStaysHidden() {
+        let attrs = style("- [x] done\n", configuration: revealing)
+        #expect(color(attrs, at: 0) == .clear)   // the `-` the checkbox replaces
+    }
+}


### PR DESCRIPTION
Closes #169.

## Why

A source-style pane — raw Markdown on the left, rendered preview on the right — has no good option today:

- `rawSourceMode` shows the source, but `restyleTextView` returns before the styling pass (`NativeTextViewCoordinator+Restyling.swift:206`), so nothing is coloured — Markdown syntax and fenced code blocks alike. `MarkdownEngineCodeBlocks` has no effect there.
- The styled mode colours everything but shrinks every marker the caret isn't in, and `MarkerStyle.hiddenMarkerFontSize` only decides *how* invisible that is, not *whether*.

## What

`MarkdownEditorConfiguration.hidesInactiveMarkers`, default `true` — so nothing changes for any existing embedder. With it `false`, the document is still fully styled (headings large, code blocks keeping their background *and* their syntax highlighting) and markers render the way an active span already renders them: `theme.mutedText`, normal size.

It is deliberately **not** a change to `rawSourceMode`'s contract. That flag also drops smart input and the wiki-link display transform; this one leaves both intact, so the two stay meaningfully different.

## Shape of the diff

Hiding is centralised in one call, which becomes conditional:

```swift
// MarkdownASTStyler.swift:80
if configuration.hidesInactiveMarkers {
    shrinkInactiveMarkers(in: blocks, ctx: ctx, into: &attrs)
}
```

Three block markers hide outside that pass and take the same condition through a new `Ctx.revealsMarkers(_:)` — blockquote `>`, fenced-code fences, extension-block fences. That helper reads `!config.hidesInactiveMarkers || isActive(range)`, so the existing caret-reveal path is untouched.

Markers that stand in for **drawn content** are left alone on purpose: task checkboxes, list bullets, thematic breaks, image embeds, LaTeX. Revealing those would draw the glyph and its source at once. Two tests pin that down so the distinction can't erode.

## Tests

`Tests/MarkdownEngineTests/InactiveMarkerVisibilityTests.swift`, 8 cases:

- the default still shrinks heading markers and still renders fences clear (no regression)
- revealed: heading markers keep the heading font; fence and `>` take `mutedText`; inline markers lose the shrink override entirely
- revealed is **not** `rawSourceMode`: headings still scale, bold still composes
- revealed: thematic break and task checkbox keep hiding their source

`swift build` and `swift test` green — 478 tests, 69 suites.

## Notes

I realise this cuts against the live-styling design the engine is built around, which is why it's strictly opt-in with the default preserving today's behaviour. Happy to reshape it if you'd rather it lived on `rawSourceMode` instead, or under a different name.

macOS 15.7.9, Xcode 26.3, Swift 6.2.4.
