### PR TITLE
Allow opt-in task toggles in read-only editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `NativeTextViewWrapper.allowsTaskCheckboxInteractionWhenReadOnly` optionally
+  keeps task checkboxes interactive without enabling ordinary text editing.
 - **Directive seam (parsing)**: opt-in named inline commands with typed
   arguments, for constructs that need a name and parameters rather than
   delimiters. A `MarkdownDirective` declares a name, a form — self-contained

--- a/Demo/MarkdownEngineDemo/ContentView.swift
+++ b/Demo/MarkdownEngineDemo/ContentView.swift
@@ -46,6 +46,7 @@ struct ContentView: View {
             configuration: configuration,
             fontSize: fontSize,
             isEditable: !isReadOnly,
+            allowsTaskCheckboxInteractionWhenReadOnly: true,
             placeholder: NSAttributedString(
                 string: "Empty document — start typing, markdown styles live…",
                 attributes: [
@@ -66,7 +67,7 @@ struct ContentView: View {
                 Toggle(isOn: $isReadOnly) {
                     Label("Read-only", systemImage: isReadOnly ? "lock" : "lock.open")
                 }
-                .help("Read-only: the styled document stays scrollable and selectable, editing is off")
+                .help("Read-only: text editing is off, while task checkboxes remain interactive")
 
                 Toggle(isOn: $showRawSource) {
                     Label("Raw source", systemImage: "chevron.left.forwardslash.chevron.right")

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -60,7 +60,28 @@ extension NativeTextView {
         guard checkboxText.range(of: #"\[[ xX]\]"#, options: .regularExpression) != nil else { return nil }
 
         let replacement = hitIsChecked ? "[ ]" : "[x]"
-        if shouldChangeText(in: effectiveRange, replacementString: replacement) {
+        let shouldToggle: Bool
+        if isEditable {
+            shouldToggle = shouldChangeText(in: effectiveRange, replacementString: replacement)
+        } else if allowsTaskCheckboxInteractionWhenReadOnly {
+            // NSTextView rejects shouldChangeText while read-only. Consult the
+            // coordinator directly so its exact-edit bookkeeping and binding
+            // synchronization still run, without briefly enabling text input.
+            if let coordinator = delegate as? NativeTextViewCoordinator {
+                coordinator.isProgrammaticEdit = true
+                defer { coordinator.isProgrammaticEdit = false }
+                shouldToggle = coordinator.textView(
+                    self,
+                    shouldChangeTextIn: effectiveRange,
+                    replacementString: replacement
+                )
+            } else {
+                shouldToggle = true
+            }
+        } else {
+            shouldToggle = false
+        }
+        if shouldToggle {
             storage.replaceCharacters(in: effectiveRange, with: replacement)
             storage.addAttribute(.taskCheckbox, value: !hitIsChecked, range: effectiveRange)
             storage.addAttribute(.foregroundColor, value: NSColor.clear, range: effectiveRange)

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -45,8 +45,7 @@ extension NativeTextView {
     }
 
     func toggleTaskCheckboxIfHit(event: NSEvent) -> Bool? {
-        guard let bridge = layoutBridge,
-              let storage = textStorage else { return nil }
+        guard layoutBridge != nil, let storage = textStorage else { return nil }
         let localPoint = convert(event.locationInWindow, from: nil)
         let containerPoint = CGPoint(
             x: localPoint.x - textContainerOrigin.x,
@@ -59,11 +58,26 @@ extension NativeTextView {
         let checkboxText = nsText.substring(with: effectiveRange)
         guard checkboxText.range(of: #"\[[ xX]\]"#, options: .regularExpression) != nil else { return nil }
 
-        let replacement = hitIsChecked ? "[ ]" : "[x]"
+        _ = applyTaskCheckboxState(!hitIsChecked, in: effectiveRange)
+        return true
+    }
+
+    @discardableResult
+    private func applyTaskCheckboxState(_ isChecked: Bool, in range: NSRange) -> Bool {
+        guard let bridge = layoutBridge,
+              let storage = textStorage,
+              NSMaxRange(range) <= storage.length else { return false }
+        let checkboxText = (storage.string as NSString).substring(with: range)
+        let checkedPattern = #"\[[xX]\]"#
+        let previousIsChecked = checkboxText.range(of: checkedPattern, options: .regularExpression) != nil
+        guard previousIsChecked != isChecked else { return false }
+
+        let replacement = isChecked ? "[x]" : "[ ]"
+        let isReadOnlyOptIn = !isEditable && allowsTaskCheckboxInteractionWhenReadOnly
         let shouldToggle: Bool
         if isEditable {
-            shouldToggle = shouldChangeText(in: effectiveRange, replacementString: replacement)
-        } else if allowsTaskCheckboxInteractionWhenReadOnly {
+            shouldToggle = shouldChangeText(in: range, replacementString: replacement)
+        } else if isReadOnlyOptIn {
             // NSTextView rejects shouldChangeText while read-only. Consult the
             // coordinator directly so its exact-edit bookkeeping and binding
             // synchronization still run, without briefly enabling text input.
@@ -72,7 +86,7 @@ extension NativeTextView {
                 defer { coordinator.isProgrammaticEdit = false }
                 shouldToggle = coordinator.textView(
                     self,
-                    shouldChangeTextIn: effectiveRange,
+                    shouldChangeTextIn: range,
                     replacementString: replacement
                 )
             } else {
@@ -81,16 +95,25 @@ extension NativeTextView {
         } else {
             shouldToggle = false
         }
-        if shouldToggle {
-            storage.replaceCharacters(in: effectiveRange, with: replacement)
-            storage.addAttribute(.taskCheckbox, value: !hitIsChecked, range: effectiveRange)
-            storage.addAttribute(.foregroundColor, value: NSColor.clear, range: effectiveRange)
-            didChangeText()
-            bridge.invalidateDisplay(forCharacterRange: effectiveRange)
-            if let coord = delegate as? NativeTextViewCoordinator {
-                let paragraph = (storage.string as NSString).paragraphRange(for: effectiveRange)
-                coord.restyleParagraphs([paragraph], in: self)
+        guard shouldToggle else { return false }
+
+        if isReadOnlyOptIn,
+           let readOnlyUndoManager = (delegate as? NativeTextViewCoordinator)?.undoManager(for: self)
+                ?? undoManager {
+            readOnlyUndoManager.registerUndo(withTarget: self) { textView in
+                textView.applyTaskCheckboxState(previousIsChecked, in: range)
             }
+            readOnlyUndoManager.setActionName("Toggle Task Checkbox")
+        }
+
+        storage.replaceCharacters(in: range, with: replacement)
+        storage.addAttribute(.taskCheckbox, value: isChecked, range: range)
+        storage.addAttribute(.foregroundColor, value: NSColor.clear, range: range)
+        didChangeText()
+        bridge.invalidateDisplay(forCharacterRange: range)
+        if let coord = delegate as? NativeTextViewCoordinator {
+            let paragraph = (storage.string as NSString).paragraphRange(for: range)
+            coord.restyleParagraphs([paragraph], in: self)
         }
         return true
     }

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -46,6 +46,7 @@ final class NativeTextView: NSTextView {
 
     // MARK: Editor wiring
     var onPasteImage: ((NSPasteboard) -> String?)?
+    var allowsTaskCheckboxInteractionWhenReadOnly = false
     weak var layoutBridge: LayoutBridge?
     var baseFont: NSFont = NSFont.systemFont(ofSize: NSFont.systemFontSize)
 

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -71,6 +71,9 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
     public var documentId: String
     /// When `false` the editor renders read-only with no caret.
     public var isEditable: Bool
+    /// Allows task checkboxes to remain interactive while ordinary text editing
+    /// is disabled. Defaults to `false`, preserving fully read-only behavior.
+    public var allowsTaskCheckboxInteractionWhenReadOnly: Bool
     /// Optional paste hook. Return a Markdown image-embed string (e.g.
     /// `"![[my-image]]"`) to insert at the caret, or `nil` to fall through
     /// to the system's default plain-text paste.
@@ -150,6 +153,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         fontSize: CGFloat = 16,
         documentId: String = "default",
         isEditable: Bool = true,
+        allowsTaskCheckboxInteractionWhenReadOnly: Bool = false,
         onPasteImage: ((NSPasteboard) -> String?)? = nil,
         onLinkClick: ((String) -> Void)? = nil,
         onCaretRectChange: ((CGRect) -> Void)? = nil,
@@ -176,6 +180,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         self.fontSize = fontSize
         self.documentId = documentId
         self.isEditable = isEditable
+        self.allowsTaskCheckboxInteractionWhenReadOnly = allowsTaskCheckboxInteractionWhenReadOnly
         self.onPasteImage = onPasteImage
         self.onLinkClick = onLinkClick
         self.onCaretRectChange = onCaretRectChange
@@ -264,6 +269,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
         context.coordinator.configuration = configuration
         textView.insertionPointColor = configuration.theme.bodyText
         textView.isEditable = isEditable
+        textView.allowsTaskCheckboxInteractionWhenReadOnly = allowsTaskCheckboxInteractionWhenReadOnly
         textView.isSelectable = true
         textView.isRichText = true
         let initialState = WikiLinkService.makeDisplayState(from: text) { configuration.services.wikiLinks.name(forID: $0) }
@@ -557,6 +563,7 @@ public struct NativeTextViewWrapper: NSViewRepresentable {
             }
         }
         textView.isEditable = isEditable
+        textView.allowsTaskCheckboxInteractionWhenReadOnly = allowsTaskCheckboxInteractionWhenReadOnly
         textView.isSelectable = true
         // Keep the caret ink the selection handler resolved (an extension span
         // can invert it); a plain bodyText reset here stomps it on every pass.

--- a/Tests/MarkdownEngineTests/ReadOnlyTaskCheckboxTests.swift
+++ b/Tests/MarkdownEngineTests/ReadOnlyTaskCheckboxTests.swift
@@ -1,0 +1,125 @@
+//
+//  ReadOnlyTaskCheckboxTests.swift
+//  MarkdownEngineTests
+//
+
+import AppKit
+import SwiftUI
+import Testing
+@testable import MarkdownEngine
+
+@MainActor
+@Suite("Read-only task checkbox interaction")
+struct ReadOnlyTaskCheckboxTests {
+    @Test("The opt-in click toggles the binding while ordinary edits stay blocked")
+    func optInClickTogglesWithoutEnablingEditing() async throws {
+        let source = "- [ ] Item\r\nPlain\r\n"
+        let fixture = try makeFixture(source, allowsReadOnlyToggle: true)
+
+        #expect(fixture.textView.isEditable == false)
+        #expect(fixture.textView.shouldChangeText(
+            in: NSRange(location: 6, length: 0),
+            replacementString: "X"
+        ) == false)
+
+        #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
+        for _ in 0..<4 {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
+
+        #expect(fixture.textView.string == "- [x] Item\r\nPlain\r\n")
+        #expect(fixture.published() == "- [x] Item\r\nPlain\r\n")
+    }
+
+    @Test("Read-only checkboxes remain inert by default")
+    func defaultReadOnlyClickIsInert() throws {
+        let source = "- [ ] Item\n"
+        let fixture = try makeFixture(source, allowsReadOnlyToggle: false)
+
+        #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
+        #expect(fixture.textView.string == source)
+        #expect(fixture.published() == source)
+    }
+
+    private func makeFixture(
+        _ source: String,
+        allowsReadOnlyToggle: Bool
+    ) throws -> (
+        textView: NativeTextView,
+        click: NSEvent,
+        published: () -> String,
+        window: NSWindow
+    ) {
+        _ = NSApplication.shared
+        var published = source
+        let coordinator = NativeTextViewCoordinator(
+            text: Binding(get: { published }, set: { published = $0 }),
+            fontName: NSFont.systemFont(ofSize: 14).fontName,
+            fontSize: 14,
+            isWikiLinkActive: .constant(false),
+            onLinkClick: nil,
+            onInlineSelectionChange: nil
+        )
+        let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = textView
+        textView.frame = window.contentView?.bounds ?? .zero
+        textView.baseFont = .systemFont(ofSize: 14)
+        textView.font = textView.baseFont
+        textView.textContainerInset = NSSize(width: 40, height: 20)
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.allowsTaskCheckboxInteractionWhenReadOnly = allowsReadOnlyToggle
+        textView.delegate = coordinator
+        coordinator.textView = textView
+        coordinator.rebuildTextStorageAndStyle(textView, from: source)
+
+        let checkboxRange = NSRange(location: 2, length: 3)
+        guard let textContainer = textView.textContainer,
+              let layoutManager = textView.textLayoutManager else {
+            throw FixtureError.missingTextKitStack
+        }
+        let bridge = LayoutBridge(layoutManager)
+        textView.layoutBridge = bridge
+        coordinator.layoutBridge = bridge
+        layoutManager.ensureLayout(for: layoutManager.documentRange)
+        let anchor = bridge.boundingRect(forCharacterRange: checkboxRange, in: textContainer)
+        let size = TaskCheckboxGeometry.size(for: textView.baseFont)
+        let containerPoint = CGPoint(
+            x: TaskCheckboxGeometry.boxX(contentX: anchor.minX, size: size) + size / 2,
+            y: anchor.midY
+        )
+        let viewPoint = CGPoint(
+            x: containerPoint.x + textView.textContainerOrigin.x,
+            y: containerPoint.y + textView.textContainerOrigin.y
+        )
+        let windowPoint = textView.convert(viewPoint, to: nil)
+        guard let click = NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: windowPoint,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ) else {
+            throw FixtureError.missingMouseEvent
+        }
+
+        return (textView, click, { published }, window)
+    }
+
+    private enum FixtureError: Error {
+        case missingTextKitStack
+        case missingMouseEvent
+    }
+}

--- a/Tests/MarkdownEngineTests/ReadOnlyTaskCheckboxTests.swift
+++ b/Tests/MarkdownEngineTests/ReadOnlyTaskCheckboxTests.swift
@@ -11,10 +11,21 @@ import Testing
 @MainActor
 @Suite("Read-only task checkbox interaction")
 struct ReadOnlyTaskCheckboxTests {
+    @Test("The public wrapper defaults read-only checkbox interaction to off")
+    func wrapperDefaultIsOff() {
+        let wrapper = NativeTextViewWrapper(text: .constant(""))
+
+        #expect(wrapper.allowsTaskCheckboxInteractionWhenReadOnly == false)
+    }
+
     @Test("The opt-in click toggles the binding while ordinary edits stay blocked")
     func optInClickTogglesWithoutEnablingEditing() async throws {
         let source = "- [ ] Item\r\nPlain\r\n"
-        let fixture = try makeFixture(source, allowsReadOnlyToggle: true)
+        let fixture = try makeFixture(
+            source,
+            checkboxRange: NSRange(location: 2, length: 3),
+            allowsReadOnlyToggle: true
+        )
 
         #expect(fixture.textView.isEditable == false)
         #expect(fixture.textView.shouldChangeText(
@@ -23,11 +34,7 @@ struct ReadOnlyTaskCheckboxTests {
         ) == false)
 
         #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
-        for _ in 0..<4 {
-            await withCheckedContinuation { continuation in
-                DispatchQueue.main.async { continuation.resume() }
-            }
-        }
+        await settleBinding()
 
         #expect(fixture.textView.string == "- [x] Item\r\nPlain\r\n")
         #expect(fixture.published() == "- [x] Item\r\nPlain\r\n")
@@ -36,20 +43,96 @@ struct ReadOnlyTaskCheckboxTests {
     @Test("Read-only checkboxes remain inert by default")
     func defaultReadOnlyClickIsInert() throws {
         let source = "- [ ] Item\n"
-        let fixture = try makeFixture(source, allowsReadOnlyToggle: false)
+        let fixture = try makeFixture(
+            source,
+            checkboxRange: NSRange(location: 2, length: 3),
+            allowsReadOnlyToggle: false
+        )
 
         #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
         #expect(fixture.textView.string == source)
         #expect(fixture.published() == source)
     }
 
+    @Test(
+        "Clicking the second checkbox changes only its source range",
+        arguments: ["\n", "\r\n"]
+    )
+    func secondCheckboxChangesOnlyItsRange(lineEnding: String) async throws {
+        let source = "- [ ] First\(lineEnding)- [ ] Second\(lineEnding)Plain\(lineEnding)"
+        let range = try secondCheckboxRange(in: source)
+        let fixture = try makeFixture(
+            source,
+            checkboxRange: range,
+            allowsReadOnlyToggle: true
+        )
+
+        #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
+        await settleBinding()
+
+        let expected = "- [ ] First\(lineEnding)- [x] Second\(lineEnding)Plain\(lineEnding)"
+        #expect(fixture.textView.string == expected)
+        #expect(fixture.published() == expected)
+    }
+
+    @Test("The click reports the exact three-character text mutation")
+    func reportsExactMutation() async throws {
+        let source = "- [ ] First\n- [ ] Second\n"
+        let range = try secondCheckboxRange(in: source)
+        var mutations: [MarkdownTextMutation] = []
+        let fixture = try makeFixture(
+            source,
+            checkboxRange: range,
+            allowsReadOnlyToggle: true,
+            onTextMutation: { mutations.append($0) }
+        )
+
+        #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
+        await settleBinding()
+
+        #expect(mutations.count == 1)
+        #expect(mutations.first?.range == range)
+        #expect(mutations.first?.replacement == "[x]")
+    }
+
+    @Test("A read-only checkbox toggle participates in undo and redo")
+    func supportsUndoAndRedo() async throws {
+        let source = "- [ ] Item\r\n"
+        let fixture = try makeFixture(
+            source,
+            checkboxRange: NSRange(location: 2, length: 3),
+            allowsReadOnlyToggle: true
+        )
+
+        #expect(fixture.textView.toggleTaskCheckboxIfHit(event: fixture.click) == true)
+        await settleBinding()
+        #expect(fixture.textView.string == "- [x] Item\r\n")
+
+        let undoManager = try #require(fixture.coordinator.undoManager(for: fixture.textView))
+        #expect(undoManager.canUndo)
+        undoManager.undo()
+        await settleBinding()
+        #expect(fixture.textView.string == source)
+        #expect(fixture.published() == source)
+
+        #expect(undoManager.canRedo)
+        undoManager.redo()
+        await settleBinding()
+        #expect(fixture.textView.string == "- [x] Item\r\n")
+        #expect(fixture.published() == "- [x] Item\r\n")
+        #expect(fixture.textView.isEditable == false)
+    }
+
     private func makeFixture(
         _ source: String,
-        allowsReadOnlyToggle: Bool
+        checkboxRange: NSRange,
+        allowsReadOnlyToggle: Bool,
+        onTextMutation: ((MarkdownTextMutation) -> Void)? = nil
     ) throws -> (
         textView: NativeTextView,
         click: NSEvent,
         published: () -> String,
+        coordinator: NativeTextViewCoordinator,
         window: NSWindow
     ) {
         _ = NSApplication.shared
@@ -62,6 +145,7 @@ struct ReadOnlyTaskCheckboxTests {
             onLinkClick: nil,
             onInlineSelectionChange: nil
         )
+        coordinator.onTextMutation = onTextMutation
         let textView = NativeTextView(frame: NSRect(x: 0, y: 0, width: 400, height: 200))
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
@@ -76,12 +160,12 @@ struct ReadOnlyTaskCheckboxTests {
         textView.textContainerInset = NSSize(width: 40, height: 20)
         textView.isEditable = false
         textView.isSelectable = true
+        textView.allowsUndo = true
         textView.allowsTaskCheckboxInteractionWhenReadOnly = allowsReadOnlyToggle
         textView.delegate = coordinator
         coordinator.textView = textView
         coordinator.rebuildTextStorageAndStyle(textView, from: source)
 
-        let checkboxRange = NSRange(location: 2, length: 3)
         guard let textContainer = textView.textContainer,
               let layoutManager = textView.textLayoutManager else {
             throw FixtureError.missingTextKitStack
@@ -115,11 +199,30 @@ struct ReadOnlyTaskCheckboxTests {
             throw FixtureError.missingMouseEvent
         }
 
-        return (textView, click, { published }, window)
+        return (textView, click, { published }, coordinator, window)
+    }
+
+    private func secondCheckboxRange(in source: String) throws -> NSRange {
+        let text = source as NSString
+        let first = text.range(of: "[ ]")
+        guard first.location != NSNotFound else { throw FixtureError.missingCheckbox }
+        let remainder = NSRange(location: NSMaxRange(first), length: text.length - NSMaxRange(first))
+        let second = text.range(of: "[ ]", options: [], range: remainder)
+        guard second.location != NSNotFound else { throw FixtureError.missingCheckbox }
+        return second
+    }
+
+    private func settleBinding() async {
+        for _ in 0..<4 {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.main.async { continuation.resume() }
+            }
+        }
     }
 
     private enum FixtureError: Error {
         case missingTextKitStack
         case missingMouseEvent
+        case missingCheckbox
     }
 }


### PR DESCRIPTION
Adds an opt-in wrapper policy that keeps task checkboxes interactive while NSTextView remains non-editable. Qualification proved the existing isEditable=false path rejects shouldChangeText, which justifies a narrow opt-in API; the default stays fully read-only. Tests exercise the actual checkbox hit-test and click mutation path, prove ordinary edits remain rejected, cover second-of-two exact-range changes under LF and CRLF, verify the exact three-character onTextMutation callback, preserve the settled binding, and prove document-scoped undo and redo. Includes 6 focused tests; the full suite passes 476 tests in 69 suites. Follow-up embedder parity work discovered while implementing issue #173.