### PR TITLE
Make automatic quote substitution configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`SpellCheckingPolicy.automaticQuoteSubstitution`**: makes
+  `NSTextView.isAutomaticQuoteSubstitutionEnabled` configurable instead of
+  hard-coded on. Some Markdown sources need straight quotes throughout
+  (frontmatter, code-adjacent prose) where automatic curly-quote substitution
+  would corrupt the source. Defaults to `true`, preserving the prior
+  always-on behavior.
 - **Directive seam (parsing)**: opt-in named inline commands with typed
   arguments, for constructs that need a name and parameters rather than
   delimiters. A `MarkdownDirective` declares a name, a form — self-contained

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -167,15 +167,21 @@ public struct SpellCheckingPolicy: Sendable {
     public var grammarChecking: Bool
     /// Mirrors `NSTextView.isAutomaticSpellingCorrectionEnabled`.
     public var automaticSpellingCorrection: Bool
+    /// Mirrors `NSTextView.isAutomaticQuoteSubstitutionEnabled`. Markdown sources
+    /// sometimes need straight quotes throughout (frontmatter, code-adjacent prose);
+    /// `true` preserves the historical always-on behavior.
+    public var automaticQuoteSubstitution: Bool
 
     public init(
         continuousSpellChecking: Bool = true,
         grammarChecking: Bool = true,
-        automaticSpellingCorrection: Bool = true
+        automaticSpellingCorrection: Bool = true,
+        automaticQuoteSubstitution: Bool = true
     ) {
         self.continuousSpellChecking = continuousSpellChecking
         self.grammarChecking = grammarChecking
         self.automaticSpellingCorrection = automaticSpellingCorrection
+        self.automaticQuoteSubstitution = automaticQuoteSubstitution
     }
 
     public static let `default` = SpellCheckingPolicy()

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
@@ -62,7 +62,9 @@ extension NativeTextViewCoordinator {
         textView.isGrammarCheckingEnabled = shouldDisableSpelling
             ? false
             : userPrefersGrammarChecking
-        textView.isAutomaticQuoteSubstitutionEnabled = !shouldDisableSpelling
+        textView.isAutomaticQuoteSubstitutionEnabled = shouldDisableSpelling
+            ? false
+            : configuration.spellChecking.automaticQuoteSubstitution
         textView.isAutomaticDashSubstitutionEnabled = false
     }
 

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -286,7 +286,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         textView.isAutomaticSpellingCorrectionEnabled = configuration.spellChecking.automaticSpellingCorrection
         textView.isContinuousSpellCheckingEnabled = configuration.spellChecking.continuousSpellChecking
         textView.isGrammarCheckingEnabled = configuration.spellChecking.grammarChecking
-        textView.isAutomaticQuoteSubstitutionEnabled = true
+        textView.isAutomaticQuoteSubstitutionEnabled = configuration.spellChecking.automaticQuoteSubstitution
         textView.isAutomaticDataDetectionEnabled = true
         textView.isAutomaticDashSubstitutionEnabled = false
         textView.onPasteImage = onPasteImage

--- a/Tests/MarkdownEngineTests/SpellCheckingPolicyTests.swift
+++ b/Tests/MarkdownEngineTests/SpellCheckingPolicyTests.swift
@@ -1,0 +1,26 @@
+//
+//  SpellCheckingPolicyTests.swift
+//  MarkdownEngineTests
+//
+
+import Testing
+@testable import MarkdownEngine
+
+@Suite("SpellCheckingPolicy")
+struct SpellCheckingPolicyTests {
+    @Test("automaticQuoteSubstitution defaults to true, preserving prior always-on behavior")
+    func defaultsToEnabled() {
+        let policy = SpellCheckingPolicy()
+        #expect(policy.automaticQuoteSubstitution == true)
+        #expect(SpellCheckingPolicy.default.automaticQuoteSubstitution == true)
+    }
+
+    @Test("automaticQuoteSubstitution can be disabled independently of the other toggles")
+    func canBeDisabled() {
+        let policy = SpellCheckingPolicy(automaticQuoteSubstitution: false)
+        #expect(policy.automaticQuoteSubstitution == false)
+        #expect(policy.continuousSpellChecking == true)
+        #expect(policy.grammarChecking == true)
+        #expect(policy.automaticSpellingCorrection == true)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `SpellCheckingPolicy.automaticQuoteSubstitution`, mirroring
`NSTextView.isAutomaticQuoteSubstitutionEnabled` alongside the existing
`continuousSpellChecking` / `grammarChecking` / `automaticSpellingCorrection`
toggles. Previously `isAutomaticQuoteSubstitutionEnabled` was hard-coded to
`true` in `NativeTextViewWrapper` and in the autocorrect suppress-zone
restore path, with no way for an embedder to turn it off.

Some Markdown sources need straight quotes preserved throughout — frontmatter,
code-adjacent prose, anywhere automatic curly-quote substitution would
silently corrupt the source text. This came up integrating the engine into
an app that edits Markdown files directly on disk.

Defaults to `true`, so existing embedders see no behavior change.

## Test plan

- [x] `swift build`
- [x] `swift test --filter SpellCheckingPolicyTests` — new coverage for the
      default value and for setting it independently of the other toggles
- [x] Added a `CHANGELOG.md` entry under `[Unreleased]`