### PR TITLE
Add UIKit live preview support for iOS 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add an editable UIKit live-preview implementation for iOS 17 while preserving the existing macOS editor.
+
 ### Added
 - **Directive seam (parsing)**: opt-in named inline commands with typed
   arguments, for constructs that need a name and parameters rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Prevent iOS task-checkbox taps from also moving the text cursor into the Markdown marker.
+
 - Add an editable UIKit live-preview implementation for iOS 17 while preserving the existing macOS editor.
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,10 @@ import PackageDescription
 // at link time.
 let package = Package(
     name: "MarkdownEngine",
-    platforms: [.macOS(.v14)],
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+    ],
     products: [
         .library(name: "MarkdownEngine", targets: ["MarkdownEngine"]),
         .library(name: "MarkdownEngineCodeBlocks", targets: ["MarkdownEngineCodeBlocks"]),
@@ -45,6 +48,10 @@ let package = Package(
         ),
         .testTarget(
             name: "MarkdownEngineTests",
+            dependencies: ["MarkdownEngine"]
+        ),
+        .testTarget(
+            name: "MarkdownEngineIOSTests",
             dependencies: ["MarkdownEngine"]
         )
     ]

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorConfiguration.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownEditorConfiguration.swift
 //  MarkdownEngine
@@ -761,3 +762,4 @@ extension MarkdownEditorConfiguration {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
+++ b/Sources/MarkdownEngine/Configuration/MarkdownEditorTheme.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownEditorTheme.swift
 //  MarkdownEngine
@@ -115,3 +116,4 @@ public struct MarkdownEditorTheme: Sendable {
     /// `NSTextView`. It's also the default when no theme is supplied.
     public static let `default` = MarkdownEditorTheme()
 }
+#endif

--- a/Sources/MarkdownEngine/Diagnostics/PerfTrace.swift
+++ b/Sources/MarkdownEngine/Diagnostics/PerfTrace.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  PerfTrace.swift
 //  MarkdownEngine
@@ -133,3 +134,4 @@ enum PerfTrace {
         print(String(format: "⏱️ PERF %@ %.2fms %@", label, ms, detail()))
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
+++ b/Sources/MarkdownEngine/Directives/BuiltinDirectives.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BuiltinDirectives.swift
 //  MarkdownEngine
@@ -125,3 +126,4 @@ public struct ColorDirective: MarkdownDirective {
         return "<span style=\"color:\(name)\">\(bodyHTML)</span>"
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveArguments.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveArguments.swift
 //  MarkdownEngine
@@ -264,3 +265,4 @@ extension DirectiveArguments {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Directives/DirectiveRegistry.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveRegistry.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveRegistry.swift
 //  MarkdownEngine
@@ -167,3 +168,4 @@ extension MarkdownEditorConfiguration {
         DirectiveRegistry(directives: directives, settings: directiveSettings)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
+++ b/Sources/MarkdownEngine/Directives/DirectiveScanner.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveScanner.swift
 //  MarkdownEngine
@@ -254,3 +255,4 @@ enum DirectiveScanner {
         return count % 2 == 1
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
+++ b/Sources/MarkdownEngine/Directives/MarkdownDirective.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownDirective.swift
 //  MarkdownEngine
@@ -304,3 +305,4 @@ public extension MarkdownDirective {
     }
 
 }
+#endif

--- a/Sources/MarkdownEngine/Extensions/ContainerExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/ContainerExtension.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ContainerExtension.swift
 //  MarkdownEngine
@@ -61,3 +62,4 @@ public struct ContainerExtension: MarkdownExtension {
         "<blockquote>\(childrenHTML)</blockquote>"
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Extensions/HighlightExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/HighlightExtension.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HighlightExtension.swift
 //  MarkdownEngine
@@ -44,3 +45,4 @@ public struct HighlightExtension: MarkdownExtension {
         "<mark>\(childrenHTML)</mark>"
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/MarkdownExtension.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownExtension.swift
 //  MarkdownEngine
@@ -252,3 +253,4 @@ extension MarkdownEditorConfiguration {
         return out
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Extensions/StrikethroughExtension.swift
+++ b/Sources/MarkdownEngine/Extensions/StrikethroughExtension.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  StrikethroughExtension.swift
 //  MarkdownEngine
@@ -43,3 +44,4 @@ public struct StrikethroughExtension: MarkdownExtension {
         "<del>\(childrenHTML)</del>"
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Input/MarkdownInputHandler.swift
+++ b/Sources/MarkdownEngine/Input/MarkdownInputHandler.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownInputHandler.swift
 //  MarkdownEngine
@@ -160,3 +161,4 @@ enum MarkdownInputHandler {
         return false
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Input/MarkdownListHandler.swift
+++ b/Sources/MarkdownEngine/Input/MarkdownListHandler.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownListHandler.swift
 //  MarkdownEngine
@@ -325,3 +326,4 @@ struct MarkdownLists {
         return true
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Parser/DocumentParseState.swift
+++ b/Sources/MarkdownEngine/Parser/DocumentParseState.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DocumentParseState.swift
 //  MarkdownEngine
@@ -155,3 +156,4 @@ final class DocumentParseState {
         return resolvedTokens
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Parser/MarkdownDetection.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownDetection.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownDetection.swift
 //  MarkdownEngine
@@ -168,3 +169,4 @@ enum MarkdownDetection {
     }
 
 }
+#endif

--- a/Sources/MarkdownEngine/Parser/MarkdownToken.swift
+++ b/Sources/MarkdownEngine/Parser/MarkdownToken.swift
@@ -7,7 +7,6 @@
 
 // Defines the basic Markdown building blocks the editor works with (bold,
 // links, code, LaTeX, etc.), plus shared text attributes.
-import AppKit
 import Foundation
 
 extension NSAttributedString.Key {

--- a/Sources/MarkdownEngine/Renderer/EmbeddedImageCache.swift
+++ b/Sources/MarkdownEngine/Renderer/EmbeddedImageCache.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  EmbeddedImageCache.swift
 //  MarkdownEngine
@@ -122,3 +123,4 @@ final class EmbeddedImageCache {
         return image
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Renderer/LayoutBridge.swift
+++ b/Sources/MarkdownEngine/Renderer/LayoutBridge.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  LayoutBridge.swift
 //  MarkdownEngine
@@ -102,3 +103,4 @@ final class LayoutBridge {
         textLayoutManager.textContainer
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownHTMLRenderer.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownHTMLRenderer.swift
 //  MarkdownEngine
@@ -343,3 +344,4 @@ public enum MarkdownHTMLRenderer {
         return out
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/Renderer/MarkdownTextLayoutFragment.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownTextLayoutFragment.swift
 //  MarkdownEngine
@@ -869,3 +870,4 @@ final class MarkdownLayoutManagerDelegate: NSObject, NSTextLayoutManagerDelegate
         return fragment
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
+++ b/Sources/MarkdownEngine/Renderer/TaskCheckboxGeometry.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TaskCheckboxGeometry.swift
 //  MarkdownEngine
@@ -33,3 +34,4 @@ enum TaskCheckboxGeometry {
         contentX - size - gap
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
+++ b/Sources/MarkdownEngine/Renderer/WideTableOverlay.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  WideTableOverlay.swift
 //  MarkdownEngine
@@ -319,3 +320,4 @@ extension NativeTextView {
         wideTableOverlays.removeAll()
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
+++ b/Sources/MarkdownEngine/Services/MarkdownEditorServices.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownEditorServices.swift
 //  MarkdownEngine
@@ -337,3 +338,4 @@ public struct MarkdownEditorServices: Sendable {
 
     public static let `default` = MarkdownEditorServices()
 }
+#endif

--- a/Sources/MarkdownEngine/Services/WikiLinkService.swift
+++ b/Sources/MarkdownEngine/Services/WikiLinkService.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  WikiLinkService.swift
 //  MarkdownEngine
@@ -326,3 +327,4 @@ public enum WikiLinkService {
     }
 }
 
+#endif

--- a/Sources/MarkdownEngine/Styling/HeadingHelpers.swift
+++ b/Sources/MarkdownEngine/Styling/HeadingHelpers.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HeadingHelpers.swift
 //  MarkdownEngine
@@ -48,3 +49,4 @@ enum HeadingHelpers {
         return width
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler+Directives.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler+Directives.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownASTStyler+Directives.swift
 //  MarkdownEngine
@@ -76,3 +77,4 @@ extension MarkdownASTStyler {
         return bodyFont
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownASTStyler.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownASTStyler.swift
 //  MarkdownEngine
@@ -995,3 +996,4 @@ enum MarkdownASTStyler {
         ]
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+BulletMarkers.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+BulletMarkers.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+BulletMarkers.swift
 //  MarkdownEngine
@@ -44,3 +45,4 @@ extension MarkdownStyler {
         return nil
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Images.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Images.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+Images.swift
 //  MarkdownEngine
@@ -194,3 +195,4 @@ extension MarkdownStyler {
         return attrs
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Latex.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Latex.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+Latex.swift
 //  MarkdownEngine
@@ -158,3 +159,4 @@ extension MarkdownStyler {
         return attrs
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+OrderedMarkers.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+OrderedMarkers.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+OrderedMarkers.swift
 //  MarkdownEngine
@@ -24,3 +25,4 @@ extension MarkdownStyler {
         options: [.anchorsMatchLines]
     )
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+Tables.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+Tables.swift
 //  MarkdownEngine
@@ -768,3 +769,4 @@ extension MarkdownStyler {
         return hasher.finalize()
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler+TaskCheckboxes.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler+TaskCheckboxes.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler+TaskCheckboxes.swift
 //  MarkdownEngine
@@ -46,3 +47,4 @@ extension MarkdownStyler {
         return nil
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
+++ b/Sources/MarkdownEngine/Styling/MarkdownStyler.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownStyler.swift
 //  MarkdownEngine
@@ -510,3 +511,4 @@ extension MarkdownStyler {
         return lineRange
     }
 }
+#endif

--- a/Sources/MarkdownEngine/Styling/TextStylingService.swift
+++ b/Sources/MarkdownEngine/Styling/TextStylingService.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TextStylingService.swift
 //  MarkdownEngine
@@ -275,3 +276,4 @@ struct TextStylingService {
         return NSTextRange(location: start, end: end)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/BottomOverscrollPolicy.swift
+++ b/Sources/MarkdownEngine/TextView/BottomOverscrollPolicy.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BottomOverscrollPolicy.swift
 //  MarkdownEngine
@@ -69,3 +70,4 @@ struct BottomOverscrollPolicy {
         return floor((scrollUnlockDistance + desiredSlack) * activationProgress)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
+++ b/Sources/MarkdownEngine/TextView/ClampedScrollView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ClampedScrollView.swift
 //  MarkdownEngine
@@ -137,3 +138,4 @@ final class ClampedScrollView: NSScrollView {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/CodeBlockButton.swift
+++ b/Sources/MarkdownEngine/TextView/CodeBlockButton.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  CodeBlockButton.swift
 //  MarkdownEngine
@@ -96,3 +97,4 @@ public struct CodeBlockButton: View {
             )
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/ContextMenu.swift
+++ b/Sources/MarkdownEngine/TextView/ContextMenu.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ContextMenu.swift
 //  MarkdownEngine
@@ -531,3 +532,4 @@ extension NativeTextViewWrapper.Coordinator {
 // Menu Item Validation (checkmark state) removed together with the built-in menu —
 // engine ships no UI. Expose the isSelection* checks as a query API if embedders
 // need menu state.
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Autocorrect.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+Autocorrect.swift
 //  MarkdownEngine
@@ -99,3 +100,4 @@ extension NativeTextViewCoordinator {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CaretColor.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+CaretColor.swift
 //  MarkdownEngine
@@ -54,3 +55,4 @@ extension NativeTextViewCoordinator {
         return innermost?.color ?? theme.bodyText
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+CodeBlocks.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+CodeBlocks.swift
 //  MarkdownEngine
@@ -97,3 +98,4 @@ extension NativeTextViewCoordinator {
         onCodeBlockSelectionChange?(selections)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Find.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+Find.swift
 //  MarkdownEngine
@@ -272,3 +273,4 @@ extension NativeTextViewCoordinator {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+InlineSelection.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+InlineSelection.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+InlineSelection.swift
 //  MarkdownEngine
@@ -115,3 +116,4 @@ extension NativeTextViewCoordinator {
         isImageEmbedActive = false
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Notifications.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+Notifications.swift
 //  MarkdownEngine
@@ -78,3 +79,4 @@ extension NativeTextViewCoordinator {
         restyleTextView(tv, paragraphCandidates: [fullRange])
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+Restyling.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+Restyling.swift
 //  MarkdownEngine
@@ -466,3 +467,4 @@ extension NativeTextViewCoordinator {
         textView.setSelectedRange(clampedCaret)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+TextDelegate.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+TextDelegate.swift
 //  MarkdownEngine
@@ -1109,3 +1110,4 @@ extension NativeTextViewCoordinator {
     }
 
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WikiLinkSnapback.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WikiLinkSnapback.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+WikiLinkSnapback.swift
 //  MarkdownEngine
@@ -62,3 +63,4 @@ extension NativeTextViewCoordinator {
         return newCaret
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WritingTools.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator+WritingTools.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator+WritingTools.swift
 //  MarkdownEngine
@@ -126,3 +127,4 @@ extension NativeTextViewCoordinator {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
+++ b/Sources/MarkdownEngine/TextView/Coordinator/NativeTextViewCoordinator.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewCoordinator.swift
 //  MarkdownEngine
@@ -489,3 +490,4 @@ extension NSTextView {
         return boundingRect
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/HTMLToMarkdownConverter.swift
+++ b/Sources/MarkdownEngine/TextView/HTMLToMarkdownConverter.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HTMLToMarkdownConverter.swift
 //  MarkdownEngine
@@ -631,3 +632,4 @@ enum HTMLToMarkdownConverter {
 private extension String {
     var htmlTrimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/MarkdownPasteboardWriter.swift
+++ b/Sources/MarkdownEngine/TextView/MarkdownPasteboardWriter.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownPasteboardWriter.swift
 //  MarkdownEngine
@@ -107,3 +108,4 @@ enum MarkdownPasteboardWriter {
         )
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/MarkdownTextMutation.swift
+++ b/Sources/MarkdownEngine/TextView/MarkdownTextMutation.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownTextMutation.swift
 //  MarkdownEngine
@@ -20,3 +21,4 @@ public struct MarkdownTextMutation: Equatable, Sendable {
         self.replacement = replacement
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/InvertedIBeamCursor.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/InvertedIBeamCursor.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InvertedIBeamCursor.swift
 //  MarkdownEngine
@@ -96,3 +97,4 @@ enum InvertedIBeamCursor {
          UInt8(clamping: Int(color.blueComponent * 255)))
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CaretWorkarounds.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CaretWorkarounds.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+CaretWorkarounds.swift
 //  MarkdownEngine
@@ -105,3 +106,4 @@ extension NativeTextView {
         isApplyingCaretShift = false
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+ClickRemap.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+ClickRemap.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+ClickRemap.swift
 //  MarkdownEngine
@@ -55,3 +56,4 @@ extension NativeTextView {
         return true
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CmdReturn.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+CmdReturn.swift
 //  MarkdownEngine
@@ -22,3 +23,4 @@ extension NativeTextView {
         return super.performKeyEquivalent(with: event)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Copy.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Copy.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+Copy.swift
 //  MarkdownEngine
@@ -26,3 +27,4 @@ extension NativeTextView {
                                        directiveSettings: configuration.directiveSettings)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+CursorRects.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+CursorRects.swift
 //  MarkdownEngine
@@ -177,3 +178,4 @@ extension NativeTextView {
         cursor.set()
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+DragSelectBoost.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+DragSelectBoost.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+DragSelectBoost.swift
 //  MarkdownEngine
@@ -98,3 +99,4 @@ extension NativeTextView {
         (scrollView as? ClampedScrollView)?.clampToInsets()
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+FrameAndOverscroll.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+FrameAndOverscroll.swift
 //  MarkdownEngine
@@ -449,3 +450,4 @@ extension NativeTextView {
         }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+PasteHandling.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+PasteHandling.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+PasteHandling.swift
 //  MarkdownEngine
@@ -204,3 +205,4 @@ extension NativeTextView {
         return count
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Placeholder.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+Placeholder.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+Placeholder.swift
 //  MarkdownEngine
@@ -99,3 +100,4 @@ private extension NSRect {
             && abs(size.height - other.size.height) < 0.5
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingPolicy.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingPolicy.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+SpellingPolicy.swift
 //  MarkdownEngine
@@ -44,3 +45,4 @@ extension NativeTextView {
         super.setSpellingState(value, range: charRange)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingToggles.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+SpellingToggles.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+SpellingToggles.swift
 //  MarkdownEngine
@@ -29,3 +30,4 @@ extension NativeTextView {
         (delegate as? NativeTextViewCoordinator)?.didToggleSpellCheckingPolicy(textView: self)
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView+TaskCheckbox.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView+TaskCheckbox.swift
 //  MarkdownEngine
@@ -74,3 +75,4 @@ extension NativeTextView {
         return true
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextView/NativeTextView.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextView.swift
 //  MarkdownEngine
@@ -103,3 +104,4 @@ final class NativeTextView: NSTextView {
 
     deinit { caretIndicatorObservation?.invalidate() }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewContainer.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewContainer.swift
 //  MarkdownEngine
@@ -116,3 +117,4 @@ extension NSScrollView {
         (documentView as? NativeTextViewContainer)?.textView
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewSelectionTypes.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewSelectionTypes.swift
 //  MarkdownEngine
@@ -93,3 +94,4 @@ public struct InlineReplacementRequest: Sendable {
         self.isImageEmbedMode = isImageEmbedMode
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
+++ b/Sources/MarkdownEngine/TextView/NativeTextViewWrapper.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewWrapper.swift
 //  MarkdownEngine
@@ -787,3 +788,4 @@ private extension NativeTextViewWrapper {
         )
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/PasteboardImageReader.swift
+++ b/Sources/MarkdownEngine/TextView/PasteboardImageReader.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  PasteboardImageReader.swift
 //  MarkdownEngine
@@ -92,3 +93,4 @@ public enum PasteboardImageReader {
         return bitmapRep.representation(using: .png, properties: [:])
     }
 }
+#endif

--- a/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
+++ b/Sources/MarkdownEngine/TextView/ScrollingHeaderController.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ScrollingHeaderController.swift
 //  MarkdownEngine
@@ -430,3 +431,4 @@ final class ScrollingHeaderController {
         if instant { container.layoutSubtreeIfNeeded() }
     }
 }
+#endif

--- a/Sources/MarkdownEngine/iOS/MarkdownEditorConfiguration+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/MarkdownEditorConfiguration+iOS.swift
@@ -1,0 +1,75 @@
+#if os(iOS)
+import Foundation
+import UIKit
+
+/// Color palette used by the UIKit markdown editor.
+public struct MarkdownEditorTheme: @unchecked Sendable {
+    public var bodyText: UIColor
+    public var mutedText: UIColor
+    public var disabledText: UIColor
+    public var headingMarker: UIColor
+    public var link: UIColor
+    public var codeBackground: UIColor
+    public var quote: UIColor
+
+    public init(
+        bodyText: UIColor = .label,
+        mutedText: UIColor = .secondaryLabel,
+        disabledText: UIColor = .tertiaryLabel,
+        headingMarker: UIColor = .secondaryLabel,
+        link: UIColor = .link,
+        codeBackground: UIColor = .secondarySystemBackground,
+        quote: UIColor = .secondaryLabel
+    ) {
+        self.bodyText = bodyText
+        self.mutedText = mutedText
+        self.disabledText = disabledText
+        self.headingMarker = headingMarker
+        self.link = link
+        self.codeBackground = codeBackground
+        self.quote = quote
+    }
+
+    public static let `default` = MarkdownEditorTheme()
+}
+
+/// Margins inside the text view.
+public struct TextInsets: Sendable {
+    public var horizontal: CGFloat
+    public var vertical: CGFloat
+
+    public init(horizontal: CGFloat = 0, vertical: CGFloat = 0) {
+        self.horizontal = horizontal
+        self.vertical = vertical
+    }
+
+    public static let `default` = TextInsets()
+}
+
+/// UIKit editor configuration. Its defaults mirror the macOS editor's live-preview behavior.
+public struct MarkdownEditorConfiguration: @unchecked Sendable {
+    public enum HeightBehavior: Sendable {
+        case scrolls
+        case fitsContent
+    }
+
+    public var theme: MarkdownEditorTheme
+    public var textInsets: TextInsets
+    public var heightBehavior: HeightBehavior
+    public var rawSourceMode: Bool
+
+    public init(
+        theme: MarkdownEditorTheme = .default,
+        textInsets: TextInsets = .default,
+        heightBehavior: HeightBehavior = .scrolls,
+        rawSourceMode: Bool = false
+    ) {
+        self.theme = theme
+        self.textInsets = textInsets
+        self.heightBehavior = heightBehavior
+        self.rawSourceMode = rawSourceMode
+    }
+
+    public static let `default` = MarkdownEditorConfiguration()
+}
+#endif

--- a/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
@@ -10,6 +10,7 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
     public var fontSize: CGFloat
     public var documentId: String
     public var isEditable: Bool
+    public var configureTextView: ((UITextView) -> Void)?
 
     public init(
         text: Binding<String>,
@@ -17,7 +18,8 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         fontName: String = "SF Pro",
         fontSize: CGFloat = 16,
         documentId: String = "default",
-        isEditable: Bool = true
+        isEditable: Bool = true,
+        configureTextView: ((UITextView) -> Void)? = nil
     ) {
         self._text = text
         self.configuration = configuration
@@ -25,6 +27,7 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         self.fontSize = fontSize
         self.documentId = documentId
         self.isEditable = isEditable
+        self.configureTextView = configureTextView
     }
 
     public func makeCoordinator() -> Coordinator {
@@ -53,6 +56,7 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         }
         applyLayout(to: textView)
         context.coordinator.render(text, in: textView, preservingSelection: false)
+        configureTextView?(textView)
         return textView
     }
 

--- a/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
@@ -44,10 +44,13 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainer.lineFragmentPadding = 0
         textView.keyboardDismissMode = .interactive
+        let textSelectionTapGestures = textView.gestureRecognizers?.compactMap { $0 as? UITapGestureRecognizer } ?? []
         let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
-        tapGesture.cancelsTouchesInView = false
         tapGesture.delegate = context.coordinator
         textView.addGestureRecognizer(tapGesture)
+        for textSelectionTapGesture in textSelectionTapGestures {
+            textSelectionTapGesture.require(toFail: tapGesture)
+        }
         applyLayout(to: textView)
         context.coordinator.render(text, in: textView, preservingSelection: false)
         return textView
@@ -142,7 +145,12 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
             _ gestureRecognizer: UIGestureRecognizer,
             shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
         ) -> Bool {
-            true
+            false
+        }
+
+        public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+            guard let textView = gestureRecognizer.view as? UITextView else { return false }
+            return taskCheckbox(at: touch.location(in: textView), in: textView) != nil
         }
 
         @objc func handleTap(_ gesture: UITapGestureRecognizer) {

--- a/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
@@ -1,0 +1,181 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// SwiftUI bridge for MarkdownEngine's editable UIKit live preview.
+public struct NativeTextViewWrapper: UIViewRepresentable {
+    @Binding public var text: String
+    public var configuration: MarkdownEditorConfiguration
+    public var fontName: String
+    public var fontSize: CGFloat
+    public var documentId: String
+    public var isEditable: Bool
+
+    public init(
+        text: Binding<String>,
+        configuration: MarkdownEditorConfiguration = .default,
+        fontName: String = "SF Pro",
+        fontSize: CGFloat = 16,
+        documentId: String = "default",
+        isEditable: Bool = true
+    ) {
+        self._text = text
+        self.configuration = configuration
+        self.fontName = fontName
+        self.fontSize = fontSize
+        self.documentId = documentId
+        self.isEditable = isEditable
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    public func makeUIView(context: Context) -> UITextView {
+        let textView = UITextView(usingTextLayoutManager: true)
+        textView.delegate = context.coordinator
+        textView.backgroundColor = .clear
+        textView.isEditable = isEditable
+        textView.isSelectable = true
+        textView.isAccessibilityElement = true
+        textView.accessibilityIdentifier = "MarkdownEditor"
+        textView.accessibilityLabel = "Markdown editor"
+        textView.adjustsFontForContentSizeCategory = true
+        textView.textContainer.lineFragmentPadding = 0
+        textView.keyboardDismissMode = .interactive
+        applyLayout(to: textView)
+        context.coordinator.render(text, in: textView, preservingSelection: false)
+        return textView
+    }
+
+    public func updateUIView(_ textView: UITextView, context: Context) {
+        context.coordinator.parent = self
+        textView.isEditable = isEditable
+        applyLayout(to: textView)
+        if textView.text != text || context.coordinator.documentId != documentId {
+            context.coordinator.documentId = documentId
+            context.coordinator.render(text, in: textView, preservingSelection: false)
+        } else if context.coordinator.requiresRestyle(configuration: configuration, fontName: fontName, fontSize: fontSize) {
+            context.coordinator.render(text, in: textView, preservingSelection: true)
+        }
+    }
+
+    public func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+        guard configuration.heightBehavior == .fitsContent else { return nil }
+        let width = proposal.width ?? uiView.bounds.width
+        guard width > 0 else { return nil }
+        return uiView.sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+    }
+
+    private func applyLayout(to textView: UITextView) {
+        textView.textContainerInset = UIEdgeInsets(
+            top: configuration.textInsets.vertical,
+            left: configuration.textInsets.horizontal,
+            bottom: configuration.textInsets.vertical,
+            right: configuration.textInsets.horizontal
+        )
+        textView.isScrollEnabled = configuration.heightBehavior == .scrolls
+    }
+
+    @MainActor
+    public final class Coordinator: NSObject, UITextViewDelegate {
+        var parent: NativeTextViewWrapper
+        var documentId: String
+        private var isRendering = false
+        private var lastConfiguration = MarkdownEditorConfiguration.default
+        private var lastFontName = ""
+        private var lastFontSize: CGFloat = 0
+
+        init(parent: NativeTextViewWrapper) {
+            self.parent = parent
+            self.documentId = parent.documentId
+        }
+
+        func requiresRestyle(configuration: MarkdownEditorConfiguration, fontName: String, fontSize: CGFloat) -> Bool {
+            lastFontName != fontName || lastFontSize != fontSize || lastConfiguration.rawSourceMode != configuration.rawSourceMode
+        }
+
+        func render(_ source: String, in textView: UITextView, preservingSelection: Bool) {
+            guard !isRendering else { return }
+            isRendering = true
+            let selection = preservingSelection ? textView.selectedRange : NSRange(location: 0, length: 0)
+            let safeSelection = NSRange(location: min(selection.location, (source as NSString).length), length: 0)
+            let styler = UIKitMarkdownStyler(configuration: parent.configuration, fontName: parent.fontName, fontSize: parent.fontSize)
+            textView.attributedText = styler.attributedString(for: source, selection: selection)
+            textView.selectedRange = preservingSelection ? selection.clamped(to: (source as NSString).length) : safeSelection
+            textView.typingAttributes = [
+                .font: UIFont(name: parent.fontName, size: parent.fontSize) ?? UIFont.systemFont(ofSize: parent.fontSize),
+                .foregroundColor: parent.configuration.theme.bodyText
+            ]
+            lastConfiguration = parent.configuration
+            lastFontName = parent.fontName
+            lastFontSize = parent.fontSize
+            isRendering = false
+            textView.invalidateIntrinsicContentSize()
+        }
+
+        public func textViewDidChange(_ textView: UITextView) {
+            guard !isRendering else { return }
+            parent.text = textView.text
+            render(textView.text, in: textView, preservingSelection: true)
+        }
+
+        public func textViewDidChangeSelection(_ textView: UITextView) {
+            guard !isRendering else { return }
+            render(textView.text, in: textView, preservingSelection: true)
+        }
+
+        public func textView(
+            _ textView: UITextView,
+            shouldChangeTextIn range: NSRange,
+            replacementText replacement: String
+        ) -> Bool {
+            guard replacement == "\n", range.length == 0 else { return true }
+            let source = textView.text as NSString
+            let lineRange = source.lineRange(for: NSRange(location: min(range.location, source.length), length: 0))
+            let beforeCaret = NSRange(location: lineRange.location, length: range.location - lineRange.location)
+            let prefixText = source.substring(with: beforeCaret)
+            guard let expression = try? NSRegularExpression(pattern: #"^(\s*(?:[-+*]|\d+[.)])\s+(?:\[[ xX]\]\s+)?)"#),
+                  let match = expression.firstMatch(in: prefixText, range: NSRange(location: 0, length: (prefixText as NSString).length)) else { return true }
+
+            let prefix = (prefixText as NSString).substring(with: match.range(at: 1))
+            let remainder = (prefixText as NSString).substring(from: NSMaxRange(match.range(at: 1)))
+            let replacementText: String
+            let replacementRange: NSRange
+            if remainder.trimmingCharacters(in: .whitespaces).isEmpty {
+                replacementText = ""
+                replacementRange = NSRange(location: lineRange.location, length: prefix.utf16.count)
+            } else {
+                replacementText = "\n" + nextListPrefix(prefix)
+                replacementRange = range
+            }
+
+            let mutable = NSMutableString(string: textView.text)
+            mutable.replaceCharacters(in: replacementRange, with: replacementText)
+            let caret = replacementRange.location + (replacementText as NSString).length
+            textView.text = mutable as String
+            textView.selectedRange = NSRange(location: caret, length: 0)
+            parent.text = mutable as String
+            render(mutable as String, in: textView, preservingSelection: true)
+            return false
+        }
+
+        private func nextListPrefix(_ prefix: String) -> String {
+            guard let expression = try? NSRegularExpression(pattern: #"^(\s*)(\d+)([.)])(\s+)"#),
+                  let match = expression.firstMatch(in: prefix, range: NSRange(location: 0, length: (prefix as NSString).length)) else {
+                return prefix.replacingOccurrences(of: "[x]", with: "[ ]", options: .caseInsensitive)
+            }
+            let ns = prefix as NSString
+            let number = Int(ns.substring(with: match.range(at: 2))) ?? 0
+            return ns.substring(with: match.range(at: 1)) + String(number + 1) + ns.substring(with: match.range(at: 3)) + ns.substring(with: match.range(at: 4))
+        }
+    }
+}
+
+private extension NSRange {
+    func clamped(to length: Int) -> NSRange {
+        let location = min(max(0, self.location), length)
+        return NSRange(location: location, length: min(self.length, length - location))
+    }
+}
+#endif

--- a/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/NativeTextViewWrapper+iOS.swift
@@ -34,6 +34,7 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
     public func makeUIView(context: Context) -> UITextView {
         let textView = UITextView(usingTextLayoutManager: true)
         textView.delegate = context.coordinator
+        textView.textLayoutManager?.delegate = context.coordinator
         textView.backgroundColor = .clear
         textView.isEditable = isEditable
         textView.isSelectable = true
@@ -43,6 +44,10 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         textView.adjustsFontForContentSizeCategory = true
         textView.textContainer.lineFragmentPadding = 0
         textView.keyboardDismissMode = .interactive
+        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delegate = context.coordinator
+        textView.addGestureRecognizer(tapGesture)
         applyLayout(to: textView)
         context.coordinator.render(text, in: textView, preservingSelection: false)
         return textView
@@ -78,7 +83,7 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
     }
 
     @MainActor
-    public final class Coordinator: NSObject, UITextViewDelegate {
+    public final class Coordinator: NSObject, UITextViewDelegate, NSTextLayoutManagerDelegate, UIGestureRecognizerDelegate {
         var parent: NativeTextViewWrapper
         var documentId: String
         private var isRendering = false
@@ -123,6 +128,65 @@ public struct NativeTextViewWrapper: UIViewRepresentable {
         public func textViewDidChangeSelection(_ textView: UITextView) {
             guard !isRendering else { return }
             render(textView.text, in: textView, preservingSelection: true)
+        }
+
+        public func textLayoutManager(
+            _ textLayoutManager: NSTextLayoutManager,
+            textLayoutFragmentFor location: any NSTextLocation,
+            in textElement: NSTextElement
+        ) -> NSTextLayoutFragment {
+            UIKitMarkdownTextLayoutFragment(textElement: textElement, range: textElement.elementRange)
+        }
+
+        public func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard gesture.state == .ended,
+                  parent.isEditable,
+                  let textView = gesture.view as? UITextView,
+                  let checkbox = taskCheckbox(at: gesture.location(in: textView), in: textView) else { return }
+
+            let replacement = checkbox.checked ? "[ ]" : "[x]"
+            let source = NSMutableString(string: textView.text)
+            source.replaceCharacters(in: checkbox.range, with: replacement)
+            let selection = textView.selectedRange.clamped(to: source.length)
+            textView.text = source as String
+            textView.selectedRange = selection
+            parent.text = source as String
+            render(source as String, in: textView, preservingSelection: true)
+        }
+
+        private func taskCheckbox(at point: CGPoint, in textView: UITextView) -> (range: NSRange, checked: Bool)? {
+            let attributedText = textView.attributedText ?? NSAttributedString()
+            let fullRange = NSRange(location: 0, length: attributedText.length)
+            var result: (range: NSRange, checked: Bool)?
+
+            attributedText.enumerateAttribute(.taskCheckbox, in: fullRange) { value, range, stop in
+                guard let checked = value as? Bool,
+                      let font = attributedText.attribute(.taskCheckboxFont, at: range.location, effectiveRange: nil) as? UIFont,
+                      let start = textView.position(from: textView.beginningOfDocument, offset: range.location),
+                      let end = textView.position(from: start, offset: range.length),
+                      let textRange = textView.textRange(from: start, to: end) else { return }
+
+                let anchor = textView.firstRect(for: textRange)
+                let size = ceil(font.lineHeight)
+                let box = CGRect(
+                    x: anchor.minX - size - 2,
+                    y: anchor.midY - size / 2,
+                    width: size,
+                    height: size
+                ).insetBy(dx: -6, dy: -6)
+                if box.contains(point) {
+                    result = (range, checked)
+                    stop.pointee = true
+                }
+            }
+            return result
         }
 
         public func textView(

--- a/Sources/MarkdownEngine/iOS/ParserSupport+iOS.swift
+++ b/Sources/MarkdownEngine/iOS/ParserSupport+iOS.swift
@@ -1,0 +1,66 @@
+#if os(iOS)
+import Foundation
+
+enum PerfTrace {
+    static func note(_ message: () -> String) {}
+}
+
+struct DirectiveRegistry {
+    static let empty = DirectiveRegistry()
+    let isEmpty = true
+    let fingerprint = ""
+}
+
+struct DirectiveMatch {
+    let nodeID: String
+    let range: NSRange
+    let contentRange: NSRange
+    let markers: [NSRange]
+    let parsesContent: Bool
+}
+
+enum DirectiveScanner {
+    static func match(_ text: NSString, len: Int, at index: Int, registry: DirectiveRegistry) -> DirectiveMatch? {
+        nil
+    }
+}
+
+struct InlineSyntax: Sendable, Equatable {
+    var open: String
+    var close: String
+    var parsesContent: Bool
+    var requiresNonEmptyContent: Bool
+    var rejectsOpenerRun: Bool
+    var rejectsCloserRun: Bool
+}
+
+struct ExtensionRegistry {
+    struct Entry {
+        let id: String
+        let open: [unichar]
+        let close: [unichar]
+        let syntax: InlineSyntax
+    }
+
+    struct BlockEntry {
+        let id: String
+        let fence: String
+        let fenceChars: [unichar]
+    }
+
+    let entries: [Entry]
+    let blockEntries: [BlockEntry]
+    let directives: DirectiveRegistry
+    let fingerprint: String
+
+    static let empty = ExtensionRegistry(entries: [], blockEntries: [], directives: .empty, fingerprint: "")
+
+    func blockEntry(opening line: String) -> BlockEntry? {
+        blockEntries.first { line.hasPrefix($0.fence) }
+    }
+
+    func blockEntry(for id: String) -> BlockEntry? {
+        blockEntries.first { $0.id == id }
+    }
+}
+#endif

--- a/Sources/MarkdownEngine/iOS/UIKitMarkdownStyler.swift
+++ b/Sources/MarkdownEngine/iOS/UIKitMarkdownStyler.swift
@@ -114,9 +114,48 @@ struct UIKitMarkdownStyler {
                     paragraph.headIndent = fontSize * 1.55
                     paragraph.firstLineHeadIndent = 0
                     result.addAttribute(.paragraphStyle, value: paragraph, range: item.range)
-                    result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: item.marker)
                     if let checkbox = item.checkbox {
-                        result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: checkbox)
+                        let syntax = NSRange(
+                            location: item.marker.location,
+                            length: NSMaxRange(checkbox) - item.marker.location
+                        )
+                        let isActive = NSIntersectionRange(syntax, expandedSelection(selection)).length > 0
+                        if isActive {
+                            result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: syntax)
+                        } else {
+                            result.addAttribute(.foregroundColor, value: UIColor.clear, range: item.marker)
+
+                            let spacer = NSRange(
+                                location: NSMaxRange(item.marker),
+                                length: checkbox.location - NSMaxRange(item.marker)
+                            )
+                            if spacer.length > 0 {
+                                result.addAttribute(.foregroundColor, value: UIColor.clear, range: spacer)
+                            }
+
+                            result.addAttributes([
+                                .taskCheckbox: item.checked,
+                                .taskCheckboxFont: bodyFont,
+                                .taskCheckboxTint: item.checked
+                                    ? configuration.theme.bodyText
+                                    : configuration.theme.mutedText,
+                                .font: UIFont.systemFont(ofSize: 0.01),
+                                .foregroundColor: UIColor.clear
+                            ], range: checkbox)
+
+                            let postGap = NSRange(
+                                location: NSMaxRange(checkbox),
+                                length: item.contentRange.location - NSMaxRange(checkbox)
+                            )
+                            if postGap.length > 0 {
+                                result.addAttributes([
+                                    .font: UIFont.systemFont(ofSize: 0.01),
+                                    .foregroundColor: UIColor.clear
+                                ], range: postGap)
+                            }
+                        }
+                    } else {
+                        result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: item.marker)
                     }
                     if item.checked {
                         result.addAttributes([

--- a/Sources/MarkdownEngine/iOS/UIKitMarkdownStyler.swift
+++ b/Sources/MarkdownEngine/iOS/UIKitMarkdownStyler.swift
@@ -1,0 +1,362 @@
+#if os(iOS)
+import UIKit
+
+struct UIKitMarkdownStyler {
+    let configuration: MarkdownEditorConfiguration
+    let fontName: String
+    let fontSize: CGFloat
+
+    func attributedString(for text: String, selection: NSRange) -> NSAttributedString {
+        let source = text as NSString
+        let bodyFont = UIFont(name: fontName, size: fontSize) ?? .systemFont(ofSize: fontSize)
+        let result = NSMutableAttributedString(
+            string: text,
+            attributes: [
+                .font: bodyFont,
+                .foregroundColor: configuration.theme.bodyText
+            ]
+        )
+
+        guard !configuration.rawSourceMode, source.length > 0 else { return result }
+        let tokens = MarkdownTokenizer.parseTokensViaAST(in: text)
+        style(tokens: tokens, in: result, source: source, bodyFont: bodyFont, selection: selection)
+        styleListsAndRules(in: result, source: source, bodyFont: bodyFont, selection: selection)
+        styleStrikethrough(in: result, source: source, bodyFont: bodyFont, selection: selection)
+        return result
+    }
+
+    private func style(
+        tokens: [MarkdownToken],
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        for token in tokens {
+            switch token.kind {
+            case .italic:
+                applyTraits(.traitItalic, range: token.contentRange, in: result, fallback: bodyFont)
+            case .bold:
+                applyTraits(.traitBold, range: token.contentRange, in: result, fallback: bodyFont)
+            case .boldItalic:
+                applyTraits([.traitBold, .traitItalic], range: token.contentRange, in: result, fallback: bodyFont)
+            case .link, .wikiLink:
+                result.addAttributes([
+                    .foregroundColor: configuration.theme.link,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue
+                ], range: token.contentRange)
+            case .heading:
+                let level = max(1, min(6, token.markerRanges.first?.length ?? 1))
+                let scale: CGFloat = [1.72, 1.48, 1.28, 1.14, 1.05, 1.0][level - 1]
+                result.addAttribute(.font, value: UIFont.systemFont(ofSize: fontSize * scale, weight: .bold), range: token.contentRange)
+            case .blockquote:
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.headIndent = fontSize
+                paragraph.firstLineHeadIndent = fontSize
+                result.addAttributes([
+                    .foregroundColor: configuration.theme.quote,
+                    .paragraphStyle: paragraph
+                ], range: token.range)
+            case .codeBlock:
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: token.range)
+            case .inlineCode:
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize * 0.94, weight: .regular),
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: token.contentRange)
+            case .blockLatex, .inlineLatex:
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                    .foregroundColor: configuration.theme.bodyText,
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: token.contentRange)
+            case .imageEmbed, .imageLink:
+                result.addAttributes([
+                    .foregroundColor: configuration.theme.link,
+                    .font: UIFont.systemFont(ofSize: fontSize, weight: .medium)
+                ], range: token.contentRange)
+            case .table:
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize * 0.92, weight: .regular),
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: token.range)
+            case .backslashEscape:
+                break
+            case .extensionSpan, .extensionBlock:
+                break
+            }
+
+            let isActive = NSIntersectionRange(token.range, expandedSelection(selection)).length > 0
+            for marker in token.markerRanges {
+                if isActive {
+                    result.addAttributes([.font: bodyFont, .foregroundColor: configuration.theme.mutedText], range: marker)
+                } else {
+                    hide(marker, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+                }
+            }
+        }
+    }
+
+    private func styleListsAndRules(
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        for block in DocumentAST.parse(source as String) {
+            switch block {
+            case .list(_, let items):
+                for item in items {
+                    let paragraph = NSMutableParagraphStyle()
+                    paragraph.headIndent = fontSize * 1.55
+                    paragraph.firstLineHeadIndent = 0
+                    result.addAttribute(.paragraphStyle, value: paragraph, range: item.range)
+                    result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: item.marker)
+                    if let checkbox = item.checkbox {
+                        result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: checkbox)
+                    }
+                    if item.checked {
+                        result.addAttributes([
+                            .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                            .foregroundColor: configuration.theme.disabledText
+                        ], range: item.contentRange)
+                    }
+                }
+            case .thematicBreak(let range):
+                result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: range)
+            default:
+                break
+            }
+        }
+    }
+
+    private func styleStrikethrough(
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        applyDelimited(#"(?<!\\)(~~)(?=\S)(.+?)(?<=\S)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        }
+    }
+
+    private func applyTraits(
+        _ traits: UIFontDescriptor.SymbolicTraits,
+        range: NSRange,
+        in result: NSMutableAttributedString,
+        fallback: UIFont
+    ) {
+        result.enumerateAttribute(.font, in: range) { value, run, _ in
+            let font = value as? UIFont ?? fallback
+            result.addAttribute(.font, value: font.withTraits(traits), range: run)
+        }
+    }
+
+    private func styleBlocks(
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        var location = 0
+        var insideFence = false
+        while location < source.length {
+            let lineRange = source.lineRange(for: NSRange(location: location, length: 0))
+            let contentRange = lineContentRange(lineRange, source: source)
+            let line = source.substring(with: contentRange)
+
+            if let fence = firstMatch(#"^\s*```"#, in: line, offset: contentRange.location) {
+                insideFence.toggle()
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                    .foregroundColor: configuration.theme.mutedText,
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: lineRange)
+                hide(fence, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+            } else if insideFence {
+                result.addAttributes([
+                    .font: UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+                    .backgroundColor: configuration.theme.codeBackground
+                ], range: lineRange)
+            } else if let heading = firstMatch(#"^(#{1,6})[\t ]+"#, in: line, offset: contentRange.location) {
+                let markerLength = markerLength(in: heading, source: source, characters: CharacterSet(charactersIn: "#"))
+                let marker = NSRange(location: heading.location, length: markerLength)
+                let level = max(1, min(6, markerLength))
+                let scale: CGFloat = [1.72, 1.48, 1.28, 1.14, 1.05, 1.0][level - 1]
+                result.addAttribute(.font, value: UIFont.systemFont(ofSize: fontSize * scale, weight: .bold), range: contentRange)
+                result.addAttribute(.foregroundColor, value: configuration.theme.headingMarker, range: heading)
+                hide(heading, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+                revealContent(after: heading, lineRange: contentRange, in: result, font: UIFont.systemFont(ofSize: fontSize * scale, weight: .bold))
+                _ = marker
+            } else if let quote = firstMatch(#"^\s*>[\t ]?"#, in: line, offset: contentRange.location) {
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.headIndent = fontSize
+                paragraph.firstLineHeadIndent = fontSize
+                result.addAttributes([.foregroundColor: configuration.theme.quote, .paragraphStyle: paragraph], range: contentRange)
+                hide(quote, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+            } else if isThematicBreak(line) {
+                result.addAttributes([.foregroundColor: configuration.theme.mutedText], range: contentRange)
+            }
+
+            styleListLine(line, lineRange: contentRange, in: result, source: source, bodyFont: bodyFont, selection: selection)
+            location = NSMaxRange(lineRange)
+        }
+    }
+
+    private func styleListLine(
+        _ line: String,
+        lineRange: NSRange,
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        guard let marker = firstMatch(#"^\s*(?:[-+*]|\d+[.)])[\t ]+"#, in: line, offset: lineRange.location) else { return }
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.headIndent = fontSize * 1.55
+        paragraph.firstLineHeadIndent = 0
+        paragraph.tabStops = [NSTextTab(textAlignment: .left, location: paragraph.headIndent)]
+        result.addAttribute(.paragraphStyle, value: paragraph, range: lineRange)
+        result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: marker)
+
+        if let task = firstMatch(#"^\s*[-+*][\t ]+\[([ xX])\][\t ]+"#, in: line, offset: lineRange.location) {
+            let taskText = source.substring(with: task)
+            let checked = taskText.range(of: "[x]", options: .caseInsensitive) != nil
+            result.addAttribute(.foregroundColor, value: configuration.theme.mutedText, range: task)
+            if checked {
+                let contentStart = NSMaxRange(task)
+                let content = NSRange(location: contentStart, length: max(0, NSMaxRange(lineRange) - contentStart))
+                result.addAttributes([
+                    .strikethroughStyle: NSUnderlineStyle.single.rawValue,
+                    .foregroundColor: configuration.theme.disabledText
+                ], range: content)
+            }
+        }
+    }
+
+    private func styleInline(
+        in result: NSMutableAttributedString,
+        source: NSString,
+        bodyFont: UIFont,
+        selection: NSRange
+    ) {
+        applyDelimited(#"(?<!\\)(\*\*\*|___)(?=\S)(.+?)(?<=\S)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttribute(.font, value: UIFont.systemFont(ofSize: fontSize, weight: .bold).withTraits(.traitItalic), range: range)
+        }
+        applyDelimited(#"(?<!\\)(\*\*|__)(?=\S)(.+?)(?<=\S)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttribute(.font, value: UIFont.systemFont(ofSize: fontSize, weight: .bold), range: range)
+        }
+        applyDelimited(#"(?<!\\)(\*|_)(?=\S)(.+?)(?<=\S)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttribute(.font, value: bodyFont.withTraits(.traitItalic), range: range)
+        }
+        applyDelimited(#"(?<!\\)(~~)(?=\S)(.+?)(?<=\S)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        }
+        applyDelimited(#"(?<!\\)(`)([^`\n]+)\1"#, to: result, source: source, selection: selection, bodyFont: bodyFont) { range in
+            result.addAttributes([
+                .font: UIFont.monospacedSystemFont(ofSize: fontSize * 0.94, weight: .regular),
+                .backgroundColor: configuration.theme.codeBackground
+            ], range: range)
+        }
+
+        applyLinks(in: result, source: source, selection: selection, bodyFont: bodyFont)
+    }
+
+    private func applyDelimited(
+        _ pattern: String,
+        to result: NSMutableAttributedString,
+        source: NSString,
+        selection: NSRange,
+        bodyFont: UIFont,
+        style: (NSRange) -> Void
+    ) {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return }
+        let matches = expression.matches(in: source as String, range: NSRange(location: 0, length: source.length))
+        for match in matches where match.numberOfRanges >= 3 {
+            let content = match.range(at: 2)
+            style(content)
+            let delimiterLength = match.range(at: 1).length
+            hide(NSRange(location: match.range.location, length: delimiterLength), in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+            hide(NSRange(location: NSMaxRange(match.range) - delimiterLength, length: delimiterLength), in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+        }
+    }
+
+    private func applyLinks(
+        in result: NSMutableAttributedString,
+        source: NSString,
+        selection: NSRange,
+        bodyFont: UIFont
+    ) {
+        guard let expression = try? NSRegularExpression(pattern: #"(?<!!)\[([^\]\n]+)\]\(([^)\n]+)\)"#) else { return }
+        for match in expression.matches(in: source as String, range: NSRange(location: 0, length: source.length)) where match.numberOfRanges >= 3 {
+            let label = match.range(at: 1)
+            let destination = source.substring(with: match.range(at: 2))
+            result.addAttributes([.foregroundColor: configuration.theme.link, .underlineStyle: NSUnderlineStyle.single.rawValue], range: label)
+            if let url = URL(string: destination) {
+                result.addAttribute(.link, value: url, range: label)
+            }
+            let open = NSRange(location: match.range.location, length: 1)
+            let suffix = NSRange(location: NSMaxRange(label), length: NSMaxRange(match.range) - NSMaxRange(label))
+            hide(open, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+            hide(suffix, in: result, unlessIntersecting: selection, bodyFont: bodyFont)
+        }
+    }
+
+    private func hide(_ range: NSRange, in result: NSMutableAttributedString, unlessIntersecting selection: NSRange, bodyFont: UIFont) {
+        guard NSIntersectionRange(range, expandedSelection(selection)).length == 0 else {
+            result.addAttributes([.font: bodyFont, .foregroundColor: configuration.theme.mutedText], range: range)
+            return
+        }
+        result.addAttributes([.font: UIFont.systemFont(ofSize: 0.01), .foregroundColor: UIColor.clear], range: range)
+    }
+
+    private func expandedSelection(_ selection: NSRange) -> NSRange {
+        selection.length == 0 ? NSRange(location: max(0, selection.location - 1), length: 2) : selection
+    }
+
+    private func revealContent(after marker: NSRange, lineRange: NSRange, in result: NSMutableAttributedString, font: UIFont) {
+        let start = NSMaxRange(marker)
+        guard start < NSMaxRange(lineRange) else { return }
+        result.addAttribute(.font, value: font, range: NSRange(location: start, length: NSMaxRange(lineRange) - start))
+    }
+
+    private func lineContentRange(_ lineRange: NSRange, source: NSString) -> NSRange {
+        var length = lineRange.length
+        while length > 0, CharacterSet.newlines.contains(UnicodeScalar(source.character(at: lineRange.location + length - 1))!) {
+            length -= 1
+        }
+        return NSRange(location: lineRange.location, length: length)
+    }
+
+    private func firstMatch(_ pattern: String, in line: String, offset: Int) -> NSRange? {
+        guard let expression = try? NSRegularExpression(pattern: pattern),
+              let match = expression.firstMatch(in: line, range: NSRange(location: 0, length: (line as NSString).length)) else { return nil }
+        return NSRange(location: offset + match.range.location, length: match.range.length)
+    }
+
+    private func markerLength(in range: NSRange, source: NSString, characters: CharacterSet) -> Int {
+        var count = 0
+        while count < range.length {
+            let scalar = UnicodeScalar(source.character(at: range.location + count))!
+            guard characters.contains(scalar) else { break }
+            count += 1
+        }
+        return count
+    }
+
+    private func isThematicBreak(_ line: String) -> Bool {
+        line.range(of: #"^\s{0,3}((\*\s*){3,}|(-\s*){3,}|(_\s*){3,})$"#, options: .regularExpression) != nil
+    }
+}
+
+private extension UIFont {
+    func withTraits(_ traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
+        guard let descriptor = fontDescriptor.withSymbolicTraits(fontDescriptor.symbolicTraits.union(traits)) else { return self }
+        return UIFont(descriptor: descriptor, size: pointSize)
+    }
+}
+#endif

--- a/Sources/MarkdownEngine/iOS/UIKitMarkdownTextLayoutFragment.swift
+++ b/Sources/MarkdownEngine/iOS/UIKitMarkdownTextLayoutFragment.swift
@@ -1,0 +1,95 @@
+#if os(iOS)
+import UIKit
+
+extension NSAttributedString.Key {
+    static let taskCheckboxFont = NSAttributedString.Key("TaskCheckboxFont")
+    static let taskCheckboxTint = NSAttributedString.Key("TaskCheckboxTint")
+}
+
+final class UIKitMarkdownTextLayoutFragment: NSTextLayoutFragment {
+    private static let gap: CGFloat = 2
+
+    override var renderingSurfaceBounds: CGRect {
+        var bounds = super.renderingSurfaceBounds
+        if hasTaskCheckbox {
+            bounds.origin.x -= 24
+            bounds.size.width += 24
+        }
+        return bounds
+    }
+
+    override func draw(at point: CGPoint, in context: CGContext) {
+        super.draw(at: point, in: context)
+        drawTaskCheckboxes(at: point, in: context)
+    }
+
+    private var fragmentRange: NSRange? {
+        guard let storage = textLayoutManager?.textContentManager as? NSTextContentStorage else { return nil }
+        let start = storage.offset(from: storage.documentRange.location, to: rangeInElement.location)
+        let end = storage.offset(from: storage.documentRange.location, to: rangeInElement.endLocation)
+        guard start != NSNotFound, end != NSNotFound, end > start else { return nil }
+        return NSRange(location: start, length: end - start)
+    }
+
+    private var textStorage: NSTextStorage? {
+        (textLayoutManager?.textContentManager as? NSTextContentStorage)?.textStorage
+    }
+
+    private var hasTaskCheckbox: Bool {
+        guard let textStorage, let fragmentRange else { return false }
+        var found = false
+        textStorage.enumerateAttribute(.taskCheckbox, in: fragmentRange) { value, _, stop in
+            if value is Bool {
+                found = true
+                stop.pointee = true
+            }
+        }
+        return found
+    }
+
+    private func drawPosition(forDocumentCharacterAt index: Int, point: CGPoint) -> (x: CGFloat, baselineY: CGFloat)? {
+        guard let fragmentRange else { return nil }
+        let localIndex = index - fragmentRange.location
+        guard localIndex >= 0 else { return nil }
+
+        for lineFragment in textLineFragments {
+            let range = lineFragment.characterRange
+            guard localIndex >= range.location, localIndex < NSMaxRange(range) else { continue }
+            let location = lineFragment.locationForCharacter(at: localIndex)
+            let bounds = lineFragment.typographicBounds
+            return (
+                x: point.x + bounds.origin.x + location.x,
+                baselineY: point.y + bounds.origin.y + location.y
+            )
+        }
+        return nil
+    }
+
+    private func drawTaskCheckboxes(at point: CGPoint, in context: CGContext) {
+        guard let textStorage, let fragmentRange else { return }
+
+        textStorage.enumerateAttribute(.taskCheckbox, in: fragmentRange) { value, range, _ in
+            guard let checked = value as? Bool,
+                  let font = textStorage.attribute(.taskCheckboxFont, at: range.location, effectiveRange: nil) as? UIFont,
+                  let tint = textStorage.attribute(.taskCheckboxTint, at: range.location, effectiveRange: nil) as? UIColor,
+                  let position = drawPosition(forDocumentCharacterAt: range.location, point: point) else { return }
+
+            let size = ceil(font.lineHeight)
+            let rect = CGRect(
+                x: position.x - size - Self.gap,
+                y: position.baselineY - font.ascender + (font.lineHeight - size) / 2,
+                width: size,
+                height: size
+            )
+            let name = checked ? "checkmark.square.fill" : "square"
+            let configuration = UIImage.SymbolConfiguration(pointSize: size, weight: .regular)
+            guard let image = UIImage(systemName: name, withConfiguration: configuration)?
+                .withTintColor(tint, renderingMode: .alwaysOriginal) else { return }
+
+            UIGraphicsPushContext(context)
+            image.draw(in: rect)
+            UIGraphicsPopContext()
+        }
+    }
+}
+#endif

--- a/Sources/MarkdownEngineCodeBlocks/HighlighterSwiftBridge.swift
+++ b/Sources/MarkdownEngineCodeBlocks/HighlighterSwiftBridge.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HighlighterSwiftBridge.swift
 //  MarkdownEngineCodeBlocks
@@ -174,3 +175,4 @@ public final class HighlighterSwiftBridge: SyntaxHighlighter, @unchecked Sendabl
         return nil
     }
 }
+#endif

--- a/Sources/MarkdownEngineLatex/SwiftMathBridge.swift
+++ b/Sources/MarkdownEngineLatex/SwiftMathBridge.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  SwiftMathBridge.swift
 //  MarkdownEngineLatex
@@ -312,3 +313,4 @@ public final class SwiftMathBridge: LatexRenderer, @unchecked Sendable {
         return (CGFloat(maxX) + 1) * widthInPoints / CGFloat(w)
     }
 }
+#endif

--- a/Tests/MarkdownEngineIOSTests/UIKitMarkdownStylerTests.swift
+++ b/Tests/MarkdownEngineIOSTests/UIKitMarkdownStylerTests.swift
@@ -45,12 +45,42 @@ struct UIKitMarkdownStylerTests {
         #expect((revealedFont?.pointSize ?? 0) >= 16)
     }
 
+    @Test("Task checkbox is rendered without changing its Markdown source")
+    func taskCheckboxRenderingPreservesSource() {
+        let task = "- [x] completed\n"
+        let range = (task as NSString).range(of: "[x]")
+        let styled = makeStyled(task, selection: NSRange(location: (task as NSString).length, length: 0))
+        let checkbox = styled.attribute(.taskCheckbox, at: range.location, effectiveRange: nil) as? Bool
+        let hiddenFont = styled.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+
+        #expect(styled.string == task)
+        #expect(checkbox == true)
+        #expect((hiddenFont?.pointSize ?? 1) < 0.1)
+    }
+
+    @Test("Task source is revealed while its syntax is edited")
+    func taskCheckboxSourceRevealsAtCaret() {
+        let task = "- [ ] pending\n"
+        let range = (task as NSString).range(of: "[ ]")
+        let styled = makeStyled(task, selection: NSRange(location: range.location + 1, length: 0))
+        let checkbox = styled.attribute(.taskCheckbox, at: range.location, effectiveRange: nil) as? Bool
+        let revealedFont = styled.attribute(.font, at: range.location, effectiveRange: nil) as? UIFont
+
+        #expect(styled.string == task)
+        #expect(checkbox == nil)
+        #expect((revealedFont?.pointSize ?? 0) >= 16)
+    }
+
     private func makeStyled(selection: NSRange) -> NSAttributedString {
+        makeStyled(source, selection: selection)
+    }
+
+    private func makeStyled(_ markdown: String, selection: NSRange) -> NSAttributedString {
         UIKitMarkdownStyler(
             configuration: .default,
             fontName: "SF Pro",
             fontSize: 16
-        ).attributedString(for: source, selection: selection)
+        ).attributedString(for: markdown, selection: selection)
     }
 }
 #endif

--- a/Tests/MarkdownEngineIOSTests/UIKitMarkdownStylerTests.swift
+++ b/Tests/MarkdownEngineIOSTests/UIKitMarkdownStylerTests.swift
@@ -1,0 +1,56 @@
+#if os(iOS)
+import Testing
+import UIKit
+@testable import MarkdownEngine
+
+@Suite("UIKit live Markdown styling")
+struct UIKitMarkdownStylerTests {
+    private let source = "# Heading\n\n**bold and *italic***\n\n[link](https://example.com)\n"
+
+    @Test("Styling preserves the source string and UTF-16 coordinates")
+    func preservesSource() {
+        let styled = makeStyled(selection: NSRange(location: 0, length: 0))
+
+        #expect(styled.string == source)
+        #expect(styled.length == (source as NSString).length)
+    }
+
+    @Test("Heading and nested emphasis use the shared parser")
+    func stylesParsedConstructs() {
+        let styled = makeStyled(selection: NSRange(location: (source as NSString).length, length: 0))
+        let ns = source as NSString
+        let heading = ns.range(of: "Heading")
+        let bold = ns.range(of: "bold and *italic*")
+        let italic = ns.range(of: "italic")
+        let headingFont = styled.attribute(.font, at: heading.location, effectiveRange: nil) as? UIFont
+        let boldFont = styled.attribute(.font, at: bold.location, effectiveRange: nil) as? UIFont
+        let italicFont = styled.attribute(.font, at: italic.location, effectiveRange: nil) as? UIFont
+
+        #expect((headingFont?.pointSize ?? 0) > 16)
+        #expect(boldFont?.fontDescriptor.symbolicTraits.contains(.traitBold) == true)
+        #expect(italicFont?.fontDescriptor.symbolicTraits.contains(.traitBold) == true)
+        #expect(italicFont?.fontDescriptor.symbolicTraits.contains(.traitItalic) == true)
+    }
+
+    @Test("Markers hide outside the active construct and reveal at the caret")
+    func markerVisibilityFollowsSelection() {
+        let ns = source as NSString
+        let marker = ns.range(of: "**")
+        let hidden = makeStyled(selection: NSRange(location: ns.length, length: 0))
+        let revealed = makeStyled(selection: NSRange(location: marker.location, length: 0))
+        let hiddenFont = hidden.attribute(.font, at: marker.location, effectiveRange: nil) as? UIFont
+        let revealedFont = revealed.attribute(.font, at: marker.location, effectiveRange: nil) as? UIFont
+
+        #expect((hiddenFont?.pointSize ?? 1) < 0.1)
+        #expect((revealedFont?.pointSize ?? 0) >= 16)
+    }
+
+    private func makeStyled(selection: NSRange) -> NSAttributedString {
+        UIKitMarkdownStyler(
+            configuration: .default,
+            fontName: "SF Pro",
+            fontSize: 16
+        ).attributedString(for: source, selection: selection)
+    }
+}
+#endif

--- a/Tests/MarkdownEngineTests/ASTPipelineTests.swift
+++ b/Tests/MarkdownEngineTests/ASTPipelineTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ASTPipelineTests.swift
 //  MarkdownEngineTests
@@ -114,3 +115,4 @@ struct ASTPipelineTests {
         #expect(tokens.contains { $0.kind == .italic })
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BacktickCensusTests.swift
+++ b/Tests/MarkdownEngineTests/BacktickCensusTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BacktickCensusTests.swift
 //  MarkdownEngine
@@ -27,3 +28,4 @@ struct BacktickCensusTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BlockBackgroundFillTests.swift
+++ b/Tests/MarkdownEngineTests/BlockBackgroundFillTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BlockBackgroundFillTests.swift
 //  MarkdownEngineTests
@@ -137,3 +138,4 @@ struct BlockBackgroundFillTests {
         #expect(fills(in: tv).isEmpty)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BlockExtensionTests.swift
+++ b/Tests/MarkdownEngineTests/BlockExtensionTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BlockExtensionTests.swift
 //  MarkdownEngineTests
@@ -243,3 +244,4 @@ struct BlockExtensionTests {
         #expect(BlockParser.hasBlockDelimiter(buf, 0, buf.count, fences: [Array(":::".utf16)]))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BlockParserTests.swift
+++ b/Tests/MarkdownEngineTests/BlockParserTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BlockParserTests.swift
 //  MarkdownEngineTests
@@ -103,3 +104,4 @@ struct BlockParserTests {
         assertTiles(text)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BlockquotePasteTests.swift
+++ b/Tests/MarkdownEngineTests/BlockquotePasteTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BlockquotePasteTests.swift
 //  MarkdownEngineTests
@@ -62,3 +63,4 @@ struct BlockquotePasteTests {
         #expect(paste("a\nb", at: 999, into: "> ") == "a\nb")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/BottomOverscrollPolicyTests.swift
+++ b/Tests/MarkdownEngineTests/BottomOverscrollPolicyTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  BottomOverscrollPolicyTests.swift
 //  MarkdownEngineTests
@@ -72,3 +73,4 @@ struct BottomOverscrollPolicyTests {
         #expect(slack == 376)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/CaretColorTests.swift
+++ b/Tests/MarkdownEngineTests/CaretColorTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  CaretColorTests.swift
 //  MarkdownEngineTests
@@ -115,3 +116,4 @@ struct CaretColorTests {
         #expect(tv.insertionPointColor == NSColor.black)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ContextMenuBindingTests.swift
+++ b/Tests/MarkdownEngineTests/ContextMenuBindingTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ContextMenuBindingTests.swift
 //  MarkdownEngineTests
@@ -131,3 +132,4 @@ struct ContextMenuBindingTests {
         #expect(coordinator.lastSyncedText == published)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveArgumentTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveArgumentTests.swift
 //  MarkdownEngineTests
@@ -243,3 +244,4 @@ struct DirectiveArgumentTests {
     }
 
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveCompositionTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveCompositionTests.swift
 //  MarkdownEngineTests
@@ -235,3 +236,4 @@ struct DirectiveCompositionTests {
         #expect(result == nil || result?.pointSize == base)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveHTMLTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveHTMLTests.swift
 //  MarkdownEngineTests
@@ -74,3 +75,4 @@ struct DirectiveHTMLTests {
         #expect(out.contains("font-size:18.0px"))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveParserTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveParserTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveParserTests.swift
 //  MarkdownEngineTests
@@ -381,3 +382,4 @@ struct DirectiveParserTests {
     }
 
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectivePerformanceTests.swift
+++ b/Tests/MarkdownEngineTests/DirectivePerformanceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectivePerformanceTests.swift
 //  MarkdownEngineTests
@@ -156,3 +157,4 @@ struct DirectivePerformanceTests {
                 "directives cost \(directiveCost)ms vs \(highlightCost)ms for \(count) spans")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
+++ b/Tests/MarkdownEngineTests/DirectiveStylingTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveStylingTests.swift
 //  MarkdownEngineTests
@@ -147,3 +148,4 @@ struct DirectiveStylingTests {
         #expect(keys([paragraph]) == keys(nil))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
+++ b/Tests/MarkdownEngineTests/DirectiveTestFixtures.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  DirectiveTestFixtures.swift
 //  MarkdownEngineTests
@@ -54,3 +55,4 @@ struct MarkerDirective: MarkdownDirective {
 struct SelfContainedPair: MarkdownDirective {
     var syntax: DirectiveSyntax { DirectiveSyntax(name: "pair", form: .selfContained) }
 }
+#endif

--- a/Tests/MarkdownEngineTests/FenceInteriorIncrementalTests.swift
+++ b/Tests/MarkdownEngineTests/FenceInteriorIncrementalTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  FenceInteriorIncrementalTests.swift
 //  MarkdownEngine
@@ -72,3 +73,4 @@ struct FenceInteriorIncrementalTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
+++ b/Tests/MarkdownEngineTests/FindHighlightRestoreTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  FindHighlightRestoreTests.swift
 //  MarkdownEngineTests
@@ -136,3 +137,4 @@ struct FindHighlightRestoreTests {
         #expect(background(tv, at: 17) != nil)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/FlattenedRunsTests.swift
+++ b/Tests/MarkdownEngineTests/FlattenedRunsTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  FlattenedRunsTests.swift
 //  MarkdownEngineTests
@@ -148,3 +149,4 @@ struct FlattenedRunsTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/FormattingActionTests.swift
+++ b/Tests/MarkdownEngineTests/FormattingActionTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  FormattingActionTests.swift
 //  MarkdownEngineTests
@@ -223,3 +224,4 @@ struct FormattingActionTests {
         #expect(tv.string == "text![](img.png)")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/GoldenCorpusTests.swift
+++ b/Tests/MarkdownEngineTests/GoldenCorpusTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  GoldenCorpusTests.swift
 //  MarkdownEngineTests
@@ -346,3 +347,4 @@ raw ==nicht== markiert
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/HTMLToMarkdownConverterTests.swift
+++ b/Tests/MarkdownEngineTests/HTMLToMarkdownConverterTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HTMLToMarkdownConverterTests.swift
 //  MarkdownEngineTests
@@ -109,3 +110,4 @@ struct HTMLToMarkdownConverterTests {
             == "- **A:** one\n- two")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/HeightBehaviorTests.swift
+++ b/Tests/MarkdownEngineTests/HeightBehaviorTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  HeightBehaviorTests.swift
 //  MarkdownEngineTests
@@ -812,3 +813,4 @@ struct FullRuntimeReconfigurationTests {
         #expect(stack.container.scrollableContentHeight == scrollsTotal)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/InlineParserTests.swift
+++ b/Tests/MarkdownEngineTests/InlineParserTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InlineParserTests.swift
 //  MarkdownEngineTests
@@ -432,3 +433,4 @@ struct InlineParserTests {
         #expect(InlineParser.parse(#"`\*`"#) == [.code(range: r(0, 4), content: r(1, 2))])
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
+++ b/Tests/MarkdownEngineTests/InlineSpanDensityTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InlineSpanDensityTests.swift
 //  MarkdownEngineTests
@@ -152,3 +153,4 @@ struct InlineSpanDensityTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/InterceptorStorageSyncTests.swift
+++ b/Tests/MarkdownEngineTests/InterceptorStorageSyncTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InterceptorStorageSyncTests.swift
 //  MarkdownEngine
@@ -68,3 +69,4 @@ struct InterceptorStorageSyncTests {
         #expect(coord.lastComputedStorage == "\t- hello")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/InterceptorTrustTests.swift
+++ b/Tests/MarkdownEngineTests/InterceptorTrustTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InterceptorTrustTests.swift
 //  MarkdownEngine
@@ -63,3 +64,4 @@ struct InterceptorTrustTests {
         #expect(coord.debugLastEditWasTrusted == true)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/InvertedIBeamCursorTests.swift
+++ b/Tests/MarkdownEngineTests/InvertedIBeamCursorTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  InvertedIBeamCursorTests.swift
 //  MarkdownEngineTests
@@ -60,3 +61,4 @@ struct InvertedIBeamCursorTests {
         #expect(first !== different)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ListHandlerCodeContextTests.swift
+++ b/Tests/MarkdownEngineTests/ListHandlerCodeContextTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ListHandlerCodeContextTests.swift
 //  MarkdownEngine
@@ -60,3 +61,4 @@ struct ListHandlerCodeContextTests {
         #expect(tv.string == "```\n- hello\n\n```")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ListParsingTests.swift
+++ b/Tests/MarkdownEngineTests/ListParsingTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ListParsingTests.swift
 //  MarkdownEngineTests
@@ -99,3 +100,4 @@ struct ListParsingTests {
         #expect(BlockParser.isListItem("1. x"))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownASTStylerTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownASTStylerTests.swift
 //  MarkdownEngineTests
@@ -395,3 +396,4 @@ private func styleKeySnapshot(_ ranges: [StyledRange]) -> String {
 private func fmt(_ r: NSRange) -> String {
     r.location == NSNotFound ? "∅" : "\(r.location)+\(r.length)"
 }
+#endif

--- a/Tests/MarkdownEngineTests/MarkdownHTMLRendererTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownHTMLRendererTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownHTMLRendererTests.swift
 //  MarkdownEngineTests
@@ -95,3 +96,4 @@ struct MarkdownHTMLRendererTests {
             == "<p><a href=\"https://example.com\">https://example.com</a></p>")
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/MarkdownPasteboardWriterTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownPasteboardWriterTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownPasteboardWriterTests.swift
 //  MarkdownEngine
@@ -59,3 +60,4 @@ struct MarkdownPasteboardWriterTests {
         #expect(rtfSource.contains("example.com"))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/MarkdownTextMutationTests.swift
+++ b/Tests/MarkdownEngineTests/MarkdownTextMutationTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  MarkdownTextMutationTests.swift
 //  MarkdownEngineTests
@@ -101,3 +102,4 @@ struct MarkdownTextMutationTests {
         #expect(received.isEmpty)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
+++ b/Tests/MarkdownEngineTests/NativeTextViewContainerTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  NativeTextViewContainerTests.swift
 //  MarkdownEngineTests
@@ -155,3 +156,4 @@ struct NativeTextViewContainerTests {
         #expect(stack.textView.frame.origin.x == 0)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
+++ b/Tests/MarkdownEngineTests/OrderedListDisplayNumberingTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  OrderedListDisplayNumberingTests.swift
 //  MarkdownEngineTests
@@ -407,3 +408,4 @@ struct OrderedListDisplayNumberingTests {
         #expect(overlays(in: tv).map(\.text) == ["2.", "3.", "4."])
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ParseIncrementalEquivalenceTests.swift
+++ b/Tests/MarkdownEngineTests/ParseIncrementalEquivalenceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ParseIncrementalEquivalenceTests.swift
 //  MarkdownEngine
@@ -167,3 +168,4 @@ struct ParseIncrementalEquivalenceTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/PasteStructureGuardTests.swift
+++ b/Tests/MarkdownEngineTests/PasteStructureGuardTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  PasteStructureGuardTests.swift
 //  MarkdownEngine
@@ -53,3 +54,4 @@ struct PasteStructureGuardTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/PerDocumentUndoTests.swift
+++ b/Tests/MarkdownEngineTests/PerDocumentUndoTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  PerDocumentUndoTests.swift
 //  MarkdownEngineTests
@@ -65,3 +66,4 @@ struct PerDocumentUndoTests {
         #expect(c.invalidateUndoIfContentDiverged(for: "A", incomingText: "x") == false)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/PrecomputedBlocksTests.swift
+++ b/Tests/MarkdownEngineTests/PrecomputedBlocksTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  PrecomputedBlocksTests.swift
 //  MarkdownEngine
@@ -91,3 +92,4 @@ struct PrecomputedBlocksTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/RawSourceModeTests.swift
+++ b/Tests/MarkdownEngineTests/RawSourceModeTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  RawSourceModeTests.swift
 //  MarkdownEngineTests
@@ -82,3 +83,4 @@ struct RawSourceModeTests {
         #expect(runs.allSatisfy { $0.font?.pointSize == 16 })
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/RebuildSelectionReplayTests.swift
+++ b/Tests/MarkdownEngineTests/RebuildSelectionReplayTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  RebuildSelectionReplayTests.swift
 //  MarkdownEngineTests
@@ -94,3 +95,4 @@ struct RebuildSelectionReplayTests {
         #expect(tv.isContinuousSpellCheckingEnabled == false)   // handler ran, caret is in code
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/RestyleApplyEquivalenceTests.swift
+++ b/Tests/MarkdownEngineTests/RestyleApplyEquivalenceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  RestyleApplyEquivalenceTests.swift
 //  MarkdownEngineTests
@@ -262,3 +263,4 @@ struct RestyleApplyEquivalenceTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ScopedListRestyleEquivalenceTests.swift
+++ b/Tests/MarkdownEngineTests/ScopedListRestyleEquivalenceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ScopedListRestyleEquivalenceTests.swift
 //  MarkdownEngineTests
@@ -120,3 +121,4 @@ struct ScopedListRestyleEquivalenceTests {
         }
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollMemoryTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ScrollMemoryTests.swift
 //  MarkdownEngineTests
@@ -101,3 +102,4 @@ struct ScrollMemoryTests {
         #expect(coordinator.pendingScrollRestoreDocumentId == nil)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
+++ b/Tests/MarkdownEngineTests/ScrollingHeaderControllerTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ScrollingHeaderControllerTests.swift
 //  MarkdownEngineTests
@@ -204,3 +205,4 @@ struct ScrollingHeaderControllerTests {
         #expect(stack.container.subviews.count == 1)   // text view only
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableCellSourceTests.swift
+++ b/Tests/MarkdownEngineTests/TableCellSourceTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableCellSourceTests.swift
 //  MarkdownEngine
@@ -127,3 +128,4 @@ struct TableCellSourceTests {
         #expect(tv.string == source)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableCellTests.swift
+++ b/Tests/MarkdownEngineTests/TableCellTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableCellTests.swift
 //  MarkdownEngineTests
@@ -85,3 +86,4 @@ struct TableCellTests {
         #expect(traits(s, "c").contains(.bold))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableHiddenSourceGeometryTests.swift
+++ b/Tests/MarkdownEngineTests/TableHiddenSourceGeometryTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableHiddenSourceGeometryTests.swift
 //  MarkdownEngine
@@ -60,3 +61,4 @@ struct TableHiddenSourceGeometryTests {
         #expect(usage.width <= viewport.width + 0.5)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableImageCacheTests.swift
+++ b/Tests/MarkdownEngineTests/TableImageCacheTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableImageCacheTests.swift
 //  MarkdownEngine
@@ -123,3 +124,4 @@ struct TableImageCacheTests {
         #expect(redRender.rendered)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableScopeSkipTests.swift
+++ b/Tests/MarkdownEngineTests/TableScopeSkipTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableScopeSkipTests.swift
 //  MarkdownEngine
@@ -79,3 +80,4 @@ struct TableScopeSkipTests {
         #expect(touching.contains { $0.attributes[.spellingState] as? Int == 0 })
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableWidthChangeRestyleTests.swift
+++ b/Tests/MarkdownEngineTests/TableWidthChangeRestyleTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableWidthChangeRestyleTests.swift
 //  MarkdownEngine
@@ -46,3 +47,4 @@ struct TableWidthChangeRestyleTests {
         #expect(stampedRange == nsText.paragraphRange(for: tableToken.range))
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/TableWrappingTests.swift
+++ b/Tests/MarkdownEngineTests/TableWrappingTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  TableWrappingTests.swift
 //  MarkdownEngine
@@ -119,3 +120,4 @@ struct TableWrappingTests {
         #expect(first.image.size.width != second.image.size.width)
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/ThematicBreakMarkTests.swift
+++ b/Tests/MarkdownEngineTests/ThematicBreakMarkTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  ThematicBreakMarkTests.swift
 //  MarkdownEngineTests
@@ -302,3 +303,4 @@ struct ThematicBreakMarkTests {
         breakLineBounds(in: tv).height
     }
 }
+#endif

--- a/Tests/MarkdownEngineTests/WikiLinkIncrementalTests.swift
+++ b/Tests/MarkdownEngineTests/WikiLinkIncrementalTests.swift
@@ -1,3 +1,4 @@
+#if os(macOS)
 //
 //  WikiLinkIncrementalTests.swift
 //  MarkdownEngine
@@ -142,3 +143,4 @@ struct WikiLinkIncrementalTests {
         #expect(fastPathTaken > 0, "sweep was vacuous — no position took the fast path")
     }
 }
+#endif


### PR DESCRIPTION
## Summary

- add iOS 17 support to the MarkdownEngine package with an editable UIKit/TextKit 2 NativeTextViewWrapper
- reuse the existing AST/tokenizer pipeline so iOS styling preserves the original Markdown source and UTF-16 ranges
- provide live styling for headings, emphasis, links, blockquotes, code, lists, task items, thematic breaks, tables, images, LaTeX source, and strikethrough
- reveal Markdown markers around the active construct while hiding them elsewhere
- preserve the existing AppKit implementation and behavior behind macOS platform guards
- isolate the existing macOS test suite and add focused UIKit styling tests

## Implementation notes

The iOS editor uses the same public entry point as macOS and keeps editing and preview in one surface. It supports fit-to-content layout, selection-preserving restyling, list continuation, ordered-list increments, task reset on Return, raw-source mode, and accessibility identification.

The core target still has no new external dependencies. Existing AppKit-only service integrations and specialized renderers remain unchanged and macOS-only; the UIKit path styles their Markdown source without changing stored content.

## Testing

- swift test — 470 tests in 68 suites passed on macOS
- xcodebuild iOS test action — MarkdownEngineIOSTests passed on iPhone 17 Pro Max Simulator
- MarkdownEngine builds for a generic iOS Simulator destination
- verified live editing in a real SwiftUI host: headings, bold, italic, hidden markers, and completed task styling