### PR TITLE
Add paragraph and task-list formatting actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `MarkdownEditorBus.applyParagraphRequest` and `applyTaskListRequest` add
+  multiline, line-ending-preserving block-formatting commands for embedders.
 - **Directive seam (parsing)**: opt-in named inline commands with typed
   arguments, for constructs that need a name and parameters rather than
   delimiters. A `MarkdownDirective` declares a name, a form — self-contained

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -36,6 +36,9 @@ struct ContentView: View {
     // Base font size; all relative sizing (headings, code, math) tracks it.
     @State private var fontSize: CGFloat = 16
 
+    private let paragraphRequest = Notification.Name("demo.applyParagraph")
+    private let taskListRequest = Notification.Name("demo.applyTaskList")
+
     // Scroll-away header demo.
     @State private var showHeader = false
     @State private var headerExpanded = true
@@ -100,6 +103,16 @@ struct ContentView: View {
                 }
                 .help("Base font size — headings, code, and math scale relative to it")
 
+                ControlGroup {
+                    Button("Paragraph") {
+                        NotificationCenter.default.post(name: paragraphRequest, object: nil)
+                    }
+                    Button("Task list") {
+                        NotificationCenter.default.post(name: taskListRequest, object: nil)
+                    }
+                }
+                .help("Apply block formatting through the embedder notification bus")
+
                 Menu {
                     Toggle("Show header", isOn: $showHeader)
                     Toggle("Expanded", isOn: $headerExpanded)
@@ -144,6 +157,10 @@ struct ContentView: View {
     /// so you can see exactly what each one adds.
     private var configuration: MarkdownEditorConfiguration {
         var config = MarkdownEditorConfiguration.default
+        config.services.bus = MarkdownEditorBus(
+            applyParagraphRequest: paragraphRequest,
+            applyTaskListRequest: taskListRequest
+        )
 
         #if canImport(MarkdownEngineCodeBlocks)
         // Syntax highlighting for fenced code blocks. Auto-switches between

--- a/Sources/MarkdownEngine/Input/MarkdownBlockFormatting.swift
+++ b/Sources/MarkdownEngine/Input/MarkdownBlockFormatting.swift
@@ -1,0 +1,140 @@
+//
+//  MarkdownBlockFormatting.swift
+//  MarkdownEngine
+//
+
+import Foundation
+
+struct MarkdownLinePrefixEdit {
+    let range: NSRange
+    let replacement: String
+}
+
+struct MarkdownBlockFormattingPlan {
+    let range: NSRange
+    let prefixEdits: [MarkdownLinePrefixEdit]
+    let selection: NSRange
+}
+
+enum MarkdownBlockFormatting {
+    private static let headingPrefix = try! NSRegularExpression(pattern: #"^([ \t]*)#{1,6}[ \t]+"#)
+    private static let indentation = try! NSRegularExpression(pattern: #"^[ \t]*"#)
+    private static let taskPrefix = try! NSRegularExpression(
+        pattern: #"^((?:\d+\.|[-*+]))[ \t]+\[[ xX]\][ \t]+"#
+    )
+    private static let listPrefix = try! NSRegularExpression(pattern: #"^((?:\d+\.|[-*+]))[ \t]+"#)
+
+    static func paragraphPlan(in text: String, selection: NSRange) -> MarkdownBlockFormattingPlan? {
+        let document = text as NSString
+        let lines = selectedLines(in: document, selection: selection)
+        let edits = lines.compactMap { line -> MarkdownLinePrefixEdit? in
+            let lineText = document.substring(with: line)
+            let localRange = NSRange(location: 0, length: (lineText as NSString).length)
+            guard let match = headingPrefix.firstMatch(in: lineText, range: localRange) else { return nil }
+            let indentationRange = match.range(at: 1)
+            let markerRange = NSRange(
+                location: line.location + NSMaxRange(indentationRange),
+                length: NSMaxRange(match.range) - NSMaxRange(indentationRange)
+            )
+            return MarkdownLinePrefixEdit(range: markerRange, replacement: "")
+        }
+        return plan(in: document, selection: selection, lines: lines, edits: edits)
+    }
+
+    static func taskListPlan(in text: String, selection: NSRange) -> MarkdownBlockFormattingPlan? {
+        let document = text as NSString
+        let lines = selectedLines(in: document, selection: selection)
+        let lineDetails = lines.map { line -> (range: NSRange, indentationLength: Int, taskRange: NSRange?, listRange: NSRange?, listMarker: String?) in
+            let lineText = document.substring(with: line) as NSString
+            let fullRange = NSRange(location: 0, length: lineText.length)
+            let indentationLength = indentation.firstMatch(in: lineText as String, range: fullRange)?.range.length ?? 0
+            let content = lineText.substring(from: indentationLength) as NSString
+            let contentRange = NSRange(location: 0, length: content.length)
+            let task = taskPrefix.firstMatch(in: content as String, range: contentRange).map {
+                NSRange(location: indentationLength + $0.range.location, length: $0.range.length)
+            }
+            let listMatch = listPrefix.firstMatch(in: content as String, range: contentRange)
+            let list = listMatch.map {
+                NSRange(location: indentationLength + $0.range.location, length: $0.range.length)
+            }
+            let marker = listMatch.map { content.substring(with: $0.range(at: 1)) }
+            return (line, indentationLength, task, list, marker)
+        }
+        let removeTaskPrefixes = lineDetails.allSatisfy { $0.taskRange != nil }
+        let edits = lineDetails.compactMap { line -> MarkdownLinePrefixEdit? in
+            if removeTaskPrefixes, let taskRange = line.taskRange {
+                return MarkdownLinePrefixEdit(
+                    range: NSRange(location: line.range.location + taskRange.location, length: taskRange.length),
+                    replacement: ""
+                )
+            }
+            if line.taskRange != nil { return nil }
+            if let listRange = line.listRange, let marker = line.listMarker {
+                return MarkdownLinePrefixEdit(
+                    range: NSRange(location: line.range.location + listRange.location, length: listRange.length),
+                    replacement: "\(marker) [ ] "
+                )
+            }
+            return MarkdownLinePrefixEdit(
+                range: NSRange(location: line.range.location + line.indentationLength, length: 0),
+                replacement: "- [ ] "
+            )
+        }
+        return plan(in: document, selection: selection, lines: lines, edits: edits)
+    }
+
+    private static func plan(
+        in document: NSString,
+        selection: NSRange,
+        lines: [NSRange],
+        edits: [MarkdownLinePrefixEdit]
+    ) -> MarkdownBlockFormattingPlan? {
+        guard edits.isEmpty == false, let first = lines.first, let last = lines.last else { return nil }
+        let safeSelection = clamped(selection, length: document.length)
+        let sortedEdits = edits.sorted { $0.range.location < $1.range.location }
+        let start = transformedLocation(safeSelection.location, by: sortedEdits)
+        let end = transformedLocation(NSMaxRange(safeSelection), by: sortedEdits)
+        return MarkdownBlockFormattingPlan(
+            range: NSRange(location: first.location, length: NSMaxRange(last) - first.location),
+            prefixEdits: sortedEdits,
+            selection: NSRange(location: start, length: max(0, end - start))
+        )
+    }
+
+    private static func selectedLines(in document: NSString, selection: NSRange) -> [NSRange] {
+        let safe = clamped(selection, length: document.length)
+        let first = document.lineRange(for: NSRange(location: safe.location, length: 0))
+        let lastLocation = safe.length > 0 ? NSMaxRange(safe) - 1 : safe.location
+        let last = document.lineRange(for: NSRange(location: lastLocation, length: 0))
+        let selectedRange = NSRange(location: first.location, length: NSMaxRange(last) - first.location)
+        if selectedRange.length == 0 { return [selectedRange] }
+
+        var lines: [NSRange] = []
+        var location = selectedRange.location
+        while location < NSMaxRange(selectedRange) {
+            let line = document.lineRange(for: NSRange(location: location, length: 0))
+            lines.append(line)
+            let next = NSMaxRange(line)
+            guard next > location else { break }
+            location = next
+        }
+        return lines
+    }
+
+    private static func transformedLocation(_ location: Int, by edits: [MarkdownLinePrefixEdit]) -> Int {
+        var offset = 0
+        for edit in edits {
+            if location < edit.range.location { break }
+            if location <= NSMaxRange(edit.range) {
+                return edit.range.location + offset + edit.replacement.utf16.count
+            }
+            offset += edit.replacement.utf16.count - edit.range.length
+        }
+        return location + offset
+    }
+
+    private static func clamped(_ range: NSRange, length: Int) -> NSRange {
+        let location = min(max(0, range.location), length)
+        return NSRange(location: location, length: min(max(0, range.length), length - location))
+    }
+}

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -200,6 +200,8 @@ public struct MarkdownEditorBus: Sendable {
     /// Posted by the host UI to request the engine apply a heading level.
     /// Expected `userInfo["level"] as? Int`.
     public var applyHeadingRequest: Notification.Name?
+    /// Posted by the host UI to remove heading markers from the selected lines.
+    public var applyParagraphRequest: Notification.Name?
     /// Posted by the host UI to request the engine apply highlight styling.
     public var applyHighlightRequest: Notification.Name?
     /// Posted by the host UI to request the engine apply strikethrough styling.
@@ -212,6 +214,8 @@ public struct MarkdownEditorBus: Sendable {
     public var applyUnorderedListRequest: Notification.Name?
     /// Posted by the host UI to request the engine apply ordered list styling.
     public var applyOrderedListRequest: Notification.Name?
+    /// Posted by the host UI to toggle task-list markers on the selected lines.
+    public var applyTaskListRequest: Notification.Name?
     /// Posted by the host UI to insert a Markdown link.
     /// Expected `userInfo["url"] as? String`.
     public var applyLinkRequest: Notification.Name?
@@ -260,12 +264,14 @@ public struct MarkdownEditorBus: Sendable {
         applyBoldRequest: Notification.Name? = nil,
         applyItalicRequest: Notification.Name? = nil,
         applyHeadingRequest: Notification.Name? = nil,
+        applyParagraphRequest: Notification.Name? = nil,
         applyHighlightRequest: Notification.Name? = nil,
         applyStrikethroughRequest: Notification.Name? = nil,
         applyInlineCodeRequest: Notification.Name? = nil,
         applyBlockquoteRequest: Notification.Name? = nil,
         applyUnorderedListRequest: Notification.Name? = nil,
         applyOrderedListRequest: Notification.Name? = nil,
+        applyTaskListRequest: Notification.Name? = nil,
         applyLinkRequest: Notification.Name? = nil,
         applyCodeBlockRequest: Notification.Name? = nil,
         applyHorizontalRuleRequest: Notification.Name? = nil,
@@ -283,12 +289,14 @@ public struct MarkdownEditorBus: Sendable {
         self.applyBoldRequest = applyBoldRequest
         self.applyItalicRequest = applyItalicRequest
         self.applyHeadingRequest = applyHeadingRequest
+        self.applyParagraphRequest = applyParagraphRequest
         self.applyHighlightRequest = applyHighlightRequest
         self.applyStrikethroughRequest = applyStrikethroughRequest
         self.applyInlineCodeRequest = applyInlineCodeRequest
         self.applyBlockquoteRequest = applyBlockquoteRequest
         self.applyUnorderedListRequest = applyUnorderedListRequest
         self.applyOrderedListRequest = applyOrderedListRequest
+        self.applyTaskListRequest = applyTaskListRequest
         self.applyLinkRequest = applyLinkRequest
         self.applyCodeBlockRequest = applyCodeBlockRequest
         self.applyHorizontalRuleRequest = applyHorizontalRuleRequest

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -224,6 +224,11 @@ extension NativeTextViewWrapper.Coordinator {
         applyHeading(level: sender.tag)
     }
 
+    @objc func didMarkdownParagraph(_ sender: Any?) {
+        guard let tv = textView else { return }
+        applyBlockFormatting(MarkdownBlockFormatting.paragraphPlan(in: tv.string, selection: tv.selectedRange()))
+    }
+
     private func applyList(prefix: String) {
         guard let tv = textView else { return }
         let nsText = tv.string as NSString
@@ -260,6 +265,25 @@ extension NativeTextViewWrapper.Coordinator {
 
     @objc func didMarkdownOrderedList(_ sender: Any?) {
         applyList(prefix: "1. ")
+    }
+
+    @objc func didMarkdownTaskList(_ sender: Any?) {
+        guard let tv = textView else { return }
+        applyBlockFormatting(MarkdownBlockFormatting.taskListPlan(in: tv.string, selection: tv.selectedRange()))
+    }
+
+    private func applyBlockFormatting(_ plan: MarkdownBlockFormattingPlan?) {
+        guard let plan, let tv = textView, let storage = tv.textStorage else { return }
+        let replacement = NSMutableAttributedString(attributedString: storage.attributedSubstring(from: plan.range))
+        for edit in plan.prefixEdits.reversed() {
+            let localRange = NSRange(location: edit.range.location - plan.range.location, length: edit.range.length)
+            let attributedPrefix = NSAttributedString(string: edit.replacement, attributes: tv.typingAttributes)
+            replacement.replaceCharacters(in: localRange, with: attributedPrefix)
+        }
+        guard tv.shouldChangeText(in: plan.range, replacementString: replacement.string) else { return }
+        storage.replaceCharacters(in: plan.range, with: replacement)
+        tv.didChangeText()
+        tv.setSelectedRange(plan.selection)
     }
 
     @objc func didMarkdownBold(_ sender: Any?) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
@@ -32,6 +32,10 @@ extension NativeTextViewCoordinator {
         didMarkdownHeading(item)
     }
 
+    @objc func handleParagraphNotification(_ notification: Notification) {
+        didMarkdownParagraph(nil)
+    }
+
     @objc func handleStrikethroughNotification(_ notification: Notification) {
         didMarkdownStrikethrough(nil)
     }
@@ -50,6 +54,10 @@ extension NativeTextViewCoordinator {
 
     @objc func handleOrderedListNotification(_ notification: Notification) {
         didMarkdownOrderedList(nil)
+    }
+
+    @objc func handleTaskListNotification(_ notification: Notification) {
+        didMarkdownTaskList(nil)
     }
 
     @objc func handleLinkNotification(_ notification: Notification) {

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -340,6 +340,11 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
                 self?.handleHeadingNotification(notification)
             })
         }
+        if let name = bus.applyParagraphRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleParagraphNotification(notification)
+            })
+        }
         if let name = bus.applyHighlightRequest {
             busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
                 self?.handleHighlightNotification(notification)
@@ -368,6 +373,11 @@ public final class NativeTextViewCoordinator: NSObject, NSTextViewDelegate {
         if let name = bus.applyOrderedListRequest {
             busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
                 self?.handleOrderedListNotification(notification)
+            })
+        }
+        if let name = bus.applyTaskListRequest {
+            busObservers.append(center.addObserver(forName: name, object: nil, queue: .main) { [weak self] notification in
+                self?.handleTaskListNotification(notification)
             })
         }
         if let name = bus.applyLinkRequest {

--- a/Tests/MarkdownEngineTests/BlockFormattingActionTests.swift
+++ b/Tests/MarkdownEngineTests/BlockFormattingActionTests.swift
@@ -1,0 +1,214 @@
+//
+//  BlockFormattingActionTests.swift
+//  MarkdownEngineTests
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Paragraph and task-list formatting")
+struct BlockFormattingActionTests {
+    @Test("Paragraph removes a heading at the caret")
+    func paragraphAtCaret() {
+        let (coordinator, textView) = makeEditor("# Title\n")
+        textView.setSelectedRange(NSRange(location: 3, length: 0))
+
+        coordinator.didMarkdownParagraph(nil)
+
+        #expect(textView.string == "Title\n")
+        #expect(textView.selectedRange() == NSRange(location: 1, length: 0))
+    }
+
+    @Test("Paragraph changes every selected heading and preserves LF")
+    func paragraphMultiline() {
+        let source = "# One\n## Two\nPlain\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownParagraph(nil)
+
+        let expected = "One\nTwo\nPlain\n"
+        #expect(textView.string == expected)
+        #expect(textView.selectedRange() == NSRange(location: 0, length: (expected as NSString).length))
+    }
+
+    @Test("Paragraph preserves CRLF line endings")
+    func paragraphCRLF() {
+        let source = "# One\r\n## Two\r\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownParagraph(nil)
+
+        #expect(textView.string == "One\r\nTwo\r\n")
+    }
+
+    @Test("Task list inserts at an empty caret")
+    func taskListAtEmptyCaret() {
+        let (coordinator, textView) = makeEditor("")
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "- [ ] ")
+        #expect(textView.selectedRange() == NSRange(location: 6, length: 0))
+    }
+
+    @Test("Task list formats every selected line and preserves LF")
+    func taskListMultiline() {
+        let source = "First\n* Second\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        let expected = "- [ ] First\n* [ ] Second\n"
+        #expect(textView.string == expected)
+        #expect(textView.selectedRange() == NSRange(location: 6, length: (expected as NSString).length - 6))
+    }
+
+    @Test("Task list removes markers when every selected line is a task")
+    func taskListTogglesOff() {
+        let source = "- [ ] First\n- [x] Second\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "First\nSecond\n")
+    }
+
+    @Test("Task list preserves CRLF line endings")
+    func taskListCRLF() {
+        let source = "First\r\nSecond\r\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "- [ ] First\r\n- [ ] Second\r\n")
+    }
+
+    @Test("Task list preserves indentation while replacing bullet markers")
+    func taskListIndentation() {
+        let source = "\t* Nested\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 4, length: 0))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "\t* [ ] Nested\n")
+    }
+
+    @Test("A mixed selection preserves tasks and converts plain and list lines")
+    func mixedTaskListSelection() {
+        let source = "- [x] Done\nPlain\n* Bullet\n1. Ordered\n"
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: (source as NSString).length))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "- [x] Done\n- [ ] Plain\n* [ ] Bullet\n1. [ ] Ordered\n")
+    }
+
+    @Test(
+        "Existing unordered and ordered task markers toggle off cleanly",
+        arguments: ["* [x] Item", "+ [ ] Item", "2. [X] Item"]
+    )
+    func existingTaskMarker(source: String) {
+        let (coordinator, textView) = makeEditor(source)
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        coordinator.didMarkdownTaskList(nil)
+
+        #expect(textView.string == "Item")
+    }
+
+    @Test("Bus notifications invoke both formatting actions")
+    func busNotifications() {
+        let paragraph = Notification.Name("test.paragraph.\(UUID().uuidString)")
+        let taskList = Notification.Name("test.task.\(UUID().uuidString)")
+        let (coordinator, textView) = makeEditor("# Item")
+        var configuration = MarkdownEditorConfiguration.default
+        configuration.services.bus = MarkdownEditorBus(
+            applyParagraphRequest: paragraph,
+            applyTaskListRequest: taskList
+        )
+        coordinator.configuration = configuration
+        textView.setSelectedRange(NSRange(location: 2, length: 0))
+
+        NotificationCenter.default.post(name: paragraph, object: nil)
+        NotificationCenter.default.post(name: taskList, object: nil)
+
+        #expect(textView.string == "- [ ] Item")
+    }
+
+    @Test("Paragraph preserves wiki-link storage metadata in the settled binding")
+    func paragraphPreservesStorageLink() async {
+        let result = await settledStorageText("## Intro [[Target|ABC-123]]\n") { coordinator, textView in
+            textView.setSelectedRange(NSRange(location: 3, length: 0))
+            coordinator.didMarkdownParagraph(nil)
+        }
+
+        #expect(result == "Intro [[Target|ABC-123]]\n")
+    }
+
+    @Test("Task list preserves wiki-link storage metadata in the settled binding")
+    func taskListPreservesStorageLink() async {
+        let result = await settledStorageText("Intro [[Target|ABC-123]]\n") { coordinator, textView in
+            textView.setSelectedRange(NSRange(location: 2, length: 0))
+            coordinator.didMarkdownTaskList(nil)
+        }
+
+        #expect(result == "- [ ] Intro [[Target|ABC-123]]\n")
+    }
+
+    private func makeEditor(_ text: String) -> (NativeTextViewCoordinator, NativeTextView) {
+        _ = NSApplication.shared
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        textView.isEditable = true
+        textView.string = text
+        let coordinator = NativeTextViewCoordinator(
+            text: .constant(text),
+            fontName: "SF Pro Text",
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        coordinator.textView = textView
+        textView.delegate = coordinator
+        return (coordinator, textView)
+    }
+
+    private func settledStorageText(
+        _ storage: String,
+        action: (NativeTextViewCoordinator, NativeTextView) -> Void
+    ) async -> String {
+        var published = storage
+        let binding = Binding<String>(get: { published }, set: { published = $0 })
+        let coordinator = NativeTextViewCoordinator(
+            text: binding,
+            fontName: "SF Pro Text",
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        textView.delegate = coordinator
+        coordinator.textView = textView
+        coordinator.rebuildTextStorageAndStyle(textView, from: storage)
+
+        action(coordinator, textView)
+        for _ in 0..<4 {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+        return published
+    }
+}


### PR DESCRIPTION
Adds optional embedder bus actions for converting selected lines to paragraph or task-list form. The transformations preserve LF or CRLF, indentation, list markers, attributed storage, and deterministic selections. Includes end-to-end binding coverage for aliased wiki links and 13 focused tests. Follow-up embedder parity work discovered while implementing issue #173.